### PR TITLE
Validate package files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -224,8 +224,42 @@ namespace :plugin do
     end
   end
 
-  task export: %w[plugin:build:all] do
+  task :check_package do
+    expected_guids = []
+    package_guids = []
+
+    cd current_directory do
+      Dir.glob("unity/**/*.meta").each do |file|
+        File.open(file).each_line do |line|
+          if match = /guid: ([a-z0-9]+)/.match(line)
+            expected_guids << match[1]
+            break
+          end
+        end
+      end
+
+      Open3.popen2("tar", "-tf", "Bugsnag.unitypackage", "*/asset.meta") do |stdin, stdout, wait_thr|
+        stdout.each_line do |line|
+          if match = /\.\/([a-z0-9]+)\/asset.meta/.match(line)
+            package_guids << match[1]
+          end
+        end
+      end
+    end
+
+    unless expected_guids.sort == package_guids.sort
+      raise "package contains unknown files"
+    end
+  end
+
+  task :export_package do
     export_package
+  end
+
+  task export: %w[plugin:build:all export_package check_package]
+
+  task :check do
+    check_package
   end
 
   task maze_runner: %w[plugin:export] do

--- a/Rakefile
+++ b/Rakefile
@@ -260,10 +260,6 @@ namespace :plugin do
 
   task export: %w[plugin:build:all export_package check_package]
 
-  task :check do
-    check_package
-  end
-
   task maze_runner: %w[plugin:export] do
     sh "bundle", "exec", "bugsnag-maze-runner"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -229,11 +229,13 @@ namespace :plugin do
     package_guids = []
 
     cd current_directory do
-      Dir.glob("unity/**/*.meta").each do |file|
-        File.open(file).each_line do |line|
-          if match = /guid: ([a-z0-9]+)/.match(line)
-            expected_guids << match[1]
-            break
+      Open3.popen2("git", "ls-files", "--", "unity/**/*.meta") do |stdin, stdout, wait_thr|
+        stdout.each_line do |file|
+          File.open(file.gsub("\n", "")).each_line do |line|
+            if match = /guid: ([a-z0-9]+)/.match(line)
+              expected_guids << match[1]
+              break
+            end
           end
         end
       end


### PR DESCRIPTION
We have previously released unity packages that contain additional or unexpected files. This adds a check after exporting the package that it only contains the files that we expect by checking all of the `meta` files that we have in source control and all of the guids for the files in the package and checking for any discrepancies
