### PR TITLE
Specify maven central as a preferred repository over jcenter

### DIFF
--- a/bugsnag-android-unity/build.gradle
+++ b/bugsnag-android-unity/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 
 repositories {
     google()
+    mavenCentral()
     jcenter()
 }
 


### PR DESCRIPTION
## Goal

Specifying `mavenCentral` as a repository in addition to `jcenter` makes it possible to perform a clean build of the project in the case where one provider suffers downtime.

Note: the bugsnag-android submodule currently still only specifies jcenter for some build files. This will be addressed the next time bugsnag-android is updated, assuming the following PR is merged: https://github.com/bugsnag/bugsnag-android/pull/402