### PR TITLE
refactor: Remove duplication between config classes

### DIFF
--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BugsnagUnity
+{
+  public abstract class AbstractConfiguration : IConfiguration
+  {
+    public const string DefaultEndpoint = "https://notify.bugsnag.com";
+
+    public const string DefaultSessionEndpoint = "https://sessions.bugsnag.com";
+
+    public AbstractConfiguration(string apiKey)
+    {
+      ApiKey = apiKey;
+      AppVersion = Application.version;
+    }
+
+    public TimeSpan MaximumLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(1);
+
+    public Dictionary<LogType, int> MaximumTypePerTimePeriod { get; set; } = new Dictionary<LogType, int>
+    {
+        { LogType.Assert, 5 },
+        { LogType.Error, 5 },
+        { LogType.Exception, 20 },
+        { LogType.Log, 5 },
+        { LogType.Warning, 5 },
+    };
+
+    public TimeSpan UniqueLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(5);
+
+    public string ApiKey { get; }
+
+    public int MaximumBreadcrumbs { get; set; } = 25;
+
+    public string ReleaseStage { get; set; } = "production";
+
+    public string[] NotifyReleaseStages { get; set; }
+
+    public string AppVersion { get; set; }
+
+    public Uri Endpoint { get; set; } = new Uri(DefaultEndpoint);
+
+    public string PayloadVersion { get; } = "4.0";
+
+    public Uri SessionEndpoint { get; set; } = new Uri(DefaultSessionEndpoint);
+
+    public string SessionPayloadVersion { get; } = "1";
+
+    public string Context { get; set; }
+
+    public LogType NotifyLevel { get; set; } = LogType.Exception;
+
+    public bool AutoNotify { get; set; } = true;
+
+    public bool AutoCaptureSessions { get; set; }
+
+    public LogTypeSeverityMapping LogTypeSeverityMapping { get; } = new LogTypeSeverityMapping();
+  }
+}
+

--- a/src/BugsnagUnity/Native/Android/Configuration.cs
+++ b/src/BugsnagUnity/Native/Android/Configuration.cs
@@ -4,17 +4,12 @@ using UnityEngine;
 
 namespace BugsnagUnity
 {
-  class Configuration : IConfiguration
+  class Configuration : AbstractConfiguration
   {
-    const string DefaultEndpoint = "https://notify.bugsnag.com";
-
-    const string DefaultSessionEndpoint = "https://sessions.bugsnag.com";
-
     internal NativeInterface NativeInterface { get; }
 
-    internal Configuration(string apiKey)
+    internal Configuration(string apiKey) : base(apiKey)
     {
-      ApiKey = apiKey;
       var JavaObject = new AndroidJavaObject("com.bugsnag.android.Configuration", apiKey);
       // the bugsnag-unity notifier will handle session tracking
       JavaObject.Call("setAutoCaptureSessions", false);
@@ -23,39 +18,9 @@ namespace BugsnagUnity
       JavaObject.Call("setReleaseStage", "production");
       JavaObject.Call("setAppVersion", Application.version);
       NativeInterface = new NativeInterface(JavaObject);
-
-      AutoNotify = true;
-      MaximumBreadcrumbs = 25;
-      NotifyLevel = LogType.Exception;
-      UniqueLogsTimePeriod = TimeSpan.FromSeconds(5);
-      MaximumLogsTimePeriod = TimeSpan.FromSeconds(1);
-      LogTypeSeverityMapping = new LogTypeSeverityMapping();
     }
 
-    public TimeSpan MaximumLogsTimePeriod { get; set; }
-
-    public Dictionary<LogType, int> MaximumTypePerTimePeriod { get; } = new Dictionary<LogType, int>
-    {
-        { LogType.Assert, 5 },
-        { LogType.Error, 5 },
-        { LogType.Exception, 20 },
-        { LogType.Log, 5 },
-        { LogType.Warning, 5 },
-    };
-
-    public TimeSpan UniqueLogsTimePeriod { get; set; }
-
-    public int MaximumBreadcrumbs { get; set; } // this is stored on the client object in java so we need to figure out how this will work
-
-    public LogType NotifyLevel { get; set; }
-
-    public string PayloadVersion { get; } = "4.0";
-
-    public string SessionPayloadVersion { get; } = "1";
-
-    public string ApiKey { get; }
-
-    public string ReleaseStage
+    public new string ReleaseStage
     {
       set
       {
@@ -67,7 +32,7 @@ namespace BugsnagUnity
       }
     }
 
-    public string[] NotifyReleaseStages
+    public new string[] NotifyReleaseStages
     {
       set
       {
@@ -79,7 +44,7 @@ namespace BugsnagUnity
       }
     }
 
-    public string AppVersion
+    public new string AppVersion
     {
       set
       {
@@ -91,7 +56,7 @@ namespace BugsnagUnity
       }
     }
 
-    public Uri Endpoint
+    public new Uri Endpoint
     {
       set
       {
@@ -103,7 +68,7 @@ namespace BugsnagUnity
       }
     }
 
-    public Uri SessionEndpoint
+    public new Uri SessionEndpoint
     {
       set
       {
@@ -115,7 +80,7 @@ namespace BugsnagUnity
       }
     }
 
-    public string Context
+    public new string Context
     {
       set
       {
@@ -126,11 +91,5 @@ namespace BugsnagUnity
         return NativeInterface.GetContext();
       }
     }
-
-    public bool AutoNotify { get; set; } // how do we hook this into the android bits, this lives on the client object
-
-    public bool AutoCaptureSessions { get; set; }
-
-    public LogTypeSeverityMapping LogTypeSeverityMapping { get; }
   }
 }

