### PR TITLE
Use consistent data type

### DIFF
--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -73,10 +73,15 @@ void bugsnag_setNotifyReleaseStages(const void *configuration, const char *relea
 
 void bugsnag_getNotifyReleaseStages(const void *configuration, const void *managedConfiguration, void (*callback)(const void *instance, const char *releaseStages[], int size)) {
   NSArray *releaseStages = ((__bridge BugsnagConfiguration *)configuration).notifyReleaseStages;
-  int count = [NSNumber numberWithUnsignedInteger: [releaseStages count]].intValue;
+  int count = 0;
+
+  if ([releaseStages count] <= INT_MAX) {
+    count = (int)[releaseStages count];
+  }
+
   const char **c_releaseStages = (const char **) malloc(sizeof(char *) * (count + 1));
 
-  for (NSUInteger i = 0; i < count; i++) {
+  for (int i = 0; i < count; i++) {
     c_releaseStages[i] = [[releaseStages objectAtIndex: i] UTF8String];
   }
 
@@ -179,11 +184,16 @@ void bugsnag_retrieveBreadcrumbs(const void *breadcrumbs, const void *managedBre
     NSArray *keys = [metadata allKeys];
     NSArray *values = [metadata allValues];
 
-    int count = [NSNumber numberWithUnsignedInteger: [keys count]].intValue;
+    int count = 0;
+
+    if ([keys count] <= INT_MAX) {
+      count = (int)[keys count];
+    }
+
     const char **c_keys = (const char **) malloc(sizeof(char *) * (count + 1));
     const char **c_values = (const char **) malloc(sizeof(char *) * (count + 1));
 
-    for (NSUInteger i = 0; i < count; i++) {
+    for (int i = 0; i < count; i++) {
       c_keys[i] = [[keys objectAtIndex: i] UTF8String];
       c_values[i] = [[values objectAtIndex: i] UTF8String];
     }

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -18,7 +18,7 @@ extern "C" {
   const char *bugsnag_getReleaseStage(const void *configuration);
 
   void bugsnag_setNotifyReleaseStages(const void *configuration, const char *releaseStages[], int releaseStagesCount);
-  void bugsnag_getNotifyReleaseStages(const void *configuration, const void *managedConfiguration, void (*callback)(const void *instance, const char *releaseStages[], NSUInteger size));
+  void bugsnag_getNotifyReleaseStages(const void *configuration, const void *managedConfiguration, void (*callback)(const void *instance, const char *releaseStages[], int size));
 
   void bugsnag_setAppVersion(const void *configuration, char *appVersion);
   const char *bugsnag_getAppVersion(const void *configuration);
@@ -35,7 +35,7 @@ extern "C" {
 
   void *bugsnag_createBreadcrumbs(const void *configuration);
   void bugsnag_addBreadcrumb(const void *breadcrumbs, char *name, char *type, char *metadata[], int metadataCount);
-  void bugsnag_retrieveBreadcrumbs(const void *breadcrumbs, const void *managedBreadcrumbs, void (*breadcrumb)(const void *instance, const char *name, const char *timestamp, const char *type, const char *keys[], NSUInteger keys_size, const char *values[], NSUInteger values_size));
+  void bugsnag_retrieveBreadcrumbs(const void *breadcrumbs, const void *managedBreadcrumbs, void (*breadcrumb)(const void *instance, const char *name, const char *timestamp, const char *type, const char *keys[], int keys_size, const char *values[], int values_size));
 
   void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *instance, const char *key, const char *value));
   void bugsnag_retrieveDeviceData(const void *deviceData, void (*callback)(const void *instance, const char *key, const char *value));
@@ -71,9 +71,9 @@ void bugsnag_setNotifyReleaseStages(const void *configuration, const char *relea
   ((__bridge BugsnagConfiguration *)configuration).notifyReleaseStages = ns_releaseStages;
 }
 
-void bugsnag_getNotifyReleaseStages(const void *configuration, const void *managedConfiguration, void (*callback)(const void *instance, const char *releaseStages[], NSUInteger size)) {
+void bugsnag_getNotifyReleaseStages(const void *configuration, const void *managedConfiguration, void (*callback)(const void *instance, const char *releaseStages[], int size)) {
   NSArray *releaseStages = ((__bridge BugsnagConfiguration *)configuration).notifyReleaseStages;
-  NSUInteger count = [releaseStages count];
+  int count = [NSNumber numberWithUnsignedInteger: [releaseStages count]].intValue;
   const char **c_releaseStages = (const char **) malloc(sizeof(char *) * (count + 1));
 
   for (NSUInteger i = 0; i < count; i++) {
@@ -167,7 +167,7 @@ void bugsnag_addBreadcrumb(const void *breadcrumbs, char *name, char *type, char
   }];
 }
 
-void bugsnag_retrieveBreadcrumbs(const void *breadcrumbs, const void *managedBreadcrumbs, void (*breadcrumb)(const void *instance, const char *name, const char *timestamp, const char *type, const char *keys[], NSUInteger keys_size, const char *values[], NSUInteger values_size)) {
+void bugsnag_retrieveBreadcrumbs(const void *breadcrumbs, const void *managedBreadcrumbs, void (*breadcrumb)(const void *instance, const char *name, const char *timestamp, const char *type, const char *keys[], int keys_size, const char *values[], int values_size)) {
   NSArray *crumbs = [((__bridge BugsnagBreadcrumbs *) breadcrumbs) arrayValue];
   [crumbs enumerateObjectsUsingBlock:^(id crumb, NSUInteger index, BOOL *stop){
     const char *name = [[crumb valueForKey: @"name"] UTF8String];
@@ -179,7 +179,7 @@ void bugsnag_retrieveBreadcrumbs(const void *breadcrumbs, const void *managedBre
     NSArray *keys = [metadata allKeys];
     NSArray *values = [metadata allValues];
 
-    NSUInteger count = [keys count];
+    int count = [NSNumber numberWithUnsignedInteger: [keys count]].intValue;
     const char **c_keys = (const char **) malloc(sizeof(char *) * (count + 1));
     const char **c_values = (const char **) malloc(sizeof(char *) * (count + 1));
 

--- a/src/BugsnagUnity/Native/Cocoa/Breadcrumbs.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Breadcrumbs.cs
@@ -83,7 +83,7 @@ namespace BugsnagUnity
     }
 
     [MonoPInvokeCallback(typeof(NativeCode.BreadcrumbInformation))]
-    static void PopulateBreadcrumb(IntPtr instance, string name, string timestamp, string type, string[] keys, long keysSize, string[] values, long valuesSize)
+    static void PopulateBreadcrumb(IntPtr instance, string name, string timestamp, string type, string[] keys, int keysSize, string[] values, int valuesSize)
     {
       var handle = GCHandle.FromIntPtr(instance);
       if (handle.Target is List<Breadcrumb> breadcrumbs)

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -70,7 +70,7 @@ namespace BugsnagUnity
     [DllImport(Import)]
     internal static extern void bugsnag_addBreadcrumb(IntPtr breadcrumbs, string name, string type, string[] metadata, int metadataCount);
 
-    internal delegate void BreadcrumbInformation(IntPtr instance, string name, string timestamp, string type, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)]string[] keys, long keysSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 7)]string[] values, long valuesSize);
+    internal delegate void BreadcrumbInformation(IntPtr instance, string name, string timestamp, string type, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)]string[] keys, int keysSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 7)]string[] values, int valuesSize);
 
     [DllImport(Import)]
     internal static extern void bugsnag_retrieveBreadcrumbs(IntPtr breadcrumbs, IntPtr instance, BreadcrumbInformation visitor);


### PR DESCRIPTION
On iOS we need to run on both 32bit and 64 bit architectures, NSUInteger
differs depending on the architecture the device is running which causes issues when
interoping with the c# code.