### PR TITLE
[ENG-857] Add static API key

### DIFF
--- a/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -278,6 +278,7 @@ public class Bugsnag : MonoBehaviour {
     public static string[] SeverityValues = new string[]{"info", "error", "warning"};
 
     public string BugsnagApiKey = "";
+    public static string BugsnagApiKeyStatic = "";
     public bool AutoNotify = true;
 
     // Rate limiting section
@@ -368,6 +369,11 @@ public class Bugsnag : MonoBehaviour {
         maxCounts[unityLogType] = maxCount;
     }
 
+    // Used to set the API key when Bugsnag is being initialized
+    public static void SetApiKey(String apiKey) {
+        BugsnagApiKeyStatic = apiKey;
+    }
+
     string GetLevelName() {
 #if UNITY_5_OR_NEWER
       return SceneManager.GetActiveScene().name;
@@ -381,6 +387,13 @@ public class Bugsnag : MonoBehaviour {
         Init(null);
     }
 
+    public static Bugsnag createBugsnagInstance(GameObject gameObject, String ApiKey) {
+        Bugsnag.SetApiKey(ApiKey);
+        Bugsnag bugsnagInstance = gameObject.AddComponent<Bugsnag>();
+        bugsnagInstance.Init(); 
+        return bugsnagInstance;
+    }
+
     public void Init() {
         Init(null);
     }
@@ -391,6 +404,8 @@ public class Bugsnag : MonoBehaviour {
             InitInternal (apiKey);
         } else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
             InitInternal(BugsnagApiKey);
+        } else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
+            InitInternal(BugsnagApiKeyStatic);
         } else {
             Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
         }

--- a/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -391,7 +391,7 @@ public class Bugsnag : MonoBehaviour {
 		Init(null);
     }
 