--- a/src/BugsnagUnity/Native/Cocoa/Configuration.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Configuration.cs
@@ -6,49 +6,24 @@ using UnityEngine;
 
 namespace BugsnagUnity
 {
-  class Configuration : IConfiguration
+  class Configuration : AbstractConfiguration
   {
-    const string DefaultEndpoint = "https://notify.bugsnag.com";
-
-    const string DefaultSessionEndpoint = "https://sessions.bugsnag.com";
-
     internal IntPtr NativeConfiguration { get; }
 
-    internal Configuration(string apiKey)
+    internal Configuration(string apiKey) : base(apiKey)
     {
       NativeConfiguration = NativeCode.bugsnag_createConfiguration(apiKey);
-      Endpoint = new Uri(DefaultEndpoint);
-      AutoNotify = true;
-      SessionEndpoint = new Uri(DefaultSessionEndpoint);
-      MaximumBreadcrumbs = 25;
-      ReleaseStage = "production";
-      NotifyLevel = LogType.Exception;
-      UniqueLogsTimePeriod = TimeSpan.FromSeconds(5);
-      MaximumLogsTimePeriod = TimeSpan.FromSeconds(1);
-      AppVersion = Application.version;
-      LogTypeSeverityMapping = new LogTypeSeverityMapping();
     }
 
-    public string ApiKey => Marshal.PtrToStringAuto(NativeCode.bugsnag_getApiKey(NativeConfiguration));
-    public TimeSpan MaximumLogsTimePeriod { get; }
-    public Dictionary<LogType, int> MaximumTypePerTimePeriod { get; } = new Dictionary<LogType, int>
-    {
-      { LogType.Assert, 5 },
-      { LogType.Error, 5 },
-      { LogType.Exception, 20 },
-      { LogType.Log, 5 },
-      { LogType.Warning, 5 },
-    };
-    public TimeSpan UniqueLogsTimePeriod { get; set; }
-    public int MaximumBreadcrumbs { get; set; }
+    public new string ApiKey => Marshal.PtrToStringAuto(NativeCode.bugsnag_getApiKey(NativeConfiguration));
 
-    public string ReleaseStage
+    public new string ReleaseStage
     {
       get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getReleaseStage(NativeConfiguration));
       set => NativeCode.bugsnag_setReleaseStage(NativeConfiguration, value);
     }
 
-    public string[] NotifyReleaseStages
+    public new string[] NotifyReleaseStages
     {
       get
       {
@@ -84,32 +59,22 @@ namespace BugsnagUnity
       }
     }
 
-    public string AppVersion
+    public new string AppVersion
     {
       get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getAppVersion(NativeConfiguration));
       set => NativeCode.bugsnag_setAppVersion(NativeConfiguration, value);
     }
 
-    public Uri Endpoint
+    public new Uri Endpoint
     {
       get => new Uri(Marshal.PtrToStringAuto(NativeCode.bugsnag_getNotifyUrl(NativeConfiguration)));
       set => NativeCode.bugsnag_setNotifyUrl(NativeConfiguration, value.ToString());
     }
-    public string PayloadVersion { get; } = "4.0";
-    public string SessionPayloadVersion { get; } = "1";
-    public Uri SessionEndpoint { get; set; }
 
