### PR TITLE
tests: Make double notify scenarios consistent

### DIFF
--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -83,7 +83,7 @@ public class Main : MonoBehaviour {
 
   void NotifyTwice() {
     Bugsnag.Notify(new System.Exception("Rollback failed"));
-    System.Threading.Thread.Sleep(20);
+    System.Threading.Thread.Sleep(2000);
     Bugsnag.Notify(new ExecutionEngineException("Invalid runtime"));
   }
 


### PR DESCRIPTION
They can periodically fail, this increases the wait time to longer than
the dequeuing time for the delivery thread.

## Review

Provided CI passes, should be good :)