### PR TITLE
Add warning in place of error when initializing manually

### DIFF
--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -79,6 +79,7 @@ public class Bugsnag : MonoBehaviour {
             };
             IntPtr methodId = AndroidJNI.GetStaticMethodID(BugsnagUnity.GetRawClass(), "init", "(Landroid/content/Context;Ljava/lang/String;)V");
             AndroidJNI.CallStaticVoidMethod(BugsnagUnity.GetRawClass(), methodId, args);
+            registered_ = true;
             Notify("errorClass", "error message", "error", "", new System.Diagnostics.StackTrace (1, true).ToString (), null, true);
         }
 
@@ -87,6 +88,7 @@ public class Bugsnag : MonoBehaviour {
         }
 
         public static void Notify(string errorClass, string errorMessage, string severity, string context, string stackTrace, string type, bool warmup) {
+            if (!CheckRegistration()) return;
             var stackFrames = new ArrayList ();
 
             foreach (Match frameMatch in unityExpression.Matches(stackTrace)) {
@@ -149,10 +151,12 @@ public class Bugsnag : MonoBehaviour {
         }
 
         public static void SetNotifyUrl(string notifyUrl) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("setEndpoint", notifyUrl);
         }
 
         public static void SetAutoNotify(bool autoNotify) {
+            if (!CheckRegistration()) return;
             if (autoNotify) {
                 Bugsnag.CallStatic ("enableExceptionHandler");
             } else {
@@ -161,38 +165,47 @@ public class Bugsnag : MonoBehaviour {
         }
 
         public static void SetContext(string context) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("setContext", context);
         }
 
         public static void SetReleaseStage(string releaseStage) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("setReleaseStage", releaseStage);
         }
 
         public static void SetNotifyReleaseStages(string releaseStages) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("setNotifyReleaseStages", releaseStages.Split (','));
         }
 
         public static void AddToTab(string tabName, string attributeName, string attributeValue) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("addToTab", tabName, attributeName, attributeValue);
         }
 
         public static void ClearTab(string tabName) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("clearTab", tabName);
         }
 
         public static void LeaveBreadcrumb(string breadcrumb) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("leaveBreadcrumb", breadcrumb);
         }
 
         public static void SetBreadcrumbCapacity(int capacity) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("setMaxBreadcrumbs", capacity);
         }
 
         public static void SetAppVersion(string version) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("setAppVersion", version);
         }
 
         public static void SetUser(string userId, string userName, string userEmail) {
+            if (!CheckRegistration()) return;
             Bugsnag.CallStatic ("setUser", userId, userEmail, userName);
         }
 #else
@@ -235,6 +248,15 @@ public class Bugsnag : MonoBehaviour {
         Info = 0,
         Error = 1,
         Warning = 2
+    }
+
+    private static volatile bool registered_ = false;
+    private static bool CheckRegistration() {
+        if (!registered_) {
+            Debug.LogError("BUGSNAG: ERROR: Bugsnag must be initialized before calling other methods");
+            return false;
+        }
+        return true;
     }
 
     // Defines a translation between the Unity log types and Bugsnag log types with appropriate ordering


### PR DESCRIPTION
By default, the Android library throws an exception when called before registration/init. In this case, a warning is presented instead.

To reproduce:

* Call `Bugsnag.notify` or any other function before `Bugsnag.createBugsnagInstance`