### PR TITLE
fix(android): Cache Client object for reuse

### DIFF
--- a/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
+++ b/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
@@ -10,16 +10,24 @@ import com.bugsnag.android.*;
 
 public class UnityClient {
 
+    static Client client;
+
     public static void init(Context androidContext, String apiKey, boolean trackSessions) {
+        if (client != null) {
+            client.disableExceptionHandler();
+        }
         Configuration config = new Configuration(apiKey);
         config.setAutoCaptureSessions(trackSessions);
-        Bugsnag.init(androidContext, config);
+        client = new Client(androidContext, config);
     }
 
     public static void notify(String name, String message,
                               String context, StackTraceElement[] stacktrace,
                               Severity severity, String logLevel,
                               String severityReason) {
+        if (client == null) {
+            return;
+        }
         Throwable t = new BugsnagException(name, message, stacktrace);
 
         Map<String, Object> data = new HashMap<>();
@@ -27,15 +35,90 @@ public class UnityClient {
         data.put("severityReason", severityReason);
         data.put("logLevel", logLevel);
 
-        Bugsnag.getClient().internalClientNotify(t, data, false, new UnityCallback(context, logLevel));
+        client.internalClientNotify(t, data, false, new UnityCallback(context, logLevel));
+    }
+
+    public static void setContext(String context) {
+        if (client != null) {
+            client.setContext(context);
+        }
+    }
+
+    public static void setAutoNotify(boolean autoNotify) {
+        if (client != null) {
+            if (autoNotify) {
+                client.enableExceptionHandler();
+            } else {
+                client.disableExceptionHandler();
+            }
+        }
+    }
+
+    public static void setEndpoint(String endpoint) {
+        if (client != null) {
+            Configuration config = client.getConfig();
+            config.setEndpoint(endpoint);
+        }
     }
 
     public static void setSessionEndpoint(String endpoint) {
-        try {
-            Configuration config = Bugsnag.getClient().getConfig();
+        if (client != null) {
+            Configuration config = client.getConfig();
             config.setSessionEndpoint(endpoint);
-        } catch (IllegalStateException exception) {
-            // Bugsnag has not yet been initialized. Discarding change.
+        }
+    }
+
+    public static void setUser(String userId, String userName, String userEmail) {
+        if (client != null) {
+            client.setUser(userId, userName, userEmail);
+        }
+    }
+
+    public static void startSession() {
+        if (client != null) {
+            client.startSession();
+        }
+    }
+
+    public static void setAppVersion(String version) {
+        if (client != null) {
+            client.setAppVersion(version);
+        }
+    }
+
+    public static void setMaxBreadcrumbs(int numBreadcrumbs) {
+        if (client != null) {
+            client.setMaxBreadcrumbs(numBreadcrumbs);
+        }
+    }
+
+    public static void leaveBreadcrumb(String breadcrumb) {
+        if (client != null) {
+            client.leaveBreadcrumb(breadcrumb);
+        }
+    }
+
+    public static void setReleaseStage(String releaseStage) {
+        if (client != null) {
+            client.setReleaseStage(releaseStage);
+        }
+    }
+
+    public static void setNotifyReleaseStages(String... notifyReleaseStages) {
+        if (client != null) {
+            client.setNotifyReleaseStages(notifyReleaseStages);
+        }
+    }
+
+    public static void addToTab(String tab, String key, Object value) {
+        if (client != null) {
+            client.addToTab(tab, key, value);
+        }
+    }
+
+    public static void clearTab(String tabName) {
+        if (client != null) {
+            client.clearTab(tabName);
         }
     }
 }

--- a/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
+++ b/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
@@ -19,7 +19,7 @@ public class UnityClient {
                 if (client == null) {
                     Configuration config = new Configuration(apiKey);
                     config.setAutoCaptureSessions(trackSessions);
-                    client = new Client(androidContext, config);
+                    client = Bugsnag.init(androidContext, config);
                 }
             }
         }

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -164,7 +164,7 @@ public class Bugsnag : MonoBehaviour {
 
         public static void SetNotifyUrl(string notifyUrl) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("setEndpoint", notifyUrl);
+            BugsnagUnity.CallStatic ("setEndpoint", notifyUrl);
         }
 
         public static void SetSessionUrl(string url) {
@@ -174,61 +174,57 @@ public class Bugsnag : MonoBehaviour {
 
         public static void SetAutoNotify(bool autoNotify) {
             if (!CheckRegistration()) return;
-            if (autoNotify) {
-                Bugsnag.CallStatic ("enableExceptionHandler");
-            } else {
-                Bugsnag.CallStatic ("disableExceptionHandler");
-            }
+            BugsnagUnity.CallStatic ("setAutoNotify", autoNotify);
         }
 
         public static void SetContext(string context) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("setContext", context);
+            BugsnagUnity.CallStatic ("setContext", context);
         }
 
         public static void SetReleaseStage(string releaseStage) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("setReleaseStage", releaseStage);
+            BugsnagUnity.CallStatic ("setReleaseStage", releaseStage);
         }
 
         public static void SetNotifyReleaseStages(string releaseStages) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("setNotifyReleaseStages", releaseStages.Split (','));
+            BugsnagUnity.CallStatic ("setNotifyReleaseStages", releaseStages.Split (','));
         }
 
         public static void AddToTab(string tabName, string attributeName, string attributeValue) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("addToTab", tabName, attributeName, attributeValue);