-	public void Init(string apiKey)	{
+    public void Init(string apiKey) {
 		// Try to work out which API key to use
 		if (!String.IsNullOrEmpty(apiKey)) {
 			InitInternal(apiKey);
@@ -400,13 +400,11 @@ public class Bugsnag : MonoBehaviour {
 		} else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
 			InitInternal(BugsnagApiKeyStatic);
 		} else {
-			// Will cause the native notifiers to throw an exception on Register
-			InitInternal(null);
+			Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
 		}
 	}
 
-    private void InitInternal(string apiKey)
-    {
+    private void InitInternal(string apiKey) {
         BugsnagApiKey = apiKey;
         NativeBugsnag.Register(BugsnagApiKey);
 

--- a/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -278,7 +278,6 @@ public class Bugsnag : MonoBehaviour {
     public static string[] SeverityValues = new string[]{"info", "error", "warning"};
 
     public string BugsnagApiKey = "";
-    private static string BugsnagApiKeyStatic = "";
     public bool AutoNotify = true;
 
     // Rate limiting section
@@ -369,11 +368,6 @@ public class Bugsnag : MonoBehaviour {
         maxCounts[unityLogType] = maxCount;
     }
 
-    // Used to initialize the apiKey before the game object is created
-    public static void SetApiKey(String apiKey) {
-        BugsnagApiKeyStatic = apiKey;
-    }
-
     string GetLevelName() {
 #if UNITY_5_OR_NEWER
       return SceneManager.GetActiveScene().name;
@@ -397,8 +391,6 @@ public class Bugsnag : MonoBehaviour {
             InitInternal (apiKey);
         } else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
             InitInternal(BugsnagApiKey);
-        } else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
-            InitInternal(BugsnagApiKeyStatic);
         } else {
             Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
         }

--- a/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -278,6 +278,7 @@ public class Bugsnag : MonoBehaviour {
     public static string[] SeverityValues = new string[]{"info", "error", "warning"};
 
     public string BugsnagApiKey = "";
+    private static string BugsnagApiKeyStatic = "";
     public bool AutoNotify = true;
 
     // Rate limiting section
@@ -368,6 +369,11 @@ public class Bugsnag : MonoBehaviour {
         maxCounts[unityLogType] = maxCount;
     }
 
+    // Used to initialize the apiKey before the game object is created
+    public static void SetApiKey(String apiKey) {
+        BugsnagApiKeyStatic = apiKey;
+    }
+
     string GetLevelName() {
 #if UNITY_5_OR_NEWER
       return SceneManager.GetActiveScene().name;
@@ -378,10 +384,28 @@ public class Bugsnag : MonoBehaviour {
 
     void Awake() {
         DontDestroyOnLoad(this);
-        Init(BugsnagApiKey);
+        Init(null);
     }
 
-    public void Init(string apiKey)
+    public void Init() {
+		Init(null);
+    }
+
+	public void Init(string apiKey)	{
+		// Try to work out which API key to use
+		if (!String.IsNullOrEmpty(apiKey)) {
+			InitInternal(apiKey);
+		} else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
+			InitInternal(BugsnagApiKey);
+		} else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
+			InitInternal(BugsnagApiKeyStatic);
+		} else {
+			// Will cause the native notifiers to throw an exception on Register
+			InitInternal(null);
+		}
+	}
+
+    private void InitInternal(string apiKey)
     {
         BugsnagApiKey = apiKey;
         NativeBugsnag.Register(BugsnagApiKey);

--- a/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/example/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -388,21 +388,21 @@ public class Bugsnag : MonoBehaviour {
     }
 
     public void Init() {
-		Init(null);
+        Init(null);
     }
 
     public void Init(string apiKey) {
-		// Try to work out which API key to use
-		if (!String.IsNullOrEmpty(apiKey)) {
-			InitInternal(apiKey);
-		} else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
-			InitInternal(BugsnagApiKey);
-		} else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
-			InitInternal(BugsnagApiKeyStatic);
-		} else {
-			Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
-		}
-	}
+        // Try to work out which API key to use
+        if (!String.IsNullOrEmpty (apiKey)) {
+            InitInternal (apiKey);
+        } else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
+            InitInternal(BugsnagApiKey);
+        } else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
+            InitInternal(BugsnagApiKeyStatic);
+        } else {
+            Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
+        }
+    }
 
     private void InitInternal(string apiKey) {
         BugsnagApiKey = apiKey;

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -391,7 +391,7 @@ public class Bugsnag : MonoBehaviour {
 		Init(null);
     }
 
-	public void Init(string apiKey)	{
+    public void Init(string apiKey) {
 		// Try to work out which API key to use
 		if (!String.IsNullOrEmpty(apiKey)) {
 			InitInternal(apiKey);
@@ -400,13 +400,11 @@ public class Bugsnag : MonoBehaviour {
 		} else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
 			InitInternal(BugsnagApiKeyStatic);
 		} else {
-			// Will cause the native notifiers to throw an exception on Register
-			InitInternal(null);
+			Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
 		}
 	}
 
-    private void InitInternal(string apiKey)
-    {
+    private void InitInternal(string apiKey) {
         BugsnagApiKey = apiKey;
         NativeBugsnag.Register(BugsnagApiKey);
 

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -278,7 +278,6 @@ public class Bugsnag : MonoBehaviour {
     public static string[] SeverityValues = new string[]{"info", "error", "warning"};
 
     public string BugsnagApiKey = "";
-    private static string BugsnagApiKeyStatic = "";
     public bool AutoNotify = true;
 
     // Rate limiting section
@@ -369,11 +368,6 @@ public class Bugsnag : MonoBehaviour {
         maxCounts[unityLogType] = maxCount;
     }
 
-    // Used to initialize the apiKey before the game object is created
-    public static void SetApiKey(String apiKey) {
-        BugsnagApiKeyStatic = apiKey;
-    }
-
     string GetLevelName() {
 #if UNITY_5_OR_NEWER
       return SceneManager.GetActiveScene().name;
@@ -397,8 +391,6 @@ public class Bugsnag : MonoBehaviour {
             InitInternal (apiKey);
         } else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
             InitInternal(BugsnagApiKey);
-        } else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
-            InitInternal(BugsnagApiKeyStatic);
         } else {
             Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
         }

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -278,6 +278,7 @@ public class Bugsnag : MonoBehaviour {
     public static string[] SeverityValues = new string[]{"info", "error", "warning"};
 
     public string BugsnagApiKey = "";
+    private static string BugsnagApiKeyStatic = "";
     public bool AutoNotify = true;
 
     // Rate limiting section
@@ -368,6 +369,11 @@ public class Bugsnag : MonoBehaviour {
         maxCounts[unityLogType] = maxCount;
     }
 
+    // Used to initialize the apiKey before the game object is created
+    public static void SetApiKey(String apiKey) {
+        BugsnagApiKeyStatic = apiKey;
+    }
+
     string GetLevelName() {
 #if UNITY_5_OR_NEWER
       return SceneManager.GetActiveScene().name;
@@ -378,10 +384,28 @@ public class Bugsnag : MonoBehaviour {
 
     void Awake() {
         DontDestroyOnLoad(this);
-        Init(BugsnagApiKey);
+        Init(null);
     }
 
-    public void Init(string apiKey)
+    public void Init() {
+		Init(null);
+    }
+
+	public void Init(string apiKey)	{
+		// Try to work out which API key to use
+		if (!String.IsNullOrEmpty(apiKey)) {
+			InitInternal(apiKey);
+		} else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
+			InitInternal(BugsnagApiKey);
+		} else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
+			InitInternal(BugsnagApiKeyStatic);
+		} else {
+			// Will cause the native notifiers to throw an exception on Register
+			InitInternal(null);
+		}
+	}
+
+    private void InitInternal(string apiKey)
     {
         BugsnagApiKey = apiKey;
         NativeBugsnag.Register(BugsnagApiKey);

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -278,6 +278,7 @@ public class Bugsnag : MonoBehaviour {
     public static string[] SeverityValues = new string[]{"info", "error", "warning"};
 
     public string BugsnagApiKey = "";
+    public static string BugsnagApiKeyStatic = "";
     public bool AutoNotify = true;
 
     // Rate limiting section
@@ -368,6 +369,11 @@ public class Bugsnag : MonoBehaviour {
         maxCounts[unityLogType] = maxCount;
     }
 
+    // Used to set the API key when Bugsnag is being initialized
+    public static void SetApiKey(String apiKey) {
+        BugsnagApiKeyStatic = apiKey;
+    }
+
     string GetLevelName() {
 #if UNITY_5_OR_NEWER
       return SceneManager.GetActiveScene().name;
@@ -381,6 +387,13 @@ public class Bugsnag : MonoBehaviour {
         Init(null);
     }
 
+    public static Bugsnag createBugsnagInstance(GameObject gameObject, String ApiKey) {
+        Bugsnag.SetApiKey(ApiKey);
+        Bugsnag bugsnagInstance = gameObject.AddComponent<Bugsnag>();
+        bugsnagInstance.Init();
+        return bugsnagInstance;
+    }
+
     public void Init() {
         Init(null);
     }
@@ -391,6 +404,8 @@ public class Bugsnag : MonoBehaviour {
             InitInternal (apiKey);
         } else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
             InitInternal(BugsnagApiKey);
+        } else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
+            InitInternal(BugsnagApiKeyStatic);
         } else {
             Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
         }

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -388,21 +388,21 @@ public class Bugsnag : MonoBehaviour {
     }
 
     public void Init() {
-		Init(null);
+        Init(null);
     }
 
     public void Init(string apiKey) {
-		// Try to work out which API key to use
-		if (!String.IsNullOrEmpty(apiKey)) {
-			InitInternal(apiKey);
-		} else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
-			InitInternal(BugsnagApiKey);
-		} else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
-			InitInternal(BugsnagApiKeyStatic);
-		} else {
-			Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
-		}
-	}
+        // Try to work out which API key to use
+        if (!String.IsNullOrEmpty (apiKey)) {
+            InitInternal (apiKey);
+        } else if (!String.IsNullOrEmpty(BugsnagApiKey)) {
+            InitInternal(BugsnagApiKey);
+        } else if (!String.IsNullOrEmpty(BugsnagApiKeyStatic)) {
+            InitInternal(BugsnagApiKeyStatic);
+        } else {
+            Debug.LogError("BUGSNAG: ERROR: unable to initialize Bugsnag, API key must be specified");
+        }
+    }
 
     private void InitInternal(string apiKey) {
         BugsnagApiKey = apiKey;


### PR DESCRIPTION
A user has reported getting null pointer exceptions when manually creating the Bugsnag game object.

This seems to be because the API Key has not been set before the `awake` method gets called.

Adding a static way of setting the API Key should mean that the game object can be created manually and always have the API key set before construction.