### PR TITLE
Move Event getters/setters into Report

### DIFF
--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -32,7 +32,7 @@ public class Main : MonoBehaviour {
         new System.Uri(System.Environment.GetEnvironmentVariable("MAZE_ENDPOINT"));
       BugsnagUnity.Bugsnag.Client.Breadcrumbs.Leave("bleeb");
       BugsnagUnity.Bugsnag.Client.Notify(new System.Exception("blorb"), report => {
-        report.Event.User.Name = "blarb";
+        report.User.Name = "blarb";
       });
       // wait for 5 seconds before exiting the application
       StartCoroutine(WaitForBugsnag());

--- a/src/BugsnagUnity/Payload/Breadcrumb.cs
+++ b/src/BugsnagUnity/Payload/Breadcrumb.cs
@@ -17,19 +17,19 @@ namespace BugsnagUnity.Payload
     {
       var name = "Error";
 
-      if (report.Event.OriginalSeverity != null)
+      if (report.OriginalSeverity != null)
       {
-        name = report.Event.OriginalSeverity.Severity.ToString();
+        name = report.OriginalSeverity.Severity.ToString();
       }
 
       var metadata = new Dictionary<string, string>
       {
-        { "context", report.Event.Context },
+        { "context", report.Context },
       };
 
-      if (report.Event.Exceptions != null && report.Event.Exceptions.Any())
+      if (report.Exceptions != null && report.Exceptions.Any())
       {
-        var exception = report.Event.Exceptions.First();
+        var exception = report.Exceptions.First();
 
         metadata.Add("class", exception.ErrorClass);
         metadata.Add("message", exception.ErrorMessage);

--- a/src/BugsnagUnity/Payload/Event.cs
+++ b/src/BugsnagUnity/Payload/Event.cs
@@ -3,9 +3,9 @@ using UnityEngine;
 
 namespace BugsnagUnity.Payload
 {
-  public class Event : Dictionary<string, object>
+  class Event : Dictionary<string, object>
   {
-    private HandledState _handledState;
+    HandledState _handledState;
 
     internal HandledState OriginalSeverity { get; }
 
@@ -26,11 +26,11 @@ namespace BugsnagUnity.Payload
       this.AddToPayload("user", user);
     }
 
-    public Metadata Metadata { get; }
+    internal Metadata Metadata { get; }
 
-    public LogType? LogType { get; }
+    internal LogType? LogType { get; }
 
-    public bool IsHandled
+    internal bool IsHandled
     {
       get
       {
@@ -43,45 +43,45 @@ namespace BugsnagUnity.Payload
       }
     }
 
-    public App App
+    internal App App
     {
       get { return this.Get("app") as App; }
     }
 
-    public IEnumerable<Breadcrumb> Breadcrumbs
+    internal IEnumerable<Breadcrumb> Breadcrumbs
     {
       get { return this.Get("breadcrumbs") as IEnumerable<Breadcrumb>; }
     }
 
-    public string Context
+    internal string Context
     {
       get => this.Get("context") as string;
       set => this.AddToPayload("context", value);
     }
 
-    public Device Device => this.Get("device") as Device;
+    internal Device Device => this.Get("device") as Device;
 
-    public Exception[] Exceptions => this.Get("exceptions") as Exception[];
+    internal Exception[] Exceptions => this.Get("exceptions") as Exception[];
 
-    public string GroupingHash
+    internal string GroupingHash
     {
       get => this.Get("groupingHash") as string;
       set => this.AddToPayload("groupingHash", value);
     }
 
-    public Severity Severity
+    internal Severity Severity
     {
       set => HandledState = HandledState.ForCallbackSpecifiedSeverity(value, _handledState);
       get => _handledState.Severity;
     }
 
-    public User User
+    internal User User
     {
       get { return this.Get("user") as User; }
       set { this.AddToPayload("user", value); }
     }
 
-    private HandledState HandledState
+    HandledState HandledState
     {
       set
       {

--- a/src/BugsnagUnity/Payload/Report.cs
+++ b/src/BugsnagUnity/Payload/Report.cs
@@ -6,12 +6,30 @@ namespace BugsnagUnity.Payload
 {
   public class Report : Dictionary<string, object>, IPayload
   {
+    /// <summary>
+    /// Gets the configuration used to construct this report.
+    /// </summary>
+    /// <value>The configuration.</value>
     public IConfiguration Configuration { get; }
 
+    /// <summary>
+    /// Gets the endpoint that will be used to send the report to.
+    /// </summary>
+    /// <value>The endpoint.</value>
     public Uri Endpoint => Configuration.Endpoint;
 
+    /// <summary>
+    /// Gets the headers that will be attached to the http request used to send
+    /// this report.
+    /// </summary>
+    /// <value>The headers.</value>
     public KeyValuePair<string, string>[] Headers { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="T:BugsnagUnity.Payload.Report"/>
+    /// is ignored. If ignored the report will not be sent to Bugsnag.
+    /// </summary>
+    /// <value><c>true</c> if ignored; otherwise, <c>false</c>.</value>
     public bool Ignored { get; private set; }
 
     internal Report(IConfiguration configuration, Event @event)
@@ -32,43 +50,94 @@ namespace BugsnagUnity.Payload
 
     internal HandledState OriginalSeverity => Event.OriginalSeverity;
 
+    /// <summary>
+    /// Ignore this report and do not send it to Bugsnag.
+    /// </summary>
     public void Ignore()
     {
       Ignored = true;
     }
-
+    
+    /// <summary>
+    /// Gets the metadata associated with this report.
+    /// </summary>
+    /// <value>The metadata.</value>
     public Metadata Metadata => Event.Metadata;
-
+    
+    /// <summary>
+    /// Gets the Unity LogType that this event was generated with. Will be null
+    /// if the report was not generated from a Unity log message.
+    /// </summary>
+    /// <value>The type of the log.</value>
     public LogType? LogType => Event.LogType;
 
+    /// <summary>
+    /// Gets a value indicating whether this <see cref="T:BugsnagUnity.Payload.Report"/>
+      /// is a handled error or not.
+    /// </summary>
+    /// <value><c>true</c> if is handled; otherwise, <c>false</c>.</value>
     public bool IsHandled => Event.IsHandled;
 
+    /// <summary>
+    /// Gets the app data that was gathered for this report.
+    /// </summary>
+    /// <value>The app.</value>
     public App App => Event.App;
 
+    /// <summary>
+    /// Gets the breadcrumbs that have been attached to this report.
+    /// </summary>
+    /// <value>The breadcrumbs.</value>
     public IEnumerable<Breadcrumb> Breadcrumbs => Event.Breadcrumbs;
 
+    /// <summary>
+    /// Gets or sets the context for this report.
+    /// </summary>
+    /// <value>The context.</value>
     public string Context
     {
       get => Event.Context;
       set => Event.Context = value;
     }
 
+    /// <summary>
+    /// Gets the device data that was gathered for this report.
+    /// </summary>
+    /// <value>The device.</value>
     public Device Device => Event.Device;
 
+    /// <summary>
+    /// Gets the exceptions that generated this report. There may be multiple of
+    /// these if the exception had inner exceptions.
+    /// </summary>
+    /// <value>The exceptions.</value>
     public Exception[] Exceptions => Event.Exceptions;
-    
+
+    /// <summary>
+    /// Gets or sets the grouping hash for this report. Can be used to provide
+    /// your own grouping logic.
+    /// </summary>
+    /// <value>The grouping hash.</value>
     public string GroupingHash
     {
       get => Event.GroupingHash;
       set => Event.GroupingHash = value;
     }
-    
+
+    /// <summary>
+    /// Gets or sets the severity of this report.
+    /// </summary>
+    /// <value>The severity.</value>
     public Severity Severity
     {
       get => Event.Severity;
       set => Event.Severity = value;
     }
-    
+
+    /// <summary>
+    /// Gets or sets the user information associated with this report.
+    /// </summary>
+    /// <value>The user.</value>
     public User User
     {
       get => Event.User;

--- a/src/BugsnagUnity/Payload/Report.cs
+++ b/src/BugsnagUnity/Payload/Report.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace BugsnagUnity.Payload
 {
@@ -27,11 +28,51 @@ namespace BugsnagUnity.Payload
       this.AddToPayload("events", new[] { Event });
     }
 
-    public Event Event { get; }
+    Event Event { get; }
+
+    internal HandledState OriginalSeverity => Event.OriginalSeverity;
 
     public void Ignore()
     {
       Ignored = true;
+    }
+
+    public Metadata Metadata => Event.Metadata;
+
+    public LogType? LogType => Event.LogType;
+
+    public bool IsHandled => Event.IsHandled;
+
+    public App App => Event.App;
+
+    public IEnumerable<Breadcrumb> Breadcrumbs => Event.Breadcrumbs;
+
+    public string Context
+    {
+      get => Event.Context;
+      set => Event.Context = value;
+    }
+
+    public Device Device => Event.Device;
+
+    public Exception[] Exceptions => Event.Exceptions;
+    
+    public string GroupingHash
+    {
+      get => Event.GroupingHash;
+      set => Event.GroupingHash = value;
+    }
+    
+    public Severity Severity
+    {
+      get => Event.Severity;
+      set => Event.Severity = value;
+    }
+    
+    public User User
+    {
+      get => Event.User;
+      set => Event.User = value;
     }
   }
 }

--- a/src/BugsnagUnity/Payload/Session.cs
+++ b/src/BugsnagUnity/Payload/Session.cs
@@ -25,7 +25,7 @@ namespace BugsnagUnity.Payload
 
     internal void AddException(Report report)
     {
-      if (report.Event.IsHandled)
+      if (report.IsHandled)
       {
         Events.IncrementHandledCount();
       }


### PR DESCRIPTION
1. Make Report.Event non-public (this is the only place the Event class is used , so the class should be non-public as well)
1. Move getters/setters for User, Severity, HandledState (private), GroupingHash, Exceptions, Device, Context, Breadcrumbs, App, IsHandled, LogType, and MetaData from Event to Report.