### PR TITLE
Normalize Bugsnag interface with other platforms

### DIFF
--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -1,0 +1,47 @@
+Feature: Leaving breadcrumbs to attach to reports
+
+    Background:
+        Given I set environment variable "BUGSNAG_APIKEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And I build a Unity application
+
+    Scenario: Attaching a message breadcrumb directly
+        When I run the game in the "MessageBreadcrumbNotify" state
+        Then I should receive a request
+        And the request is valid for the error reporting API
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "System.Exception"
+        And the exception "message" equals "Collective failure"
+        And the event has a "manual" breadcrumb named "Initialize bumpers"
+
+    Scenario: Attaching a low-level log message as a breadcrumb
+        When I run the game in the "DebugLogBreadcrumbNotify" state
+        Then I should receive a request
+        And the request is valid for the error reporting API
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "System.ExecutionEngineException"
+        And the exception "message" equals "Invalid runtime"
+        And the event has a "log" breadcrumb named "Warning"
+        And the payload field "events.0.breadcrumbs.1.metaData.message" equals "Failed to validate credentials"
+
+    Scenario: Attaching a complex breadcrumb to a report
+        When I run the game in the "ComplexBreadcrumbNotify" state
+        Then I should receive a request
+        And the request is valid for the error reporting API
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "System.Exception"
+        And the exception "message" equals "Collective failure"
+        And the event has a "navigation" breadcrumb named "Reload"
+        And the payload field "events.0.breadcrumbs.1.metaData.preload" equals "launch"
+
+    Scenario: Attaching an error report breadcrumb
+        When I run the game in the "DoubleNotify" state
+        Then I should receive 2 requests
+        And request 0 is valid for the error reporting API
+        And request 1 is valid for the error reporting API
+        And the payload field "events.0.exceptions.0.errorClass" equals "System.Exception" for request 0
+        And the payload field "events.0.exceptions.0.message" equals "Rollback failed" for request 0
+        And the payload field "events.0.exceptions.0.errorClass" equals "System.ExecutionEngineException" for request 1
+        And the payload field "events.0.exceptions.0.message" equals "Invalid runtime" for request 1
+        And the payload field "events.0.breadcrumbs.1.type" equals "error" for request 1
+        And the payload field "events.0.breadcrumbs.1.name" equals "System.Exception" for request 1
+        And the payload field "events.0.breadcrumbs.1.metaData.message" equals "Rollback failed" for request 1

--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using BugsnagUnity;
+using BugsnagUnity.Payload;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -46,9 +47,43 @@ public class Main : MonoBehaviour {
   void LoadScenario() {
     var scenario = Environment.GetEnvironmentVariable("BUGSNAG_SCENARIO");
     switch (scenario) {
+      case "DebugLogBreadcrumbNotify":
+        LogLowLevelMessageAndNotify();
+        break;
+      case "ComplexBreadcrumbNotify":
+        LeaveComplexBreadcrumbAndNotify();
+        break;
+      case "DoubleNotify":
+        NotifyTwice();
+        break;
+      case "MessageBreadcrumbNotify":
+        LeaveMessageBreadcrumbAndNotify();
+        break;
       case "Notify":
         Bugsnag.Notify(new System.Exception("blorb"));
         break;
     }
+  }
+
+  void LeaveComplexBreadcrumbAndNotify() {
+    Bugsnag.LeaveBreadcrumb("Reload", BreadcrumbType.Navigation, new Dictionary<string, string>() {
+      { "preload", "launch" }
+    });
+    Bugsnag.Notify(new System.Exception("Collective failure"));
+  }
+
+  void NotifyTwice() {
+    Bugsnag.Notify(new System.Exception("Rollback failed"));
+    Bugsnag.Notify(new ExecutionEngineException("Invalid runtime"));
+  }
+
+  void LeaveMessageBreadcrumbAndNotify() {
+    Bugsnag.LeaveBreadcrumb("Initialize bumpers");
+    Bugsnag.Notify(new System.Exception("Collective failure"));
+  }
+
+  void LogLowLevelMessageAndNotify() {
+    Debug.LogWarning("Failed to validate credentials");
+    Bugsnag.Notify(new ExecutionEngineException("Invalid runtime"));
   }
 }

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using BugsnagUnity.Payload;
 
 namespace BugsnagUnity
@@ -18,7 +19,7 @@ namespace BugsnagUnity
 
       return Client;
     }
-    
+
     static Client InternalClient { get; set; }
 
     public static IClient Client => InternalClient;
@@ -44,6 +45,20 @@ namespace BugsnagUnity
     public static void Notify(System.Exception exception, Severity severity) => InternalClient.Notify(exception, severity, 3);
 
     public static void Notify(System.Exception exception, Severity severity, Middleware callback) => InternalClient.Notify(exception, severity, callback, 3);
+
+    public static void LeaveBreadcrumb(string message) => InternalClient.Breadcrumbs.Leave(message);
+
+    public static void LeaveBreadcrumb(string message, BreadcrumbType type, IDictionary<string, string> metadata) => InternalClient.Breadcrumbs.Leave(message, type, metadata);
+
+    public static void LeaveBreadcrumb(Breadcrumb breadcrumb) => InternalClient.Breadcrumbs.Leave(breadcrumb);
+
+    public static void SetUser(string id, string email, string name) {
+      User.Id = id;
+      User.Email = email;
+      User.Name = name;
+    }
+
+    public static void StartSession() => InternalClient.SessionTracking.StartSession();
 
     /// <summary>
     /// Used to signal to the Bugsnag client that the focused state of the

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -101,8 +101,7 @@ namespace BugsnagUnity
       else
       {
         Breadcrumbs.Leave(logType.ToString(), BreadcrumbType.Log, new Dictionary<string, string> {
-          { "condition", condition },
-          { "stackTrace", stackTrace },
+          { "message", condition },
         });
       }
     }

--- a/src/BugsnagUnity/Payload/Breadcrumb.cs
+++ b/src/BugsnagUnity/Payload/Breadcrumb.cs
@@ -16,12 +16,6 @@ namespace BugsnagUnity.Payload
     internal static Breadcrumb FromReport(Report report)
     {
       var name = "Error";
-
-      if (report.OriginalSeverity != null)
-      {
-        name = report.OriginalSeverity.Severity.ToString();
-      }
-
       var metadata = new Dictionary<string, string>
       {
         { "context", report.Context },
@@ -30,8 +24,7 @@ namespace BugsnagUnity.Payload
       if (report.Exceptions != null && report.Exceptions.Any())
       {
         var exception = report.Exceptions.First();
-
-        metadata.Add("class", exception.ErrorClass);
+        name = exception.ErrorClass;
         metadata.Add("message", exception.ErrorMessage);
       }
 


### PR DESCRIPTION
A few small changes to make the primary interface similar to other platforms. Added a few high level tests along the way.

## Added

* `Bugsnag.StartSession()`
* `Bugsnag.LeaveBreadcrumb()`
* `Bugsnag.SetUser()`

## Changed

* Log breadcrumb metadata includes the message contents under the `message` key instead of `condition`
* Error breadcrumb names are the error class instead of severity