+            BugsnagUnity.CallStatic ("addToTab", tabName, attributeName, attributeValue);
         }
 
         public static void ClearTab(string tabName) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("clearTab", tabName);
+            BugsnagUnity.CallStatic ("clearTab", tabName);
         }
 
         public static void LeaveBreadcrumb(string breadcrumb) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("leaveBreadcrumb", breadcrumb);
+            BugsnagUnity.CallStatic ("leaveBreadcrumb", breadcrumb);
         }
 
         public static void SetBreadcrumbCapacity(int capacity) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("setMaxBreadcrumbs", capacity);
+            BugsnagUnity.CallStatic ("setMaxBreadcrumbs", capacity);
         }
 
         public static void SetAppVersion(string version) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("setAppVersion", version);
+            BugsnagUnity.CallStatic ("setAppVersion", version);
         }
 
         public static void SetUser(string userId, string userName, string userEmail) {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("setUser", userId, userEmail, userName);
+            BugsnagUnity.CallStatic ("setUser", userId, userEmail, userName);
         }
 
         public static void StartSession() {
             if (!CheckRegistration()) return;
-            Bugsnag.CallStatic ("startSession");
+            BugsnagUnity.CallStatic ("startSession");
         }
 #else
         private static string apiKey_;

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -309,6 +309,7 @@ public class Bugsnag : MonoBehaviour {
     public bool AutoNotify = true;
     public bool TrackAppSessions = false;
     public static bool TrackAppSessionsStatic = false;
+    private static string BugsnagReleaseStageStatic = null;
 
     // Rate limiting section
     // Defines the maximum number of logs to send (per type) in the rate limit time frame
@@ -360,6 +361,7 @@ public class Bugsnag : MonoBehaviour {
             if (value == null) {
                 value = "production";
             }
+            BugsnagReleaseStageStatic = value;
             NativeBugsnag.SetReleaseStage(value);
         }
     }
@@ -468,7 +470,9 @@ public class Bugsnag : MonoBehaviour {
         BugsnagApiKey = apiKey;
         NativeBugsnag.Register(BugsnagApiKey, TrackAppSessions || TrackAppSessionsStatic);
 
-        if(Debug.isDebugBuild) {
+        if(BugsnagReleaseStageStatic != null) {
+            Bugsnag.ReleaseStage = BugsnagReleaseStageStatic;
+        } else if(Debug.isDebugBuild) {
             Bugsnag.ReleaseStage = "development";
         } else {
             Bugsnag.ReleaseStage = "production";

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -73,7 +73,6 @@ public class Bugsnag : MonoBehaviour {
         public static extern void SetSessionUrl(string sessionUrl);
 
 #elif UNITY_ANDROID && !UNITY_EDITOR
-        public static AndroidJavaClass Bugsnag = new AndroidJavaClass("com.bugsnag.android.Bugsnag");
         public static AndroidJavaClass BugsnagUnity = new AndroidJavaClass("com.bugsnag.android.unity.UnityClient");
         public static Regex unityExpression = new Regex ("(\\S+)\\s*\\(.*?\\)\\s*(?:(?:\\[.*\\]\\s*in\\s|\\(at\\s*\\s*)(.*):(\\d+))?", RegexOptions.IgnoreCase | RegexOptions.Multiline);
 

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -182,7 +182,10 @@ public class Bugsnag : MonoBehaviour {
         }
 
         public static void SetReleaseStage(string releaseStage) {
-            if (!CheckRegistration()) return;
+            // bypass calling CheckRegistration method here as we don't
+            // want to log an error as this can now be called prior to
+            // setting up the notifier
+            if (!registered_) return;
             BugsnagUnity.CallStatic ("setReleaseStage", releaseStage);
         }
 


### PR DESCRIPTION
Passes all usage of the android client to the unity wrapper, avoiding calls to `Bugsnag.getClient()` and preventing multiple clients from being registered (unintentionally or otherwise) from the unity layer.