### PR TITLE
Remove Entrypoint usage

### DIFF
--- a/src/BugsnagUnity/Native/Cocoa/Breadcrumbs.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Breadcrumbs.cs
@@ -12,7 +12,7 @@ namespace BugsnagUnity
 
     Breadcrumbs(IntPtr nativeConfiguration)
     {
-      NativeBreadcrumbs = NativeCode.CreateBreadcrumbs(nativeConfiguration);
+      NativeBreadcrumbs = NativeCode.bugsnag_createBreadcrumbs(nativeConfiguration);
     }
 
     internal Breadcrumbs(Configuration configuration) : this(configuration.NativeConfiguration)
@@ -55,11 +55,11 @@ namespace BugsnagUnity
             index += 2;
           }
 
-          NativeCode.NativeAddBreadcrumb(NativeBreadcrumbs, breadcrumb.Name, breadcrumb.Type, metadata, metadata.Length);
+          NativeCode.bugsnag_addBreadcrumb(NativeBreadcrumbs, breadcrumb.Name, breadcrumb.Type, metadata, metadata.Length);
         }
         else
         {
-          NativeCode.NativeAddBreadcrumb(NativeBreadcrumbs, breadcrumb.Name, breadcrumb.Type, null, 0);
+          NativeCode.bugsnag_addBreadcrumb(NativeBreadcrumbs, breadcrumb.Name, breadcrumb.Type, null, 0);
         }
       }
     }
@@ -72,7 +72,7 @@ namespace BugsnagUnity
 
       try
       {
-        NativeCode.NativeRetrieveBreadcrumbs(NativeBreadcrumbs, GCHandle.ToIntPtr(handle), PopulateBreadcrumb);
+        NativeCode.bugsnag_retrieveBreadcrumbs(NativeBreadcrumbs, GCHandle.ToIntPtr(handle), PopulateBreadcrumb);
       }
       finally
       {

--- a/src/BugsnagUnity/Native/Cocoa/Configuration.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Configuration.cs
@@ -16,7 +16,7 @@ namespace BugsnagUnity
 
     internal Configuration(string apiKey)
     {
-      NativeConfiguration = NativeCode.CreateConfiguration(apiKey);
+      NativeConfiguration = NativeCode.bugsnag_createConfiguration(apiKey);
       Endpoint = new Uri(DefaultEndpoint);
       AutoNotify = true;
       SessionEndpoint = new Uri(DefaultSessionEndpoint);
@@ -29,7 +29,7 @@ namespace BugsnagUnity
       LogTypeSeverityMapping = new LogTypeSeverityMapping();
     }
 
-    public string ApiKey => Marshal.PtrToStringAuto(NativeCode.GetApiKey(NativeConfiguration));
+    public string ApiKey => Marshal.PtrToStringAuto(NativeCode.bugsnag_getApiKey(NativeConfiguration));
     public TimeSpan MaximumLogsTimePeriod { get; }
     public Dictionary<LogType, int> MaximumTypePerTimePeriod { get; } = new Dictionary<LogType, int>
     {
@@ -44,8 +44,8 @@ namespace BugsnagUnity
 
     public string ReleaseStage
     {
-      get => Marshal.PtrToStringAuto(NativeCode.GetReleaseStage(NativeConfiguration));
-      set => NativeCode.SetReleaseStage(NativeConfiguration, value);
+      get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getReleaseStage(NativeConfiguration));
+      set => NativeCode.bugsnag_setReleaseStage(NativeConfiguration, value);
     }
 
     public string[] NotifyReleaseStages
@@ -58,7 +58,7 @@ namespace BugsnagUnity
 
         try
         {
-          NativeCode.GetNotifyReleaseStages(NativeConfiguration, GCHandle.ToIntPtr(handle), PopulateReleaseStages);
+          NativeCode.bugsnag_getNotifyReleaseStages(NativeConfiguration, GCHandle.ToIntPtr(handle), PopulateReleaseStages);
         }
         finally
         {
@@ -71,7 +71,7 @@ namespace BugsnagUnity
         }
         return releaseStages.ToArray();
       }
-      set => NativeCode.SetNotifyReleaseStages(NativeConfiguration, value, value.Length);
+      set => NativeCode.bugsnag_setNotifyReleaseStages(NativeConfiguration, value, value.Length);
     }
 
     [MonoPInvokeCallback(typeof(NativeCode.NotifyReleaseStageCallback))]
@@ -86,14 +86,14 @@ namespace BugsnagUnity
 
     public string AppVersion
     {
-      get => Marshal.PtrToStringAuto(NativeCode.GetAppVersion(NativeConfiguration));
-      set => NativeCode.SetAppVersion(NativeConfiguration, value);
+      get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getAppVersion(NativeConfiguration));
+      set => NativeCode.bugsnag_setAppVersion(NativeConfiguration, value);
     }
 
     public Uri Endpoint
     {
-      get => new Uri(Marshal.PtrToStringAuto(NativeCode.GetNotifyEndpoint(NativeConfiguration)));
-      set => NativeCode.SetNotifyEndpoint(NativeConfiguration, value.ToString());
+      get => new Uri(Marshal.PtrToStringAuto(NativeCode.bugsnag_getNotifyUrl(NativeConfiguration)));
+      set => NativeCode.bugsnag_setNotifyUrl(NativeConfiguration, value.ToString());
     }
     public string PayloadVersion { get; } = "4.0";
     public string SessionPayloadVersion { get; } = "1";
