### PR TITLE
Fix android java exception parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fix exception parsing for Android Java exceptions to ensure correct grouping,
+  "handled"-ness, and remove extraneous stack frame from the top of the
+  backtrace.
+
 ## 4.0.0 (2018-11-19)
 
 This is a new major release with many features and fixes. See the [upgrade

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -90,9 +90,10 @@ namespace BugsnagUnity
         {
           if (LogTypeCounter.ShouldSend(logMessage))
           {
-            var handledState = HandledState.ForUnityLogMessage(Configuration.LogTypeSeverityMapping.Map(logType));
-            var stackFrames = new System.Diagnostics.StackTrace(1, true).GetFrames();
-            Notify(new UnityLogExceptions(logMessage, stackFrames).ToArray(), handledState, null, logType);
+            var severity = Configuration.LogTypeSeverityMapping.Map(logType);
+            var backupStackFrames = new System.Diagnostics.StackTrace(1, true).GetFrames();
+            var exception = Exception.FromUnityLogMessage(logMessage, backupStackFrames, severity);
+            Notify(new Exception[]{exception}, exception.HandledState, null, logType);
           }
         }
       }

--- a/src/BugsnagUnity/Payload/Exception.cs
+++ b/src/BugsnagUnity/Payload/Exception.cs
@@ -85,6 +85,9 @@ namespace BugsnagUnity.Payload
   /// </summary>
   public class Exception : Dictionary<string, object>
   {
+    private static string AndroidJavaErrorClass = "AndroidJavaException";
+    private static string ErrorClassMessagePattern = @"^(?<errorClass>\S+):\s*(?<message>.*)";
+
     internal Exception(string errorClass, string message, StackTraceLine[] stackTrace)
     {
       this.AddToPayload("errorClass", errorClass);
@@ -92,7 +95,7 @@ namespace BugsnagUnity.Payload
       this.AddToPayload("stacktrace", stackTrace);
     }
 
-    internal IEnumerable<StackTraceLine> StackTrace { get { return this.Get("stacktrace") as IEnumerable<StackTraceLine>; } }
+    public IEnumerable<StackTraceLine> StackTrace { get { return this.Get("stacktrace") as IEnumerable<StackTraceLine>; } }
 
     public string ErrorClass => this.Get("errorClass") as string;
 
@@ -117,15 +120,28 @@ namespace BugsnagUnity.Payload
       return new Exception(errorClass, exception.Message, lines);
     }
 
