### PR TITLE
Allow multiline message

### DIFF
--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -537,7 +537,7 @@ public class Bugsnag : MonoBehaviour {
         if(logSeverity >= NotifyLevel) {
             string errorClass, errorMessage = "";
 
-            Regex exceptionRegEx = new Regex(@"^(?<errorClass>\S+):\s*(?<message>.*)");
+            Regex exceptionRegEx = new Regex(@"^(?<errorClass>\S+):\s*(?<message>.*)", RegexOptions.Singleline);
             Match match = exceptionRegEx.Match(logString);
 
             if(match.Success) {


### PR DESCRIPTION
When an exception with multiline message was captured by Application.logMessageReceived, its lines was omitted except the first line because default Regex ctor is used.