@@ -101,8 +101,8 @@ namespace BugsnagUnity
 
     public string Context
     {
-      get => Marshal.PtrToStringAuto(NativeCode.GetContext(NativeConfiguration));
-      set => NativeCode.SetContext(NativeConfiguration, value);
+      get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getContext(NativeConfiguration));
+      set => NativeCode.bugsnag_setContext(NativeConfiguration, value);
     }
 
     public LogType NotifyLevel { get; set; }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -21,7 +21,7 @@ namespace BugsnagUnity
       Configuration = configuration;
       NativeConfiguration = nativeConfiguration;
 
-      NativeCode.StartBugsnagWithConfiguration(NativeConfiguration);
+      NativeCode.bugsnag_startBugsnagWithConfiguration(NativeConfiguration);
 
       Delivery = new Delivery();
       Breadcrumbs = breadcrumbs;
@@ -37,7 +37,7 @@ namespace BugsnagUnity
 
       try
       {
-        NativeCode.RetrieveAppData(GCHandle.ToIntPtr(handle), PopulateAppData);
+        NativeCode.bugsnag_retrieveAppData(GCHandle.ToIntPtr(handle), PopulateAppData);
       }
       finally
       {
@@ -64,7 +64,7 @@ namespace BugsnagUnity
 
       try
       {
-        NativeCode.RetrieveDeviceData(GCHandle.ToIntPtr(handle), PopulateDeviceData);
+        NativeCode.bugsnag_retrieveDeviceData(GCHandle.ToIntPtr(handle), PopulateDeviceData);
       }
       finally
       {
@@ -103,7 +103,7 @@ namespace BugsnagUnity
     {
       var nativeUser = new NativeUser();
 
-      NativeCode.PopulateUser(ref nativeUser);
+      NativeCode.bugsnag_populateUser(ref nativeUser);
 
       user.Id = Marshal.PtrToStringAuto(nativeUser.Id);
     }
@@ -120,7 +120,7 @@ namespace BugsnagUnity
         index += 2;
       }
 
-      NativeCode.AddMetadata(NativeConfiguration, tab, metadata, metadata.Length);
+      NativeCode.bugsnag_setMetadata(NativeConfiguration, tab, metadata, metadata.Length);
     }
 
     public void PopulateMetadata(Metadata metadata)

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -11,68 +11,68 @@ namespace BugsnagUnity
 
   partial class NativeCode
   {
-    [DllImport(Import, EntryPoint = "bugsnag_startBugsnagWithConfiguration")]
-    internal static extern void StartBugsnagWithConfiguration(IntPtr configuration);
+    [DllImport(Import)]
+    internal static extern void bugsnag_startBugsnagWithConfiguration(IntPtr configuration);
 
-    [DllImport(Import, EntryPoint = "bugsnag_setMetadata")]
-    internal static extern void AddMetadata(IntPtr configuration, string tab, string[] metadata, int metadataCount);
+    [DllImport(Import)]
+    internal static extern void bugsnag_setMetadata(IntPtr configuration, string tab, string[] metadata, int metadataCount);
 
-    [DllImport(Import, EntryPoint = "bugsnag_retrieveAppData")]
-    internal static extern void RetrieveAppData(IntPtr instance, Action<IntPtr, string, string> populate);
+    [DllImport(Import)]
+    internal static extern void bugsnag_retrieveAppData(IntPtr instance, Action<IntPtr, string, string> populate);
 
-    [DllImport(Import, EntryPoint = "bugsnag_retrieveDeviceData")]
-    internal static extern void RetrieveDeviceData(IntPtr instance, Action<IntPtr, string, string> populate);
+    [DllImport(Import)]
+    internal static extern void bugsnag_retrieveDeviceData(IntPtr instance, Action<IntPtr, string, string> populate);
 
-    [DllImport(Import, EntryPoint = "bugsnag_populateUser")]
-    internal static extern void PopulateUser(ref NativeUser user);
+    [DllImport(Import)]
+    internal static extern void bugsnag_populateUser(ref NativeUser user);
 
-    [DllImport(Import, EntryPoint = "bugsnag_createConfiguration")]
-    internal static extern IntPtr CreateConfiguration(string apiKey);
+    [DllImport(Import)]
+    internal static extern IntPtr bugsnag_createConfiguration(string apiKey);
 
-    [DllImport(Import, EntryPoint = "bugsnag_getApiKey")]
-    internal static extern IntPtr GetApiKey(IntPtr configuration);
+    [DllImport(Import)]
+    internal static extern IntPtr bugsnag_getApiKey(IntPtr configuration);
 
-    [DllImport(Import, EntryPoint = "bugsnag_setReleaseStage")]
-    internal static extern void SetReleaseStage(IntPtr configuration, string releaseStage);
+    [DllImport(Import)]
+    internal static extern void bugsnag_setReleaseStage(IntPtr configuration, string releaseStage);
 
-    [DllImport(Import, EntryPoint = "bugsnag_getReleaseStage")]
-    internal static extern IntPtr GetReleaseStage(IntPtr configuration);
+    [DllImport(Import)]
+    internal static extern IntPtr bugsnag_getReleaseStage(IntPtr configuration);
 
-    [DllImport(Import, EntryPoint = "bugsnag_setContext")]
-    internal static extern void SetContext(IntPtr configuration, string context);
+    [DllImport(Import)]
+    internal static extern void bugsnag_setContext(IntPtr configuration, string context);
 
-    [DllImport(Import, EntryPoint = "bugsnag_getContext")]
-    internal static extern IntPtr GetContext(IntPtr configuration);
+    [DllImport(Import)]
+    internal static extern IntPtr bugsnag_getContext(IntPtr configuration);
 
-    [DllImport(Import, EntryPoint = "bugsnag_setAppVersion")]
-    internal static extern void SetAppVersion(IntPtr configuration, string appVersion);
+    [DllImport(Import)]
+    internal static extern void bugsnag_setAppVersion(IntPtr configuration, string appVersion);
 
-    [DllImport(Import, EntryPoint = "bugsnag_getAppVersion")]
-    internal static extern IntPtr GetAppVersion(IntPtr configuration);
+    [DllImport(Import)]
+    internal static extern IntPtr bugsnag_getAppVersion(IntPtr configuration);
 
-    [DllImport(Import, EntryPoint = "bugsnag_setNotifyUrl")]
-    internal static extern void SetNotifyEndpoint(IntPtr configuration, string endpoint);
+    [DllImport(Import)]
+    internal static extern void bugsnag_setNotifyUrl(IntPtr configuration, string endpoint);
 
-    [DllImport(Import, EntryPoint = "bugsnag_getNotifyUrl")]
-    internal static extern IntPtr GetNotifyEndpoint(IntPtr configuration);
+    [DllImport(Import)]
+    internal static extern IntPtr bugsnag_getNotifyUrl(IntPtr configuration);
 
     internal delegate void NotifyReleaseStageCallback(IntPtr instance, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]string[] releaseStages, long count);
 
