### PR TITLE
Normalize stacktraces across platforms

### DIFF
--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -52,6 +52,12 @@ public class Main : MonoBehaviour {
       case "LogUnthrown":
         DoLogUnthrown();
         break;
+      case "UncaughtException":
+        DoUnhandledException(0);
+        break;
+      case "AssertionFailure":
+        MakeAssertionFailure(4);
+        break;
     }
   }
 
@@ -61,6 +67,17 @@ public class Main : MonoBehaviour {
 
   void DoLogUnthrown() {
     Debug.LogException(new System.Exception("auth failed!"));
+  }
+
+  void DoUnhandledException(long counter) {
+    var items = new int[]{1, 2, 3};
+    Debug.Log("Item #1 is: " + items[counter]);
+    throw new ExecutionEngineException("Promise Rejection");
+  }
+
+  void MakeAssertionFailure(int counter) {
+    var items = new int[]{1, 2, 3};
+    Debug.Log("Item4 is: " + items[counter]);
   }
 }
 

--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -47,8 +47,20 @@ public class Main : MonoBehaviour {
     var scenario = Environment.GetEnvironmentVariable("BUGSNAG_SCENARIO");
     switch (scenario) {
       case "Notify":
-        Bugsnag.Notify(new System.Exception("blorb"));
+        DoNotify();
+        break;
+      case "LogUnthrown":
+        DoLogUnthrown();
         break;
     }
   }
+
+  void DoNotify() {
+    Bugsnag.Notify(new System.Exception("blorb"));
+  }
+
+  void DoLogUnthrown() {
+    Debug.LogException(new System.Exception("auth failed!"));
+  }
 }
+

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -1,9 +1,5 @@
 Feature: Handled Errors and Exceptions
 
-    Background:
-        Given I set environment variable "BUGSNAG_APIKEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
-        And I build a Unity application
-
     Scenario: Reporting a handled exception
         When I run the game in the "Notify" state
         Then I should receive a request
@@ -11,5 +7,24 @@ Feature: Handled Errors and Exceptions
         And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
         And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
         And the payload field "events" is an array with 1 element
-        And the exception "errorClass" equals "System.Exception"
+        And the exception "errorClass" equals "Exception"
         And the exception "message" equals "blorb"
+        And the first significant stack frame methods and files should match:
+            | Main.DoNotify()      |
+            | Main.LoadScenario()  |
+            | Main.Update()        |
+
+    Scenario: Logging an unthrown exception
+        When I run the game in the "LogUnthrown" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "Exception"
+        And the exception "message" equals "auth failed!"
+        And the first significant stack frame methods and files should match:
+            | Main:DoLogUnthrown() |
+            | Main:LoadScenario()  |
+            | Main:Update()        |
+

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -1,9 +1,3 @@
-When("I build a Unity application") do
-  run_required_commands([
-    ["features/scripts/create_unity_project.sh"]
-  ])
-end
-
 When("I run the application") do
   steps %Q{
     When I set environment variable "MAZE_ENDPOINT" to "http://localhost:#{MOCK_API_PORT}"
@@ -18,4 +12,17 @@ When("I run the game in the {string} state") do |state|
     When I set environment variable "BUGSNAG_SCENARIO" to "#{state}"
     When I run the application
   }
+end
+Then("the first significant stack frame methods and files should match:") do |expected_values|
+  stacktrace = read_key_path(find_request(0)[:body], "events.0.exceptions.0.stacktrace")
+  expected_frame_values = expected_values.raw
+  expected_index = 0
+  stacktrace.each_with_index do |item, index|
+    next if expected_index >= expected_frame_values.length
+    expected_frame = expected_frame_values[expected_index]
+    next if item["method"].start_with? "UnityEngine"
+
+    assert_equal(expected_frame[0], item["method"])
+    expected_index += 1
+  end
 end

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -1,16 +1,9 @@
-When("I run the application") do
-  steps %Q{
-    When I set environment variable "MAZE_ENDPOINT" to "http://localhost:#{MOCK_API_PORT}"
-  }
-  run_required_commands([
-    ["features/scripts/launch_unity_application.sh"]
-  ])
-end
-
 When("I run the game in the {string} state") do |state|
   steps %Q{
     When I set environment variable "BUGSNAG_SCENARIO" to "#{state}"
-    When I run the application
+    When I set environment variable "MAZE_ENDPOINT" to "http://localhost:#{MOCK_API_PORT}"
+    And I run the script "features/scripts/launch_unity_application.sh"
+    And I wait for 8 seconds
   }
 end
 Then("the first significant stack frame methods and files should match:") do |expected_values|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -18,6 +18,7 @@ After do
 end
 
 at_exit do
