### PR TITLE
Fix session data

### DIFF
--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -208,7 +208,8 @@ void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *i
   callback(appData, "bundleVersion", [sysInfo[@BSG_KSSystemField_BundleVersion] UTF8String]);
   callback(appData, "id", [sysInfo[@BSG_KSSystemField_BundleID] UTF8String]);
   callback(appData, "type", [sysInfo[@BSG_KSSystemField_SystemName] UTF8String]);
-  callback(appData, "version", [sysInfo[@BSG_KSSystemField_BundleShortVersion] UTF8String]);
+  NSString *version = [Bugsnag configuration].appVersion ?: sysInfo[@BSG_KSSystemField_BundleShortVersion];
+  callback(appData, "version", [version UTF8String]);
 }
 
 void bugsnag_retrieveDeviceData(const void *deviceData, void (*callback)(const void *instance, const char *key, const char *value)) {

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -29,7 +29,7 @@ namespace BugsnagUnity
 
     object MiddlewareLock { get; } = new object();
 
-    INativeClient NativeClient { get; }
+    internal INativeClient NativeClient { get; }
 
     Stopwatch Stopwatch { get; }
 

--- a/src/BugsnagUnity/Payload/SessionReport.cs
+++ b/src/BugsnagUnity/Payload/SessionReport.cs
@@ -11,7 +11,7 @@ namespace BugsnagUnity.Payload
 
     public KeyValuePair<string, string>[] Headers { get; }
 
-    public SessionReport(IConfiguration configuration, User user, Payload.Session session)
+    public SessionReport(IConfiguration configuration, App app, Device device, User user, Payload.Session session)
     {
       Configuration = configuration;
       Headers = new KeyValuePair<string, string>[] {
@@ -19,8 +19,8 @@ namespace BugsnagUnity.Payload
         new KeyValuePair<string, string>("Bugsnag-Payload-Version", Configuration.SessionPayloadVersion),
       };
       this.AddToPayload("notifier", NotifierInfo.Instance);
-      this.AddToPayload("app", new App(configuration));
-      this.AddToPayload("device", new Device());
+      this.AddToPayload("app", app);
+      this.AddToPayload("device", device);
       this.AddToPayload("sessions", new Session[] { new Session(user, session) });
     }
 

--- a/src/BugsnagUnity/SessionTracker.cs
+++ b/src/BugsnagUnity/SessionTracker.cs
@@ -13,9 +13,9 @@ namespace BugsnagUnity
 
   class SessionTracker : ISessionTracker
   {
-    private IClient Client { get; }
+    Client Client { get; }
 
-    private Session _currentSession;
+    Session _currentSession;
 
     public Session CurrentSession
     {
@@ -23,7 +23,7 @@ namespace BugsnagUnity
       private set => _currentSession = value;
     }
 
-    internal SessionTracker(IClient client)
+    internal SessionTracker(Client client)
     {
       Client = client;
     }
@@ -34,7 +34,12 @@ namespace BugsnagUnity
 
       CurrentSession = session;
 
-      var payload = new SessionReport(Client.Configuration, Client.User, session);
+      var app = new App(Client.Configuration);
+      Client.NativeClient.PopulateApp(app);
+      var device = new Device();
+      Client.NativeClient.PopulateDevice(device);
+
+      var payload = new SessionReport(Client.Configuration, app, device, Client.User, session);
 
       Client.Send(payload);
     }


### PR DESCRIPTION
We had an issue where the sessions payload didn't include the same information as the error payload in regards to the application and device data. When the application data differed it caused issues with displaying sessions in the releases tab.

To solve this we now populate the app and device sections of the payload using the same values sourced from the native notifier as we do when we send an error payload. Additionally the value for version when using the cocoa native notifier did not apply the correct logic to determine the value to appear. This meant that the appVersion set in the Bugsnag configuration wouldn't be used.