-    public string Context
+    public new string Context
     {
       get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getContext(NativeConfiguration));
       set => NativeCode.bugsnag_setContext(NativeConfiguration, value);
     }
-
-    public LogType NotifyLevel { get; set; }
-    public bool AutoNotify { get; set; }
-
-    public bool AutoCaptureSessions { get; set; }
-
-    public LogTypeSeverityMapping LogTypeSeverityMapping { get; }
   }
 }

--- a/src/BugsnagUnity/Native/Fallback/Configuration.cs
+++ b/src/BugsnagUnity/Native/Fallback/Configuration.cs
@@ -4,66 +4,8 @@ using UnityEngine;
 
 namespace BugsnagUnity
 {
-  class Configuration : IConfiguration
+  class Configuration : AbstractConfiguration
   {
-    const string DefaultEndpoint = "https://notify.bugsnag.com";
-
-    const string DefaultSessionEndpoint = "https://sessions.bugsnag.com";
-
-    internal Configuration(string apiKey)
-    {
-      ApiKey = apiKey;
-      Endpoint = new Uri(DefaultEndpoint);
-      AutoNotify = true;
-      SessionEndpoint = new Uri(DefaultSessionEndpoint);
-      MaximumBreadcrumbs = 25;
-      ReleaseStage = "production";
-      NotifyLevel = LogType.Exception;
-      UniqueLogsTimePeriod = TimeSpan.FromSeconds(5);
-      MaximumLogsTimePeriod = TimeSpan.FromSeconds(1);
-      AppVersion = Application.version;
-      LogTypeSeverityMapping = new LogTypeSeverityMapping();
-    }
-
-    public TimeSpan MaximumLogsTimePeriod { get; set; }
-
-    public Dictionary<LogType, int> MaximumTypePerTimePeriod { get; } = new Dictionary<LogType, int>
-    {
-        { LogType.Assert, 5 },
-        { LogType.Error, 5 },
-        { LogType.Exception, 20 },
-        { LogType.Log, 5 },
-        { LogType.Warning, 5 },
-    };
-
-    public TimeSpan UniqueLogsTimePeriod { get; set; }
-
-    public string ApiKey { get; }
-
-    public int MaximumBreadcrumbs { get; set; }
-
-    public string ReleaseStage { get; set; }
-
-    public string[] NotifyReleaseStages { get; set; }
-
-    public string AppVersion { get; set; }
-
-    public Uri Endpoint { get; set; }
-
-    public string PayloadVersion { get; } = "4.0";
-
-    public Uri SessionEndpoint { get; set; }
-
-    public string SessionPayloadVersion { get; } = "1";
-
-    public string Context { get; set; }
-
-    public LogType NotifyLevel { get; set; }
-
-    public bool AutoNotify { get; set; }
-
-    public bool AutoCaptureSessions { get; set; }
-    
-    public LogTypeSeverityMapping LogTypeSeverityMapping { get; }
+    internal Configuration(string apiKey) : base(apiKey) {}
   }
 }

--- a/tests/BugsnagUnity.Tests/MaximumLogTypeCounterTests.cs
+++ b/tests/BugsnagUnity.Tests/MaximumLogTypeCounterTests.cs
@@ -15,7 +15,7 @@ namespace BugsnagUnity.Tests
       Dictionary<LogType, int> maximumTypePerTimePeriod =
         new Dictionary<LogType, int> { { LogType.Error, 5 } };
 
-      var configuration = new TestConfiguration
+      var configuration = new TestConfiguration("foo")
       {
         MaximumTypePerTimePeriod = maximumTypePerTimePeriod
       };
@@ -33,7 +33,7 @@ namespace BugsnagUnity.Tests
       Dictionary<LogType, int> maximumTypePerTimePeriod =
         new Dictionary<LogType, int> { { LogType.Error, 1 } };
 
-      var configuration = new TestConfiguration
+      var configuration = new TestConfiguration("foo")
       {
         MaximumTypePerTimePeriod = maximumTypePerTimePeriod
       };
@@ -53,7 +53,7 @@ namespace BugsnagUnity.Tests
       Dictionary<LogType, int> maximumTypePerTimePeriod =
         new Dictionary<LogType, int> { { LogType.Error, 5 } };
 
-      var configuration = new TestConfiguration
+      var configuration = new TestConfiguration("foo")
       {
         MaximumTypePerTimePeriod = maximumTypePerTimePeriod
       };