-    internal static Exception FromUnityLogMessage(UnityLogMessage logMessage, System.Diagnostics.StackFrame[] stackFrames)
+    public static Exception FromUnityLogMessage(UnityLogMessage logMessage, System.Diagnostics.StackFrame[] stackFrames)
     {
-      var match = Regex.Match(logMessage.Condition, @"^(?<errorClass>\S+):\s*(?<message>.*)", RegexOptions.Singleline);
+      var match = Regex.Match(logMessage.Condition, ErrorClassMessagePattern, RegexOptions.Singleline);
 
       var lines = new StackTrace(logMessage.StackTrace).ToArray();
 
       if (match.Success)
       {
-        return new Exception(match.Groups["errorClass"].Value, match.Groups["message"].Value.Trim(), lines);
+        var errorClass = match.Groups["errorClass"].Value;
+        var message = match.Groups["message"].Value.Trim();
+        if (errorClass == AndroidJavaErrorClass)
+        {
+          match = Regex.Match(message, ErrorClassMessagePattern, RegexOptions.Singleline);
+
+          if (match.Success)
+          {
+            errorClass = match.Groups["errorClass"].Value;
+            message = match.Groups["message"].Value.Trim();
+            lines = new StackTrace(logMessage.StackTrace, StackTraceFormat.AndroidJava).ToArray();
+          }
+        }
+        return new Exception(errorClass, message, lines);
       }
       else
       {

--- a/src/BugsnagUnity/Payload/StackTraceLine.cs
+++ b/src/BugsnagUnity/Payload/StackTraceLine.cs
@@ -71,7 +71,7 @@ namespace BugsnagUnity.Payload
   public class StackTraceLine : Dictionary<string, object>
   {
     private static Regex StackTraceLineRegex { get; } = new Regex(@"(?<method>[^()]+)(?<methodargs>\([^()]*?\))(?:\s(?:\[.*\]\s*in\s|\(at\s*\s*)(?<file>.*):(?<linenumber>\d+))?");
-    private static Regex StackTraceAndroidJavaLineRegex { get; } = new Regex(@"(?<method>[^()]+)\((?<file>[^:]*)?(?::(?<linenumber>\d+))?\)");
+    private static Regex StackTraceAndroidJavaLineRegex { get; } = new Regex(@"^\s*(?<method>[a-z][^()]+)\((?<file>[^:]*)?(?::(?<linenumber>\d+))?\)");
 
     public static StackTraceLine FromLogMessage(string message) {
       Match match = StackTraceLineRegex.Match(message);
@@ -106,7 +106,8 @@ namespace BugsnagUnity.Payload
         return new StackTraceLine(match.Groups["file"].Value,
                                   lineNumber, method);
       }
-      return new StackTraceLine("", null, message);
+      // Likely a C# line in the Android stacktrace
+      return FromLogMessage(message);
     }
 
     internal static StackTraceLine FromStackFrame(StackFrame stackFrame)

--- a/tests/BugsnagUnity.Tests/ExceptionTests.cs
+++ b/tests/BugsnagUnity.Tests/ExceptionTests.cs
@@ -1,0 +1,97 @@
+using NUnit.Framework;
+using System.Linq;
+using System.Threading;
+using UnityEngine;
+
+namespace BugsnagUnity.Payload.Tests
+{
+  [TestFixture]
+  class ExceptionTests
+  {
+    [Test]
+    public void ParseExceptionFromLogMessage()
+    {
+      string condition = "IndexOutOfRangeException: Array index is out of range.";
+      string stacktrace = @"ReporterBehavior.AssertionFailure () [0x00000] in <filename unknown>:0
+   UnityEngine.Events.InvokableCall.Invoke () [0x00000] in <filename unknown>:0
+   UnityEngine.Events.UnityEvent.Invoke () [0x00000] in <filename unknown>:0
+   UnityEngine.UI.Button.Press () [0x00000] in <filename unknown>:0
+   UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) [0x00000] in <filename unknown>:0
+   UnityEngine.EventSystems.ExecuteEvents.Execute (IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) [0x00000] in <filename unknown>:0
+   UnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor) [0x00000] in <filename unknown>:0";
+      var logType = UnityEngine.LogType.Error;
+      var log = new UnityLogMessage(condition, stacktrace, logType);
+
+      var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {});
+      var stack = exception.StackTrace.ToList();
+      Assert.AreEqual(7, stack.Count);
+      Assert.AreEqual("IndexOutOfRangeException", exception.ErrorClass);
+      Assert.AreEqual("Array index is out of range.", exception.ErrorMessage);
+      Assert.AreEqual("ReporterBehavior.AssertionFailure()", stack[0].Method);
+      Assert.AreEqual("<filename unknown>", stack[0].File);
+      Assert.AreEqual(0, stack[0].LineNumber);
+      Assert.AreEqual("UnityEngine.Events.InvokableCall.Invoke()", stack[1].Method);
+      Assert.AreEqual("<filename unknown>", stack[1].File);
+      Assert.AreEqual(0, stack[1].LineNumber);
+      Assert.AreEqual("UnityEngine.Events.UnityEvent.Invoke()", stack[2].Method);
+      Assert.AreEqual("<filename unknown>", stack[2].File);
+      Assert.AreEqual(0, stack[2].LineNumber);
+      Assert.AreEqual("UnityEngine.UI.Button.Press()", stack[3].Method);
+      Assert.AreEqual("<filename unknown>", stack[3].File);
+      Assert.AreEqual(0, stack[3].LineNumber);
+      Assert.AreEqual("UnityEngine.UI.Button.OnPointerClick(UnityEngine.EventSystems.PointerEventData eventData)", stack[4].Method);
+      Assert.AreEqual("<filename unknown>", stack[4].File);
+      Assert.AreEqual(0, stack[4].LineNumber);
+      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents.Execute(IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)", stack[5].Method);
+      Assert.AreEqual("<filename unknown>", stack[5].File);
+      Assert.AreEqual(0, stack[5].LineNumber);
+      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler](UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor)", stack[6].Method);
+      Assert.AreEqual("<filename unknown>", stack[6].File);
+      Assert.AreEqual(0, stack[6].LineNumber);
+    }
+
+    [Test]
+    public void ParseAndroidExceptionFromLogMessage()
+    {
+      string condition = "AndroidJavaException: java.lang.ArrayIndexOutOfBoundsException: length=2; index=2";
+      string stacktrace = @"java.lang.ArrayIndexOutOfBoundsException: length=2; index=2
+com.example.bugsnagcrashplugin.CrashHelper.UnhandledCrash(CrashHelper.java:11)
+com.unity3d.player.UnityPlayer.nativeRender(Native Method)
+com.unity3d.player.UnityPlayer.c(Unknown Source:0)
+com.unity3d.player.UnityPlayer$e$2.queueIdle(Unknown Source:72)
+android.os.MessageQueue.next(MessageQueue.java:395)
+android.os.Looper.loop(Looper.java:160)
+com.unity3d.player.UnityPlayer$e.run(Unknown Source:32)";
+      var logType = UnityEngine.LogType.Error;
+      var log = new UnityLogMessage(condition, stacktrace, logType);
+
+      var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {});
+      var stack = exception.StackTrace.ToList();
+      Assert.AreEqual(7, stack.Count);
+      Assert.AreEqual("java.lang.ArrayIndexOutOfBoundsException", exception.ErrorClass);
+      Assert.AreEqual("length=2; index=2", exception.ErrorMessage);
+      Assert.AreEqual("com.example.bugsnagcrashplugin.CrashHelper.UnhandledCrash()", stack[0].Method);
+      Assert.AreEqual("CrashHelper.java", stack[0].File);
+      Assert.AreEqual(11, stack[0].LineNumber);
+      Assert.AreEqual("com.unity3d.player.UnityPlayer.nativeRender()", stack[1].Method);
+      Assert.AreEqual("Native Method", stack[1].File);
+      Assert.AreEqual(null, stack[1].LineNumber);
+      Assert.AreEqual("com.unity3d.player.UnityPlayer.c()", stack[2].Method);
+      Assert.AreEqual("Unknown Source", stack[2].File);
+      Assert.AreEqual(0, stack[2].LineNumber);
+      Assert.AreEqual("com.unity3d.player.UnityPlayer$e$2.queueIdle()", stack[3].Method);
+      Assert.AreEqual("Unknown Source", stack[3].File);
+      Assert.AreEqual(72, stack[3].LineNumber);
+      Assert.AreEqual("android.os.MessageQueue.next()", stack[4].Method);
+      Assert.AreEqual("MessageQueue.java", stack[4].File);
+      Assert.AreEqual(395, stack[4].LineNumber);
+      Assert.AreEqual("android.os.Looper.loop()", stack[5].Method);
+      Assert.AreEqual("Looper.java", stack[5].File);
+      Assert.AreEqual(160, stack[5].LineNumber);
+      Assert.AreEqual("com.unity3d.player.UnityPlayer$e.run()", stack[6].Method);
+      Assert.AreEqual("Unknown Source", stack[6].File);
+      Assert.AreEqual(32, stack[6].LineNumber);
+    }
+  }
+}
+

