### PR TITLE
Load bugsnag-js as a dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "bugsnag-android"]
 	path = bugsnag-android
 	url = https://github.com/bugsnag/bugsnag-android
+[submodule "bugsnag-js"]
+	path = bugsnag-js
+	url = https://github.com/bugsnag/bugsnag-js

--- a/Rakefile
+++ b/Rakefile
@@ -61,10 +61,18 @@ task :copy_into_project do
   cp_r "src/Assets", $path
 
   # Create the individual platform plugins
+  Rake::Task[:create_webgl_plugin].invoke
   Rake::Task[:create_ios_plugin].invoke
   Rake::Task[:create_android_plugin].invoke
   Rake::Task[:create_osx_plugin].invoke
 
+end
+
+task :create_webgl_plugin do
+  raise "Use rake build instead." unless defined?($path)
+
+  webgl_dir = $path + "/Assets/Plugins/WebGL"
+  cp "bugsnag-js/src/bugsnag.js", File.join(webgl_dir, "bugsnag.jspre")
 end
 
 task :create_ios_plugin do

--- a/src/Assets/Standard Assets/Bugsnag/Editor/BugsnagPostProcess.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Editor/BugsnagPostProcess.cs
@@ -47,12 +47,6 @@ public class BugsnagBuilder : MonoBehaviour {
         var sbWeb = new StringBuilder ();
         foreach (var line in indexLines) {
             sbWeb.AppendLine (line);
-
-            // Add an extra line below the first script tag, linking to the js notifier
-            if (line.Contains ("<script src=\"TemplateData/UnityProgress.js\"></script>")) {
-                var extra = line.Replace ("TemplateData/UnityProgress.js", "//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js");
-                sbWeb.AppendLine (extra);
-            }
         }
         File.WriteAllText(indexPath, sbWeb.ToString());
         return;


### PR DESCRIPTION
In the case that Bugsnag fails to load, either due to networking issues
or content blockers, _load it from disk to avoid this entirely!_ Added 
bugsnag-js as a submodule dependency, like iOS/Android/Mac.

~print a warning message and mock the global Bugsnag
object to avoid further errors. It also provides a debuggable interface
for using Bugsnag from JS to set config options.~

Fixes #43

Example to reproduce:
* Rebuild the package with `rake build`
* Open a project in unity, then `Bugsnag.unitypackage`
* Install uBlock Origin in Firefox
* Generate a WebGL build of an app including Bugsnag
* Confirm that everything is fine.