### PR TITLE
Proxy client methods to bugsnag

### DIFF
--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
+using BugsnagUnity;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -12,7 +13,7 @@ public class Main : MonoBehaviour {
     var scene = UnityEditor.SceneManagement.EditorSceneManager.NewScene(UnityEditor.SceneManagement.NewSceneSetup.DefaultGameObjects, UnityEditor.SceneManagement.NewSceneMode.Single);
     UnityEngine.SceneManagement.SceneManager.SetActiveScene(scene);
     var obj = new GameObject("Bugsnag");
-    var bugsnag = obj.AddComponent<BugsnagUnity.BugsnagBehaviour>();
+    var bugsnag = obj.AddComponent<BugsnagBehaviour>();
     bugsnag.BugsnagApiKey = System.Environment.GetEnvironmentVariable("BUGSNAG_APIKEY");
     obj.AddComponent<Main>();
     UnityEditor.SceneManagement.EditorSceneManager.SaveScene(scene, "Assets/MainScene.unity");
@@ -28,10 +29,10 @@ public class Main : MonoBehaviour {
     // only send one crash
     if (!sent) {
       sent = true;
-      BugsnagUnity.Bugsnag.Client.Configuration.Endpoint =
+      Bugsnag.Configuration.Endpoint =
         new System.Uri(System.Environment.GetEnvironmentVariable("MAZE_ENDPOINT"));
-      BugsnagUnity.Bugsnag.Client.Breadcrumbs.Leave("bleeb");
-      BugsnagUnity.Bugsnag.Client.Notify(new System.Exception("blorb"), report => {
+      Bugsnag.Breadcrumbs.Leave("bleeb");
+      Bugsnag.Notify(new System.Exception("blorb"), report => {
         report.Event.User.Name = "blarb";
       });
       // wait for 5 seconds before exiting the application

--- a/src/Assets/Standard Assets/Bugsnag/BugsnagBehaviour.cs
+++ b/src/Assets/Standard Assets/Bugsnag/BugsnagBehaviour.cs
@@ -31,12 +31,12 @@ namespace BugsnagUnity
     void Awake()
     {
       Bugsnag.Init(BugsnagApiKey);
-      Bugsnag.Client.Configuration.AutoNotify = AutoNotify;
-      Bugsnag.Client.Configuration.AutoCaptureSessions = AutoCaptureSessions;
-      Bugsnag.Client.Configuration.UniqueLogsTimePeriod = TimeSpan.FromSeconds(UniqueLogsPerSecond);
-      Bugsnag.Client.Configuration.NotifyLevel = NotifyLevel;
-      Bugsnag.Client.Configuration.ReleaseStage = Debug.isDebugBuild ? "development" : "production";
-      Bugsnag.Client.Configuration.MaximumBreadcrumbs = MaximumBreadcrumbs;
+      Bugsnag.Configuration.AutoNotify = AutoNotify;
+      Bugsnag.Configuration.AutoCaptureSessions = AutoCaptureSessions;
+      Bugsnag.Configuration.UniqueLogsTimePeriod = TimeSpan.FromSeconds(UniqueLogsPerSecond);
+      Bugsnag.Configuration.NotifyLevel = NotifyLevel;
+      Bugsnag.Configuration.ReleaseStage = Debug.isDebugBuild ? "development" : "production";
+      Bugsnag.Configuration.MaximumBreadcrumbs = MaximumBreadcrumbs;
     }
 
     /// <summary>
@@ -50,13 +50,13 @@ namespace BugsnagUnity
     /// <param name="hasFocus"></param>
     void OnApplicationFocus(bool hasFocus)
     {
-      Bugsnag.Client.SetApplicationState(hasFocus);
+      Bugsnag.SetApplicationState(hasFocus);
     }
 
     void OnApplicationPause(bool paused)
     {
       var hasFocus = !paused;
-      Bugsnag.Client.SetApplicationState(hasFocus);
+      Bugsnag.SetApplicationState(hasFocus);
     }
   }
 }

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+using UnityEngine;
+using BugsnagUnity.Payload;
 
 namespace BugsnagUnity
 {
@@ -40,5 +41,35 @@ namespace BugsnagUnity
     }
 
     public static IClient Client { get; private set; }
+
+    public static IConfiguration Configuration => Client.Configuration;
+
+    public static IBreadcrumbs Breadcrumbs => Client.Breadcrumbs;
+
+    public static ISessionTracker SessionTracking => Client.SessionTracking;
+
+    public static User User => Client.User;
+
+    public static void Send(IPayload payload) => Client.Send(payload);
+
+    public static Metadata Metadata => Client.Metadata;
+
+    public static void BeforeNotify(Middleware middleware) => Client.BeforeNotify(middleware);
+
+    public static void Notify(System.Exception exception) => Client.Notify(exception);
+
+    public static void Notify(System.Exception exception, Middleware callback) => Client.Notify(exception, callback);
+
+    public static void Notify(System.Exception exception, Severity severity) => Client.Notify(exception, severity);
+
+    public static void Notify(System.Exception exception, Severity severity, Middleware callback) => Client.Notify(exception, severity, callback);
+
+    /// <summary>
+    /// Used to signal to the Bugsnag client that the focused state of the
+    /// application has changed. This is used for session tracking and also
+    /// the tracking of in foreground time for the application.
+    /// </summary>
+    /// <param name="inFocus"></param>
+    public static void SetApplicationState(bool inFocus) => Client.SetApplicationState(inFocus);
   }
 }


### PR DESCRIPTION
Proxy the Client, Breadcrumbs, and SessionTracking methods to Bugsnag to simplify usage and provide consistency with other platforms.

There are no checks here to ensure that the client has been created beforehand. This follows the same pattern as bugsnag-cocoa though. What do people think about this?