### PR TITLE
Cache Client object for reuse - preserve configuration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -144,7 +144,7 @@ task :create_android_plugin do
     sh "../bugsnag-android/gradlew build"
   end
 
-  cp "bugsnag-android/sdk/build/outputs/aar/sdk-release.aar", android_dir
+  cp "bugsnag-android/sdk/build/outputs/aar/bugsnag-android-release.aar", android_dir
   cp "bugsnag-android-unity/build/outputs/aar/bugsnag-android-unity-release.aar", android_dir
 end
 

--- a/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
+++ b/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
@@ -19,7 +19,6 @@ public class UnityClient {
         }
         Configuration config = new Configuration(apiKey);
         config.setAutoCaptureSessions(trackSessions);
-        client = new Client(androidContext, config);
         if (configuration != null) {
           // preserve the configuration values that we can that were set on the
           // previous clients configuration. We can't reuse the configuration
@@ -31,6 +30,7 @@ public class UnityClient {
           client.setReleaseStage(configuration.getReleaseStage());
           client.setNotifyReleaseStages(configuration.getNotifyReleaseStages());
         }
+        client = new Client(androidContext, config);
         configuration = config;
     }
 

--- a/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
+++ b/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
@@ -11,6 +11,7 @@ import com.bugsnag.android.*;
 public class UnityClient {
 
     static Client client;
+    static Configuration configuration;
 
     public static void init(Context androidContext, String apiKey, boolean trackSessions) {
         if (client != null) {
@@ -19,6 +20,18 @@ public class UnityClient {
         Configuration config = new Configuration(apiKey);
         config.setAutoCaptureSessions(trackSessions);
         client = new Client(androidContext, config);
+        if (configuration != null) {
+          // preserve the configuration values that we can that were set on the
+          // previous clients configuration. We can't reuse the configuration
+          // object as the apikey is readonly
+          client.setContext(configuration.getContext());
+          config.setEndpoint(configuration.getEndpoint());
+          config.setSessionEndpoint(configuration.getSessionEndpoint());
+          client.setAppVersion(configuration.getAppVersion());
+          client.setReleaseStage(configuration.getReleaseStage());
+          client.setNotifyReleaseStages(configuration.getNotifyReleaseStages());
+        }
+        configuration = config;
     }
 
     public static void notify(String name, String message,

--- a/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
+++ b/src/Assets/Standard Assets/Bugsnag/Bugsnag.cs
@@ -73,7 +73,6 @@ public class Bugsnag : MonoBehaviour {
         public static extern void SetSessionUrl(string sessionUrl);
 
 #elif UNITY_ANDROID && !UNITY_EDITOR
-        public static AndroidJavaClass Bugsnag = new AndroidJavaClass("com.bugsnag.android.Bugsnag");
         public static AndroidJavaClass BugsnagUnity = new AndroidJavaClass("com.bugsnag.android.unity.UnityClient");
         public static Regex unityExpression = new Regex ("(\\S+)\\s*\\(.*?\\)\\s*(?:(?:\\[.*\\]\\s*in\\s|\\(at\\s*\\s*)(.*):(\\d+))?", RegexOptions.IgnoreCase | RegexOptions.Multiline);
 


### PR DESCRIPTION
If a new client is ever created then the user will lose any previously set configuration values. This attempts to preserve the values that we can from the previous configuration object