### PR TITLE
Fix plugin doesn't work at editor using ios/android platform

### DIFF
--- a/src/Assets/Standard Assets/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 
 public class Bugsnag : MonoBehaviour {
     public class NativeBugsnag {
-        #if UNITY_IPHONE
+        #if UNITY_IPHONE && !UNITY_EDITOR
             [DllImport ("__Internal")]
             public static extern void SetUserId(string userId);
         
@@ -36,7 +36,7 @@ public class Bugsnag : MonoBehaviour {
                 
             [DllImport ("__Internal")]
             public static extern void ClearTab(string tabName);
-        #elif UNITY_ANDROID
+        #elif UNITY_ANDROID && !UNITY_EDITOR
             [DllImport ("bugsnag")]
             public static extern void SetUserId(string userId);
         


### PR DESCRIPTION
`UNITY_IPHONE` and `UNITY_ANDROID` defines when using their platform, even if we execute on Editor.
We need to check **not** UNITY_EDITOR.
How about this patch?

Thank you for your nice plugin for Unity :)
