### PR TITLE
Stacktrace improvements

### DIFF
--- a/src/BugsnagUnity/Clients/Client.cs
+++ b/src/BugsnagUnity/Clients/Client.cs
@@ -87,7 +87,7 @@ namespace BugsnagUnity
         {
           if (LogTypeCounter.ShouldSend(logMessage))
           {
-            Notify(new UnityLogExceptions(logMessage).ToArray(), HandledState.ForHandledException(), null, logMessage.Type);
+            Notify(new UnityLogExceptions(logMessage).ToArray(), HandledState.ForHandledException(), null);
           }
         }
       }
@@ -137,7 +137,7 @@ namespace BugsnagUnity
       Notify(new Exceptions(exception, substituteStackTrace, "BugsnagUnity.Client.Notify").ToArray(), handledState, callback);
     }
 
-    void Notify(Exception[] exceptions, HandledState handledState, Middleware callback, LogType? logType = null)
+    void Notify(Exception[] exceptions, HandledState handledState, Middleware callback)
     {
       var user = new User { Id = User.Id, Email = User.Email, Name = User.Name };
       var app = new App(Configuration)

--- a/src/BugsnagUnity/Clients/Client.cs
+++ b/src/BugsnagUnity/Clients/Client.cs
@@ -130,7 +130,11 @@ namespace BugsnagUnity
 
     void Notify(System.Exception exception, HandledState handledState, Middleware callback)
     {
-      Notify(new Exceptions(exception).ToArray(), handledState, callback);
+      // we need to generate a substitute stacktrace here as if we are not able
+      // to generate one from the exception that we are given then we are not able
+      // to do this inside of the IEnumerator generator code
+      var substituteStackTrace = new System.Diagnostics.StackTrace(true).GetFrames();
+      Notify(new Exceptions(exception, substituteStackTrace).ToArray(), handledState, callback);
     }
 
     void Notify(Exception[] exceptions, HandledState handledState, Middleware callback, LogType? logType = null)

--- a/src/BugsnagUnity/Clients/Client.cs
+++ b/src/BugsnagUnity/Clients/Client.cs
@@ -110,31 +110,43 @@ namespace BugsnagUnity
 
     public void Notify(System.Exception exception)
     {
-      Notify(exception, null);
+      // we need to generate a substitute stacktrace here as if we are not able
+      // to generate one from the exception that we are given then we are not able
+      // to do this inside of the IEnumerator generator code
+      var substituteStackTrace = new System.Diagnostics.StackTrace(1, true).GetFrames();
+      Notify(exception, HandledState.ForHandledException(), null, substituteStackTrace);
     }
 
     public void Notify(System.Exception exception, Middleware callback)
     {
-      Notify(exception, HandledState.ForHandledException(), callback);
+      // we need to generate a substitute stacktrace here as if we are not able
+      // to generate one from the exception that we are given then we are not able
+      // to do this inside of the IEnumerator generator code
+      var substituteStackTrace = new System.Diagnostics.StackTrace(1, true).GetFrames();
+      Notify(exception, HandledState.ForHandledException(), callback, substituteStackTrace);
     }
 
     public void Notify(System.Exception exception, Severity severity)
     {
-      Notify(exception, severity, null);
+      // we need to generate a substitute stacktrace here as if we are not able
+      // to generate one from the exception that we are given then we are not able
+      // to do this inside of the IEnumerator generator code
+      var substituteStackTrace = new System.Diagnostics.StackTrace(1, true).GetFrames();
+      Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), null, substituteStackTrace);
     }
 
     public void Notify(System.Exception exception, Severity severity, Middleware callback)
     {
-      Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), callback);
-    }
-
-    void Notify(System.Exception exception, HandledState handledState, Middleware callback)
-    {
       // we need to generate a substitute stacktrace here as if we are not able
       // to generate one from the exception that we are given then we are not able
       // to do this inside of the IEnumerator generator code
-      var substituteStackTrace = new System.Diagnostics.StackTrace(true).GetFrames();
-      Notify(new Exceptions(exception, substituteStackTrace, "BugsnagUnity.Client.Notify").ToArray(), handledState, callback);
+      var substituteStackTrace = new System.Diagnostics.StackTrace(1, true).GetFrames();
+      Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), callback, substituteStackTrace);
+    }
+
+    void Notify(System.Exception exception, HandledState handledState, Middleware callback, StackFrame[] substitute)
+    {
+      Notify(new Exceptions(exception, substitute).ToArray(), handledState, callback);
     }
 
     void Notify(Exception[] exceptions, HandledState handledState, Middleware callback)