+  sh "pkill", "Mazerunner"
   FileUtils.rm_rf('features/fixtures/Mazerunner.app')
   FileUtils.rm_rf('features/fixtures/unity_project')
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,6 +3,11 @@
 # Any helper functions added here will be available in step
 # definitions
 
+ENV['BUGSNAG_APIKEY'] = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
+run_required_commands([
+  ["features/scripts/create_unity_project.sh"]
+])
+
 # Scenario hooks
 Before do
 # Runs before every Scenario

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -1,32 +1,32 @@
-Feature: Handled Errors and Exceptions
+Feature: Reporting unhandled events
 
-    Scenario: Reporting a handled exception
-        When I run the game in the "Notify" state
+    Scenario: Reporting an uncaught exception
+        When I run the game in the "UncaughtException" state
         Then I should receive a request
         And the request is a valid for the error reporting API
         And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
         And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
         And the payload field "events" is an array with 1 element
-        And the exception "errorClass" equals "Exception"
-        And the exception "message" equals "blorb"
+        And the exception "errorClass" equals "ExecutionEngineException"
+        And the exception "message" equals "Promise Rejection"
         And the event "unhandled" is false
         And the first significant stack frame methods and files should match:
-            | Main.DoNotify()      |
-            | Main.LoadScenario()  |
-            | Main.Update()        |
+            | Main.DoUnhandledException(Int64 counter) |
+            | Main.LoadScenario()         |
+            | Main.Update()               |
 
-    Scenario: Logging an unthrown exception
-        When I run the game in the "LogUnthrown" state
+    Scenario: Reporting an assertion failure
+        When I run the game in the "AssertionFailure" state
         Then I should receive a request
         And the request is a valid for the error reporting API
         And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
         And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
         And the payload field "events" is an array with 1 element
-        And the exception "errorClass" equals "Exception"
-        And the exception "message" equals "auth failed!"
+        And the exception "errorClass" equals "IndexOutOfRangeException"
+        And the exception "message" equals "Array index is out of range."
         And the event "unhandled" is false
         And the first significant stack frame methods and files should match:
-            | Main:DoLogUnthrown() |
-            | Main:LoadScenario()  |
-            | Main:Update()        |
+            | Main.MakeAssertionFailure(Int32 counter) |
+            | Main.LoadScenario()                      |
+            | Main.Update()                            |
 

--- a/src/BugsnagUnity/Payload/Exception.cs
+++ b/src/BugsnagUnity/Payload/Exception.cs
@@ -121,7 +121,7 @@ namespace BugsnagUnity.Payload
     {
       var match = Regex.Match(logMessage.Condition, @"^(?<errorClass>\S+):\s*(?<message>.*)", RegexOptions.Singleline);
 
-      var lines = new StackTrace(stackFrames).ToArray();
+      var lines = new StackTrace(logMessage.StackTrace).ToArray();
 
       if (match.Success)
       {

--- a/src/BugsnagUnity/Payload/Exception.cs
+++ b/src/BugsnagUnity/Payload/Exception.cs
@@ -100,7 +100,7 @@ namespace BugsnagUnity.Payload
 
     internal static Exception FromSystemException(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace)
     {
-      var errorClass = TypeNameHelper.GetTypeDisplayName(exception.GetType());
+      var errorClass = exception.GetType().Name;
       var stackFrames = new System.Diagnostics.StackTrace(exception, true).GetFrames();
 
       StackTraceLine[] lines = null;

--- a/src/BugsnagUnity/Payload/StackTraceLine.cs
+++ b/src/BugsnagUnity/Payload/StackTraceLine.cs
@@ -52,7 +52,7 @@ namespace BugsnagUnity.Payload
   /// </summary>
   public class StackTraceLine : Dictionary<string, object>
   {
-    private static Regex StackTraceLineRegex { get; } = new Regex(@"(?<method>[^()]+\(.*?\))\s(?:(?:\[.*\]\s*in\s|\(at\s*\s*)(?<file>.*):(?<linenumber>\d+))?");
+    private static Regex StackTraceLineRegex { get; } = new Regex(@"(?<method>[^()]+)(?<methodargs>\([^()]*?\))(?:\s(?:\[.*\]\s*in\s|\(at\s*\s*)(?<file>.*):(?<linenumber>\d+))?");
 
     public static StackTraceLine FromLogMessage(string message) {
       Match match = StackTraceLineRegex.Match(message);
@@ -64,9 +64,10 @@ namespace BugsnagUnity.Payload
         {
           lineNumber = parsedValue;
         }
+        string method = string.Join("", new string[]{match.Groups["method"].Value.Trim(),
+                                                     match.Groups["methodargs"].Value});
         return new StackTraceLine(match.Groups["file"].Value,
-                                  lineNumber,
-                                  match.Groups["method"].Value);
+                                  lineNumber, method);
       }
       return new StackTraceLine("", null, message);
     }

--- a/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
+++ b/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
@@ -35,7 +35,7 @@ namespace BugsnagUnity.Payload.Tests
       var stackframe = Payload.StackTraceLine.FromLogMessage(
         "ReporterBehavior.AssertionFailure () (at /Users/gameserver/parky/Assets/ReporterBehavior.cs:46)"
       );
-      Assert.AreEqual("ReporterBehavior.AssertionFailure ()", stackframe.Method);
+      Assert.AreEqual("ReporterBehavior.AssertionFailure()", stackframe.Method);
       Assert.AreEqual(46, stackframe.LineNumber);
       Assert.AreEqual("/Users/gameserver/parky/Assets/ReporterBehavior.cs", stackframe.File);
     }
@@ -46,7 +46,7 @@ namespace BugsnagUnity.Payload.Tests
       var stackframe = Payload.StackTraceLine.FromLogMessage(
         "ReporterBehavior.AssertionFailure () (at /Users/game server/parky/Assets/ReporterBehavior.cs:46)"
       );
-      Assert.AreEqual("ReporterBehavior.AssertionFailure ()", stackframe.Method);
+      Assert.AreEqual("ReporterBehavior.AssertionFailure()", stackframe.Method);
       Assert.AreEqual(46, stackframe.LineNumber);
       Assert.AreEqual("/Users/game server/parky/Assets/ReporterBehavior.cs", stackframe.File);
     }
