### PR TITLE
Cache Client object for reuse - no-op on subsequent calls

### DIFF
--- a/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
+++ b/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
@@ -10,15 +10,19 @@ import com.bugsnag.android.*;
 
 public class UnityClient {
 
-    static Client client;
+    static volatile Client client;
+    private static Object lock = new Object();
 
     public static void init(Context androidContext, String apiKey, boolean trackSessions) {
-        if (client != null) {
-            client.disableExceptionHandler();
+        if (client == null) {
+            synchronized (lock) {
+                if (client == null) {
+                    Configuration config = new Configuration(apiKey);
+                    config.setAutoCaptureSessions(trackSessions);
+                    client = new Client(androidContext, config);
+                }
+            }
         }
-        Configuration config = new Configuration(apiKey);
-        config.setAutoCaptureSessions(trackSessions);
-        client = new Client(androidContext, config);
     }
 
     public static void notify(String name, String message,

--- a/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
+++ b/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/UnityClient.java
@@ -11,7 +11,7 @@ import com.bugsnag.android.*;
 public class UnityClient {
 
     static volatile Client client;
-    private static Object lock = new Object();
+    private static final Object lock = new Object();
 
     public static void init(Context androidContext, String apiKey, boolean trackSessions) {
         if (client == null) {


### PR DESCRIPTION
Here is the alternate approach suggested by both @snmaynard and @fractalwrench where we only create the client once. Any additional calls to `init` will be a no-op