--- a/tests/BugsnagUnity.Tests/ExceptionTests.cs
+++ b/tests/BugsnagUnity.Tests/ExceptionTests.cs
@@ -61,13 +61,19 @@ com.unity3d.player.UnityPlayer.c(Unknown Source:0)
 com.unity3d.player.UnityPlayer$e$2.queueIdle(Unknown Source:72)
 android.os.MessageQueue.next(MessageQueue.java:395)
 android.os.Looper.loop(Looper.java:160)
-com.unity3d.player.UnityPlayer$e.run(Unknown Source:32)";
+com.unity3d.player.UnityPlayer$e.run(Unknown Source:32)
+UnityEngine.AndroidJNISafe.CheckException()
+UnityEngine.AndroidJNISafe.CallStaticVoidMethod(IntPtr clazz, IntPtr methodID, UnityEngine.jvalue[] args)
+UnityEngine.AndroidJavaObject._CallStatic(System.String methodName, System.Object[] args)
+UnityEngine.EventSystems.ExecuteEvents.Execute(IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)
+UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functorUnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler]()
+UnityEngine.EventSystems.EventSystem:Update()";
       var logType = UnityEngine.LogType.Error;
       var log = new UnityLogMessage(condition, stacktrace, logType);
 
       var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {});
       var stack = exception.StackTrace.ToList();
