### PR TITLE
Init() to support runtime addition of Bugsnag component to existing GameObject

### DIFF
--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -295,26 +295,32 @@ public class Bugsnag : MonoBehaviour {
 
     void Awake() {
         DontDestroyOnLoad(this);
-        NativeBugsnag.Register(BugsnagApiKey);
-
-        if(Debug.isDebugBuild) {
-            Bugsnag.ReleaseStage = "development";
-        } else {
-            Bugsnag.ReleaseStage = "production";
-        }
-
-        Bugsnag.Context = GetLevelName();
-        NativeBugsnag.SetAutoNotify (AutoNotify);
-        NativeBugsnag.AddToTab("Unity", "unityVersion", Application.unityVersion.ToString());
-        NativeBugsnag.AddToTab("Unity", "platform", Application.platform.ToString());
-        NativeBugsnag.AddToTab("Unity", "osLanguage", Application.systemLanguage.ToString());
-#if UNITY_5_OR_NEWER
-        NativeBugsnag.AddToTab("Unity", "bundleIdentifier", Application.bundleIdentifier.ToString());
-        NativeBugsnag.AddToTab("Unity", "version", Application.version.ToString());
-        NativeBugsnag.AddToTab("Unity", "companyName", Application.companyName.ToString());
-        NativeBugsnag.AddToTab("Unity", "productName", Application.productName.ToString());
-#endif
+		Init(BugsnagApiKey);
     }
+
+	public void Init(string apiKey)
+	{
+		BugsnagApiKey = apiKey;
+		NativeBugsnag.Register(BugsnagApiKey);
+
+		if(Debug.isDebugBuild) {
+			Bugsnag.ReleaseStage = "development";
+		} else {
+			Bugsnag.ReleaseStage = "production";
+		}
+
+		Bugsnag.Context = GetLevelName();
+		NativeBugsnag.SetAutoNotify (AutoNotify);
+		NativeBugsnag.AddToTab("Unity", "unityVersion", Application.unityVersion.ToString());
+		NativeBugsnag.AddToTab("Unity", "platform", Application.platform.ToString());
+		NativeBugsnag.AddToTab("Unity", "osLanguage", Application.systemLanguage.ToString());
+#if UNITY_5_OR_NEWER
+		NativeBugsnag.AddToTab("Unity", "bundleIdentifier", Application.bundleIdentifier.ToString());
+		NativeBugsnag.AddToTab("Unity", "version", Application.version.ToString());
+		NativeBugsnag.AddToTab("Unity", "companyName", Application.companyName.ToString());
+		NativeBugsnag.AddToTab("Unity", "productName", Application.productName.ToString());
+#endif
+	}
 
     void OnEnable () {
 #if UNITY_5_4_OR_NEWER


### PR DESCRIPTION
I created a public Init() method so the Bugsnag component can be added to an existing GameObject and initialized at runtime with a variable API key instead of predefined set through the Inspector.

We need this for our SDK because we support multiple API keys that can change for each project that uses our SDK so having to set the API key through the inspector before hand breaks our integration flow.