### PR TITLE
fix require 'shellwords' escaping

### DIFF
--- a/src/Assets/Standard Assets/Bugsnag/Editor/BugsnagPostProcess.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Editor/BugsnagPostProcess.cs
@@ -120,7 +120,7 @@ public class BugsnagBuilder : MonoBehaviour {
                     "\t\t\t);\n" +
                     "\t\t\trunOnlyForDeploymentPostprocessing = 0;\n" +
                     "\t\t\tshellPath = \"/usr/bin/env ruby\";\n" +
-                    "\t\t\tshellScript = \"# bugsnag dsym upload script\\nfork do\\n  Process.setsid\\n  STDIN.reopen(\\\"/dev/null\\\")\\n  STDOUT.reopen(\\\"/dev/null\\\", \\\"a\\\")\\n  STDERR.reopen(\\\"/dev/null\\\", \\\"a\\\")\\n\\n  require 'shellwords'\\n\\n  Dir[\\\"#{ENV[\\\"DWARF_DSYM_FOLDER_PATH\\\"]}/*/Contents/Resources/DWARF/*\\\"].each do |dsym|\\n    system(\\\"curl -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV[\\\"PROJECT_DIR\\\"])} https://upload.bugsnag.com/\\\")\\n  end\\nend\";\n" +
+                    "\t\t\tshellScript = \"# bugsnag dsym upload script\\nfork do\\n  Process.setsid\\n  STDIN.reopen(\\\"/dev/null\\\")\\n  STDOUT.reopen(\\\"/dev/null\\\", \\\"a\\\")\\n  STDERR.reopen(\\\"/dev/null\\\", \\\"a\\\")\\n\\n  require \\\"shellwords\\\"\\n\\n  Dir[\\\"#{ENV[\\\"DWARF_DSYM_FOLDER_PATH\\\"]}/*/Contents/Resources/DWARF/*\\\"].each do |dsym|\\n    system(\\\"curl -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV[\\\"PROJECT_DIR\\\"])} https://upload.bugsnag.com/\\\")\\n  end\\nend\";\n" +
                     "\t\t};\n"
                 );
             } else if (needsBugsnagScript && line.Contains ("buildPhases = (")) {


### PR DESCRIPTION
`require 'shellwords'` => `require \\\"shellwords\\\"`

On some OSX El Capitan instances I found that the `'` would break string escaping. Using a standardised escaping system like the rest of the string fixes this escaping issue across my build farm.