-    [DllImport(Import, EntryPoint = "bugsnag_getNotifyReleaseStages")]
-    internal static extern void GetNotifyReleaseStages(IntPtr configuration, IntPtr instance, NotifyReleaseStageCallback callback);
+    [DllImport(Import)]
+    internal static extern void bugsnag_getNotifyReleaseStages(IntPtr configuration, IntPtr instance, NotifyReleaseStageCallback callback);
 
-    [DllImport(Import, EntryPoint = "bugsnag_setNotifyReleaseStages")]
-    internal static extern void SetNotifyReleaseStages(IntPtr configuration, string[] releaseStages, int count);
+    [DllImport(Import)]
+    internal static extern void bugsnag_setNotifyReleaseStages(IntPtr configuration, string[] releaseStages, int count);
 
-    [DllImport(Import, EntryPoint = "bugsnag_createBreadcrumbs")]
-    internal static extern IntPtr CreateBreadcrumbs(IntPtr configuration);
+    [DllImport(Import)]
+    internal static extern IntPtr bugsnag_createBreadcrumbs(IntPtr configuration);
 
-    [DllImport(Import, EntryPoint = "bugsnag_addBreadcrumb")]
-    internal static extern void NativeAddBreadcrumb(IntPtr breadcrumbs, string name, string type, string[] metadata, int metadataCount);
+    [DllImport(Import)]
+    internal static extern void bugsnag_addBreadcrumb(IntPtr breadcrumbs, string name, string type, string[] metadata, int metadataCount);
 
     internal delegate void BreadcrumbInformation(IntPtr instance, string name, string timestamp, string type, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)]string[] keys, long keysSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 7)]string[] values, long valuesSize);
 
-    [DllImport(Import, EntryPoint = "bugsnag_retrieveBreadcrumbs")]
-    internal static extern void NativeRetrieveBreadcrumbs(IntPtr breadcrumbs, IntPtr instance, BreadcrumbInformation visitor);
+    [DllImport(Import)]
+    internal static extern void bugsnag_retrieveBreadcrumbs(IntPtr breadcrumbs, IntPtr instance, BreadcrumbInformation visitor);
   }
 }


### PR DESCRIPTION
When using the mono backend and building for the ios simulator unity is
not able to export the correct function names.

This is the only thread I could find about this issue
https://forum.unity.com/threads/csharp-plugin-entrypoint-not-honored.324812/