--- a/src/BugsnagUnity/Clients/Client.cs
+++ b/src/BugsnagUnity/Clients/Client.cs
@@ -110,42 +110,30 @@ namespace BugsnagUnity
 
     public void Notify(System.Exception exception)
     {
-      // we need to generate a substitute stacktrace here as if we are not able
-      // to generate one from the exception that we are given then we are not able
-      // to do this inside of the IEnumerator generator code
-      var substituteStackTrace = new System.Diagnostics.StackTrace(1, true).GetFrames();
-      Notify(exception, HandledState.ForHandledException(), null, substituteStackTrace);
+      Notify(exception, HandledState.ForHandledException(), null);
     }
 
     public void Notify(System.Exception exception, Middleware callback)
     {
-      // we need to generate a substitute stacktrace here as if we are not able
-      // to generate one from the exception that we are given then we are not able
-      // to do this inside of the IEnumerator generator code
-      var substituteStackTrace = new System.Diagnostics.StackTrace(1, true).GetFrames();
-      Notify(exception, HandledState.ForHandledException(), callback, substituteStackTrace);
+      Notify(exception, HandledState.ForHandledException(), callback);
     }
 
     public void Notify(System.Exception exception, Severity severity)
     {
-      // we need to generate a substitute stacktrace here as if we are not able
-      // to generate one from the exception that we are given then we are not able
-      // to do this inside of the IEnumerator generator code
-      var substituteStackTrace = new System.Diagnostics.StackTrace(1, true).GetFrames();
-      Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), null, substituteStackTrace);
+      Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), null);
     }
 
     public void Notify(System.Exception exception, Severity severity, Middleware callback)
     {
+      Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), callback);
+    }
+
+    void Notify(System.Exception exception, HandledState handledState, Middleware callback)
+    {
       // we need to generate a substitute stacktrace here as if we are not able
       // to generate one from the exception that we are given then we are not able
       // to do this inside of the IEnumerator generator code
-      var substituteStackTrace = new System.Diagnostics.StackTrace(1, true).GetFrames();
-      Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), callback, substituteStackTrace);
-    }
-
-    void Notify(System.Exception exception, HandledState handledState, Middleware callback, StackFrame[] substitute)
-    {
+      var substitute = new System.Diagnostics.StackTrace(2, true).GetFrames();
       Notify(new Exceptions(exception, substitute).ToArray(), handledState, callback);
     }
 

--- a/src/BugsnagUnity/Clients/Client.cs
+++ b/src/BugsnagUnity/Clients/Client.cs
@@ -134,7 +134,7 @@ namespace BugsnagUnity
       // to generate one from the exception that we are given then we are not able
       // to do this inside of the IEnumerator generator code
       var substituteStackTrace = new System.Diagnostics.StackTrace(true).GetFrames();
-      Notify(new Exceptions(exception, substituteStackTrace).ToArray(), handledState, callback);
+      Notify(new Exceptions(exception, substituteStackTrace, "BugsnagUnity.Client.Notify").ToArray(), handledState, callback);
     }
 
     void Notify(Exception[] exceptions, HandledState handledState, Middleware callback, LogType? logType = null)

