### PR TITLE
Use preset log error class when message does not match pattern

### DIFF
--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -529,7 +529,8 @@ public class Bugsnag : MonoBehaviour {
                 errorClass = match.Groups["errorClass"].Value;
                 errorMessage = match.Groups["message"].Value.Trim();
             } else {
-                errorClass = logString;
+                errorClass = "UnityLog" + type;
+                errorMessage = logString;
             }
 
             if (stackTrace == null || stackTrace == "") {


### PR DESCRIPTION
In the case that a log message can't be broken into "class: message" format, use the entire log as the message and set an error class based on the severity of the log. For example the following log message:

```csharp
Debug.LogError("MetalDetector detected metals");
```

Will generate an error report with an error class of `UnityLogError` and the message `MetalDetector detected metals`.