@@ -79,7 +79,7 @@ namespace BugsnagUnity.Tests
       Dictionary<LogType, int> maximumTypePerTimePeriod =
         new Dictionary<LogType, int>();
 
-      var configuration = new TestConfiguration
+      var configuration = new TestConfiguration("foo")
       {
         MaximumTypePerTimePeriod = maximumTypePerTimePeriod
       };
@@ -98,7 +98,7 @@ namespace BugsnagUnity.Tests
       Dictionary<LogType, int> maximumTypePerTimePeriod =
         new Dictionary<LogType, int> { { LogType.Error, 1 } };
 
-      var configuration = new TestConfiguration
+      var configuration = new TestConfiguration("foo")
       {
         MaximumTypePerTimePeriod = maximumTypePerTimePeriod,
         MaximumLogsTimePeriod = TimeSpan.FromSeconds(2),

--- a/tests/BugsnagUnity.Tests/TestConfiguration.cs
+++ b/tests/BugsnagUnity.Tests/TestConfiguration.cs
@@ -4,40 +4,8 @@ using UnityEngine;
 
 namespace BugsnagUnity.Tests
 {
-  public class TestConfiguration : IConfiguration
+  public class TestConfiguration : AbstractConfiguration
   {
-    public TimeSpan MaximumLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(1);
-
-    public Dictionary<LogType, int> MaximumTypePerTimePeriod { get; set; }
-
-    public TimeSpan UniqueLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(5);
-
-    public string ApiKey { get; set; }
-
-    public int MaximumBreadcrumbs { get; set; }
-
-    public string ReleaseStage { get; set; }
-
-    public string[] NotifyReleaseStages { get; set; }
-
-    public string AppVersion { get; set; }
-
-    public Uri Endpoint { get; set; }
-
-    public string PayloadVersion { get; set; }
-
-    public Uri SessionEndpoint { get; set; }
-
-    public string SessionPayloadVersion { get; set; }
-
-    public string Context { get; set; }
-
-    public LogType NotifyLevel { get; set; }
-
-    public bool AutoNotify { get; set; }
-
-    public bool AutoCaptureSessions { get; set; }
-
-    public LogTypeSeverityMapping LogTypeSeverityMapping { get; }
+    internal TestConfiguration(string apiKey) : base(apiKey) {}
   }
 }

--- a/tests/BugsnagUnity.Tests/UniqueLogCounterTests.cs
+++ b/tests/BugsnagUnity.Tests/UniqueLogCounterTests.cs
@@ -10,7 +10,7 @@ namespace BugsnagUnity.Tests
     [Test]
     public void ShouldNotSendDuplicateMessages()
     {
-      var counter = new UniqueLogThrottle(new TestConfiguration());
+      var counter = new UniqueLogThrottle(new TestConfiguration("foo"));
 
       var message1 = new UnityLogMessage("", "", LogType.Error);
       var message2 = new UnityLogMessage("", "", LogType.Error);
@@ -22,7 +22,7 @@ namespace BugsnagUnity.Tests
     [Test]
     public void SendsSingleMessage()
     {
-      var counter = new UniqueLogThrottle(new TestConfiguration());
+      var counter = new UniqueLogThrottle(new TestConfiguration("foo"));
 
       var message = new UnityLogMessage("", "", LogType.Error);
 
@@ -32,7 +32,7 @@ namespace BugsnagUnity.Tests
     [Test]
     public void FlushesCorrectly()
     {
-      var configuration = new TestConfiguration();
+      var configuration = new TestConfiguration("foo");
       var counter = new UniqueLogThrottle(configuration);
 
       var message = new UnityLogMessage("", "", LogType.Error);


### PR DESCRIPTION
Move shared stuff into an abstract class. Phase one of ROAD-684, to make it easier to change config options without duplication.

## Changeset

Added `AbstractConfiguration` as the base class for each of the `Configuration` implementation, removing the shared code. The abstract class can't really be interacted with directly.

## Tests

* Existing tests cover the behavior, and the classes still conform to the public interface, `IConfiguration` (not doing so would be a compilation failure).

## Discussion

### Outstanding Questions

1. I couldn't think of any downsides here, but I'd be happy to hear about any.

## Review

What needs checked:

- [x] Is this idiomatic?
- [x] Do reports upload normally on Windows?
- [x] Do reports upload normally on Android?