-      Assert.AreEqual(7, stack.Count);
+      Assert.AreEqual(13, stack.Count);
       Assert.AreEqual("java.lang.ArrayIndexOutOfBoundsException", exception.ErrorClass);
       Assert.AreEqual("length=2; index=2", exception.ErrorMessage);
       Assert.AreEqual("com.example.bugsnagcrashplugin.CrashHelper.UnhandledCrash()", stack[0].Method);
@@ -91,6 +97,24 @@ com.unity3d.player.UnityPlayer$e.run(Unknown Source:32)";
       Assert.AreEqual("com.unity3d.player.UnityPlayer$e.run()", stack[6].Method);
       Assert.AreEqual("Unknown Source", stack[6].File);
       Assert.AreEqual(32, stack[6].LineNumber);
+      Assert.AreEqual("UnityEngine.AndroidJNISafe.CheckException()", stack[7].Method);
+      Assert.AreEqual(null, stack[7].File);
+      Assert.AreEqual(null, stack[7].LineNumber);
+      Assert.AreEqual("UnityEngine.AndroidJNISafe.CallStaticVoidMethod(IntPtr clazz, IntPtr methodID, UnityEngine.jvalue[] args)", stack[8].Method);
+      Assert.AreEqual(null, stack[8].File);
+      Assert.AreEqual(null, stack[8].LineNumber);
+      Assert.AreEqual("UnityEngine.AndroidJavaObject._CallStatic(System.String methodName, System.Object[] args)", stack[9].Method);
+      Assert.AreEqual(null, stack[9].File);
+      Assert.AreEqual(null, stack[9].LineNumber);
+      Assert.AreEqual("UnityEngine.EventSystems.ExecuteEvents.Execute(IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)", stack[10].Method);
+      Assert.AreEqual(null, stack[10].File);
+      Assert.AreEqual(null, stack[10].LineNumber);
+      Assert.AreEqual("UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functorUnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler]()", stack[11].Method);
+      Assert.AreEqual(null, stack[11].File);
+      Assert.AreEqual(null, stack[11].LineNumber);
+      Assert.AreEqual("UnityEngine.EventSystems.EventSystem:Update()", stack[12].Method);
+      Assert.AreEqual(null, stack[12].File);
+      Assert.AreEqual(null, stack[12].LineNumber);
     }
   }
 }

--- a/tests/BugsnagUnity.Tests/ExceptionTests.cs
+++ b/tests/BugsnagUnity.Tests/ExceptionTests.cs
@@ -22,7 +22,7 @@ namespace BugsnagUnity.Payload.Tests
       var logType = UnityEngine.LogType.Error;
       var log = new UnityLogMessage(condition, stacktrace, logType);
 
-      var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {});
+      var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {}, Severity.Info);
       var stack = exception.StackTrace.ToList();
       Assert.AreEqual(7, stack.Count);
       Assert.AreEqual("IndexOutOfRangeException", exception.ErrorClass);
@@ -71,7 +71,7 @@ UnityEngine.EventSystems.EventSystem:Update()";
       var logType = UnityEngine.LogType.Error;
       var log = new UnityLogMessage(condition, stacktrace, logType);
 
-      var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {});
+      var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {}, Severity.Warning);
       var stack = exception.StackTrace.ToList();
       Assert.AreEqual(13, stack.Count);
       Assert.AreEqual("java.lang.ArrayIndexOutOfBoundsException", exception.ErrorClass);


### PR DESCRIPTION
## Goal

Ensure Android Java exceptions are formatted consistently with correct
stack traces and handledness

## Background

Some versions of Unity include a built-in thread uncaught exception
handler, which intercepts Java exceptions and emits them as log messages
if they occur on the main thread. The stacktrace string argument uses a
different format from Unity/C# exceptions, including the actual Java
exception name and message as the first line of the stacktrace.


## Changeset

This change detects android java exceptions by checking the error class
for "AndroidJavaException" then parsing the stacktrace according to the
java format. It fixes a case where the message / actual exception name
is placed into the message.

Added additional logic to process Java exceptions normally:

* Unwrap the "actual" error class from the log message
* Format the Java-style stack trace to match C# lines
* Set handled state for native Java exceptions to be unhandled

## Tests

* Added additional parsing tests for stacktrace formats

## Review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency between the changeset and the goal stated above
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language