### PR TITLE
Fix release stage filtering on cocoa platforms

### DIFF
--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -330,6 +330,10 @@ namespace BugsnagUnity
           handle.Free();
         }
 
+        if (releaseStages.Count == 0)
+        {
+            return null;
+        }
         return releaseStages.ToArray();
       }
       set => SetNotifyReleaseStages(NativeConfiguration, value, value.Length);
@@ -468,6 +472,10 @@ namespace BugsnagUnity
           handle.Free();
         }
 
+        if (releaseStages.Count == 0)
+        {
+            return null;
+        }
         return releaseStages.ToArray();
       }
       set => SetNotifyReleaseStages(NativeConfiguration, value, value.Length);


### PR DESCRIPTION
During delivery, if notify release stages is non-null, then reports are
only sent if release stage is in notify release stages. On cocoa, the
value defaults to nil, but was parsed into an empty array, so no reports
could ever be sent in the default configuration.

## Changeset

### Changed

* Return null from `GetNotifyReleaseStages` in `MacOSConfiguration` and `iOSConfiguration` if the array fetched from the native side is empty.

## Tests

* Tested in the unity editor on mac, in a standalone mac app, and on an iPhone 6

## Discussion

Looks like an ideal candidate for end-to-end tests and a release checklist

## Review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