@@ -57,7 +57,7 @@ namespace BugsnagUnity.Payload.Tests
       var stackframe = Payload.StackTraceLine.FromLogMessage(
         "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) (at /Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/UI/Core/Button.cs:45)"
       );
-      Assert.AreEqual("UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)", stackframe.Method);
+      Assert.AreEqual("UnityEngine.UI.Button.OnPointerClick(UnityEngine.EventSystems.PointerEventData eventData)", stackframe.Method);
       Assert.AreEqual(45, stackframe.LineNumber);
       Assert.AreEqual("/Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/UI/Core/Button.cs", stackframe.File);
     }
@@ -68,7 +68,7 @@ namespace BugsnagUnity.Payload.Tests
       var stackframe = Payload.StackTraceLine.FromLogMessage(
         "UnityEngine.EventSystems.ExecuteEvents.Execute (IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) (at /Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs:50)"
       );
-      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents.Execute (IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)", stackframe.Method);
+      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents.Execute(IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)", stackframe.Method);
       Assert.AreEqual(50, stackframe.LineNumber);
       Assert.AreEqual("/Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs", stackframe.File);
     }
@@ -79,7 +79,7 @@ namespace BugsnagUnity.Payload.Tests
       var stackframe = Payload.StackTraceLine.FromLogMessage(
         "UnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor) (at /Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs:261)"
       );
-      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor)", stackframe.Method);
+      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler](UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor)", stackframe.Method);
       Assert.AreEqual(261, stackframe.LineNumber);
       Assert.AreEqual("/Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs", stackframe.File);
     }
@@ -90,7 +90,7 @@ namespace BugsnagUnity.Payload.Tests
       var stackframe = Payload.StackTraceLine.FromLogMessage(
         "UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1].Invoke (.T1 handler, UnityEngine.EventSystems.BaseEventData eventData)"
       );
-      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1].Invoke (.T1 handler, UnityEngine.EventSystems.BaseEventData eventData)", stackframe.Method);
+      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1].Invoke(.T1 handler, UnityEngine.EventSystems.BaseEventData eventData)", stackframe.Method);
       Assert.AreEqual(null, stackframe.LineNumber);
       Assert.AreEqual(null, stackframe.File);
     }