--- a/src/BugsnagUnity/Payload/Exception.cs
+++ b/src/BugsnagUnity/Payload/Exception.cs
@@ -35,9 +35,9 @@ namespace BugsnagUnity.Payload
   {
     private IEnumerable<Exception> UnwoundExceptions { get; }
 
-    internal Exceptions(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace)
+    internal Exceptions(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace, string boundaryMethod)
     {
-      UnwoundExceptions = FlattenAndReverseExceptionTree(exception).Select(e => Exception.FromSystemException(e, alternativeStackTrace));
+      UnwoundExceptions = FlattenAndReverseExceptionTree(exception).Select(e => Exception.FromSystemException(e, alternativeStackTrace, boundaryMethod));
     }
 
     public IEnumerator<Exception> GetEnumerator()
@@ -95,10 +95,10 @@ namespace BugsnagUnity.Payload
 
     public string ErrorMessage => this.Get("message") as string;
 
-    internal static Exception FromSystemException(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace)
+    internal static Exception FromSystemException(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace, string boundaryMethod)
     {
       var errorClass = TypeNameHelper.GetTypeDisplayName(exception.GetType());
-      var stackTrace = new StackTrace(exception, alternativeStackTrace).ToArray();
+      var stackTrace = new StackTrace(exception, alternativeStackTrace, boundaryMethod).ToArray();
       return new Exception(errorClass, exception.Message, stackTrace);
     }
 

--- a/src/BugsnagUnity/Payload/Exception.cs
+++ b/src/BugsnagUnity/Payload/Exception.cs
@@ -35,9 +35,9 @@ namespace BugsnagUnity.Payload
   {
     private IEnumerable<Exception> UnwoundExceptions { get; }
 
-    internal Exceptions(System.Exception exception)
+    internal Exceptions(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace)
     {
-      UnwoundExceptions = FlattenAndReverseExceptionTree(exception).Select(e => Exception.FromSystemException(e));
+      UnwoundExceptions = FlattenAndReverseExceptionTree(exception).Select(e => Exception.FromSystemException(e, alternativeStackTrace));
     }
 
     public IEnumerator<Exception> GetEnumerator()
@@ -95,10 +95,10 @@ namespace BugsnagUnity.Payload
 
     public string ErrorMessage => this.Get("message") as string;
 
-    internal static Exception FromSystemException(System.Exception exception)
+    internal static Exception FromSystemException(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace)
     {
       var errorClass = TypeNameHelper.GetTypeDisplayName(exception.GetType());
-      var stackTrace = new StackTrace(exception).ToArray();
+      var stackTrace = new StackTrace(exception, alternativeStackTrace).ToArray();
       return new Exception(errorClass, exception.Message, stackTrace);
     }
 

--- a/src/BugsnagUnity/Payload/Exception.cs
+++ b/src/BugsnagUnity/Payload/Exception.cs
@@ -35,9 +35,9 @@ namespace BugsnagUnity.Payload
   {
     private IEnumerable<Exception> UnwoundExceptions { get; }
 
-    internal Exceptions(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace, string boundaryMethod)
+    internal Exceptions(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace)
     {
-      UnwoundExceptions = FlattenAndReverseExceptionTree(exception).Select(e => Exception.FromSystemException(e, alternativeStackTrace, boundaryMethod));
+      UnwoundExceptions = FlattenAndReverseExceptionTree(exception).Select(e => Exception.FromSystemException(e, alternativeStackTrace));
     }
 
     public IEnumerator<Exception> GetEnumerator()
@@ -95,10 +95,10 @@ namespace BugsnagUnity.Payload
 
     public string ErrorMessage => this.Get("message") as string;
 
-    internal static Exception FromSystemException(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace, string boundaryMethod)
+    internal static Exception FromSystemException(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace)
     {
       var errorClass = TypeNameHelper.GetTypeDisplayName(exception.GetType());
-      var stackTrace = new StackTrace(exception, alternativeStackTrace, boundaryMethod).ToArray();
+      var stackTrace = new StackTrace(exception, alternativeStackTrace).ToArray();
       return new Exception(errorClass, exception.Message, stackTrace);
     }
 

--- a/src/BugsnagUnity/Payload/StackTraceLine.cs
+++ b/src/BugsnagUnity/Payload/StackTraceLine.cs
@@ -76,18 +76,18 @@ namespace BugsnagUnity.Payload
         exceptionStackTrace = false;
         stackFrames = AlternativeStackTrace;
       }
-      
+
       if (stackFrames == null)
       {
         yield break;
       }
-      
+
       var seenBugsnagFrames = false;
 
       foreach (var frame in stackFrames)
       {
         var stackFrame = StackTraceLine.FromStackFrame(frame);
-        
+
         if (!exceptionStackTrace)
         {
           // if the exception has not come from a stack trace then we need to

--- a/src/BugsnagUnity/Payload/StackTraceLine.cs
+++ b/src/BugsnagUnity/Payload/StackTraceLine.cs
@@ -18,6 +18,8 @@ namespace BugsnagUnity.Payload
 
     StackFrame[] AlternativeStackTrace { get; }
 
+    string BoundaryMethod { get; }
+
     private static string[] StringSplit { get; } = { Environment.NewLine };
 
     /// <summary>
@@ -31,8 +33,9 @@ namespace BugsnagUnity.Payload
       OriginalStackTrace = stackTrace;
     }
 
-    internal StackTrace(System.Exception exception, StackFrame[] alternativeStackTrace)
+    internal StackTrace(System.Exception exception, StackFrame[] alternativeStackTrace, string boundaryMethod)
     {
+      BoundaryMethod = boundaryMethod;
       OriginalException = exception;
       AlternativeStackTrace = alternativeStackTrace;
     }
@@ -92,7 +95,7 @@ namespace BugsnagUnity.Payload
         {
           // if the exception has not come from a stack trace then we need to
           // skip the frames that originate from inside the notifier code base
-          var currentStackFrameIsNotify = stackFrame.MethodName.StartsWith("BugsnagUnity.Client.Notify", StringComparison.InvariantCulture);
+          var currentStackFrameIsNotify = stackFrame.MethodName.StartsWith(BoundaryMethod, StringComparison.InvariantCulture);
           seenBugsnagFrames = seenBugsnagFrames || currentStackFrameIsNotify;
           if (!seenBugsnagFrames || currentStackFrameIsNotify)
           {


### PR DESCRIPTION
In the case where we have been given an exception with no stack trace (this is usually the case when we are given an exception that has not been thrown) we previously tried to generate a stack trace using the current stack trace. This does not work in Unity inside of the generator code. 

The fix here is to generate a stack trace outside of the generator code that we can use in the case where we are not able to get a stacktfrace from the provided exception.