--- a/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
+++ b/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
@@ -1,0 +1,98 @@
+using NUnit.Framework;
+using System.Threading;
+using UnityEngine;
+
+namespace BugsnagUnity.Payload.Tests
+{
+  [TestFixture]
+  class StackFrameParsingTests
+  {
+    [Test]
+    public void ParseMethodNameWithColon()
+    {
+      var stackframe = Payload.StackTraceLine.FromLogMessage(
+        "ReporterBehavior:LogCaughtException() (at /Users/gameserver/parky/Assets/ReporterBehavior.cs:58)"
+      );
+      Assert.AreEqual("ReporterBehavior:LogCaughtException()", stackframe.Method);
+      Assert.AreEqual(58, stackframe.LineNumber);
+      Assert.AreEqual("/Users/gameserver/parky/Assets/ReporterBehavior.cs", stackframe.File);
+    }
+
+    [Test]
+    public void ParseMethodNameWithColonWithoutFileInfo()
+    {
+      var stackframe = Payload.StackTraceLine.FromLogMessage(
+        "UnityEngine.EventSystems.EventSystem:Update()"
+      );
+      Assert.AreEqual("UnityEngine.EventSystems.EventSystem:Update()", stackframe.Method);
+      Assert.AreEqual(null, stackframe.LineNumber);
+      Assert.AreEqual(null, stackframe.File);
+    }
+
+    [Test]
+    public void ParseMethodNameWithSpace()
+    {
+      var stackframe = Payload.StackTraceLine.FromLogMessage(
+        "ReporterBehavior.AssertionFailure () (at /Users/gameserver/parky/Assets/ReporterBehavior.cs:46)"
+      );
+      Assert.AreEqual("ReporterBehavior.AssertionFailure ()", stackframe.Method);
+      Assert.AreEqual(46, stackframe.LineNumber);
+      Assert.AreEqual("/Users/gameserver/parky/Assets/ReporterBehavior.cs", stackframe.File);
+    }
+
+    [Test]
+    public void ParseFilePathWithSpace()
+    {
+      var stackframe = Payload.StackTraceLine.FromLogMessage(
+        "ReporterBehavior.AssertionFailure () (at /Users/game server/parky/Assets/ReporterBehavior.cs:46)"
+      );
+      Assert.AreEqual("ReporterBehavior.AssertionFailure ()", stackframe.Method);
+      Assert.AreEqual(46, stackframe.LineNumber);
+      Assert.AreEqual("/Users/game server/parky/Assets/ReporterBehavior.cs", stackframe.File);
+    }
+
+    [Test]
+    public void ParseMethodArgument()
+    {
+      var stackframe = Payload.StackTraceLine.FromLogMessage(
+        "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) (at /Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/UI/Core/Button.cs:45)"
+      );
+      Assert.AreEqual("UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)", stackframe.Method);
+      Assert.AreEqual(45, stackframe.LineNumber);
+      Assert.AreEqual("/Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/UI/Core/Button.cs", stackframe.File);
+    }
+
+    [Test]
+    public void ParseMultipleMethodArguments()
+    {
+      var stackframe = Payload.StackTraceLine.FromLogMessage(
+        "UnityEngine.EventSystems.ExecuteEvents.Execute (IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) (at /Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs:50)"
+      );
+      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents.Execute (IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)", stackframe.Method);
+      Assert.AreEqual(50, stackframe.LineNumber);
+      Assert.AreEqual("/Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs", stackframe.File);
+    }
+
+    [Test]
+    public void ParseInterfaceMethod()
+    {
+      var stackframe = Payload.StackTraceLine.FromLogMessage(
+        "UnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor) (at /Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs:261)"
+      );
+      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor)", stackframe.Method);
+      Assert.AreEqual(261, stackframe.LineNumber);
+      Assert.AreEqual("/Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEngine.UI/EventSystem/ExecuteEvents.cs", stackframe.File);
+    }
+
+    [Test]
+    public void ParseGenericMethod()
+    {
+      var stackframe = Payload.StackTraceLine.FromLogMessage(
+        "UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1].Invoke (.T1 handler, UnityEngine.EventSystems.BaseEventData eventData)"
+      );
+      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1].Invoke (.T1 handler, UnityEngine.EventSystems.BaseEventData eventData)", stackframe.Method);
+      Assert.AreEqual(null, stackframe.LineNumber);
+      Assert.AreEqual(null, stackframe.File);
+    }
+  }
+}


### PR DESCRIPTION
## Goal

Refactor stacktrace parsing to ensure exceptions are grouped across platforms.

## Changeset

* Removed stack generation for log messages in favor of the stacktrace provided to the log callback
* Added new parsing logic for the stacktrace format

## Tests

* Added new unit and end-to-end tests for stacktrace normalization
* Tested against Unity 2017, 2018, and 5.6
* Tested against Mac 10.12, iOS 11/12, Android 28, Windows 7/10

## Review

The points which need review are:

1. Verification that it works on old and new Android devices
2. Verification that reports from Android group with reports from Mac/Windows

CI is failing due to license server flakiness; working on improvements in a separate changeset.