### PR TITLE
Add config option to report Unity exceptions as "unhandled"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## TBD
 
+### Enhancements
+
+* Add a configuration option for allowing Unity exceptions to reduce a project's
+  stability score. [See the documentation for
+  `ReportUncaughtExceptionsAsHandled`](https://docs.bugsnag.com/platforms/unity/configuration-options/#ReportUncaughtExceptionsAsHandled)
+
 ### Bug fixes
 
 * Fix exception parsing for Android Java exceptions to ensure correct grouping,

--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -71,7 +71,35 @@ public class Main : MonoBehaviour {
       case "AssertionFailure":
         MakeAssertionFailure(4);
         break;
+      case "UncaughtExceptionAsUnhandled":
+        UncaughtExceptionAsUnhandled();
+        break;
+      case "LogUnthrownAsUnhandled":
+        DoLogUnthrownAsUnhandled();
+        break;
+      case "ReportLoggedWarning":
+        DoLogWarning();
+        break;
+      case "ReportLoggedWarningWithHandledConfig":
+        DoLogWarningWithHandledConfig();
+        break;
     }
+  }
+
+  void UncaughtExceptionAsUnhandled() {
+    Bugsnag.Configuration.ReportUncaughtExceptionsAsHandled = false;
+    throw new ExecutionEngineException("Invariant state failure");
+  }
+
+  void DoLogWarning() {
+    Bugsnag.Configuration.NotifyLevel = LogType.Warning;
+    Debug.LogWarning("Something went terribly awry");
+  }
+
+  void DoLogWarningWithHandledConfig() {
+    Bugsnag.Configuration.ReportUncaughtExceptionsAsHandled = false;
+    Bugsnag.Configuration.NotifyLevel = LogType.Warning;
+    Debug.LogWarning("Something went terribly awry");
   }
 
   void LeaveComplexBreadcrumbAndNotify() {
@@ -99,6 +127,11 @@ public class Main : MonoBehaviour {
 
   void DoNotify() {
     Bugsnag.Notify(new System.Exception("blorb"));
+  }
+
+  void DoLogUnthrownAsUnhandled() {
+    Bugsnag.Configuration.ReportUncaughtExceptionsAsHandled = false;
+    Debug.LogException(new System.Exception("WAT"));
   }
 
   void DoLogUnthrown() {

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -30,3 +30,48 @@ Feature: Handled Errors and Exceptions
             | Main:LoadScenario()  |
             | Main:Update()        |
 
+    Scenario: Logging an unthrown exception as unhandled
+        When I run the game in the "LogUnthrownAsUnhandled" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "Exception"
+        And the exception "message" equals "WAT"
+        And the event "unhandled" is true
+        And the first significant stack frame methods and files should match:
+            | Main:DoLogUnthrownAsUnhandled() |
+            | Main:LoadScenario()  |
+            | Main:Update()        |
+
+    Scenario: Logging a warning to Bugsnag
+        When I run the game in the "ReportLoggedWarning" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "UnityLogWarning"
+        And the exception "message" equals "Something went terribly awry"
+        And the event "unhandled" is false
+        And the first significant stack frame methods and files should match:
+            | Main:DoLogWarning()  |
+            | Main:LoadScenario()  |
+            | Main:Update()        |
+
+    Scenario: Logging a warning to Bugsnag with 'ReportAsHandled = false'
+        When I run the game in the "ReportLoggedWarningWithHandledConfig" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "UnityLogWarning"
+        And the exception "message" equals "Something went terribly awry"
+        And the event "unhandled" is false
+        And the first significant stack frame methods and files should match:
+            | Main:DoLogWarningWithHandledConfig()  |
+            | Main:LoadScenario()  |
+            | Main:Update()        |
+

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -15,6 +15,21 @@ Feature: Reporting unhandled events
             | Main.LoadScenario()         |
             | Main.Update()               |
 
+    Scenario: Forcing uncaught exceptions to be unhandled
+        When I run the game in the "UncaughtExceptionAsUnhandled" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "ExecutionEngineException"
+        And the exception "message" equals "Invariant state failure"
+        And the event "unhandled" is true
+        And the first significant stack frame methods and files should match:
+            | Main.UncaughtExceptionAsUnhandled() |
+            | Main.LoadScenario()         |
+            | Main.Update()               |
+
     Scenario: Reporting an assertion failure
         When I run the game in the "AssertionFailure" state
         Then I should receive a request

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -92,7 +92,8 @@ namespace BugsnagUnity
           {
             var severity = Configuration.LogTypeSeverityMapping.Map(logType);
             var backupStackFrames = new System.Diagnostics.StackTrace(1, true).GetFrames();
-            var exception = Exception.FromUnityLogMessage(logMessage, backupStackFrames, severity);
+            var forceUnhandled = logType == LogType.Exception && !Configuration.ReportUncaughtExceptionsAsHandled;
+            var exception = Exception.FromUnityLogMessage(logMessage, backupStackFrames, severity, forceUnhandled);
             Notify(new Exception[]{exception}, exception.HandledState, null, logType);
           }
         }

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -16,6 +16,8 @@ namespace BugsnagUnity
       AppVersion = Application.version;
     }
 
+    public bool ReportUncaughtExceptionsAsHandled { get; set; } = true;
+
     public TimeSpan MaximumLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(1);
 
     public Dictionary<LogType, int> MaximumTypePerTimePeriod { get; set; } = new Dictionary<LogType, int>

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -8,6 +8,8 @@ namespace BugsnagUnity
   {
     string ApiKey { get; }
 
+    bool ReportUncaughtExceptionsAsHandled { get; set; }
+
     TimeSpan MaximumLogsTimePeriod { get; }
 
     Dictionary<LogType, int> MaximumTypePerTimePeriod { get; }
@@ -37,7 +39,7 @@ namespace BugsnagUnity
     bool AutoNotify { get; set; }
 
     bool AutoCaptureSessions { get; set; }
-    
+
     LogTypeSeverityMapping LogTypeSeverityMapping { get; }
   }
 }

--- a/src/BugsnagUnity/Payload/Exception.cs
+++ b/src/BugsnagUnity/Payload/Exception.cs
@@ -105,11 +105,18 @@ namespace BugsnagUnity.Payload
 
     public static Exception FromUnityLogMessage(UnityLogMessage logMessage, System.Diagnostics.StackFrame[] stackFrames, Severity severity)
     {
+      return FromUnityLogMessage(logMessage, stackFrames, severity, false);
+    }
+
+    public static Exception FromUnityLogMessage(UnityLogMessage logMessage, System.Diagnostics.StackFrame[] stackFrames, Severity severity, bool forceUnhandled)
+    {
       var match = Regex.Match(logMessage.Condition, ErrorClassMessagePattern, RegexOptions.Singleline);
 
       var lines = new StackTrace(logMessage.StackTrace).ToArray();
 
-      var handledState = HandledState.ForUnityLogMessage(severity);
+      var handledState = forceUnhandled
+        ? HandledState.ForUnhandledException()
+        : HandledState.ForUnityLogMessage(severity);
 
       if (match.Success)
       {
@@ -132,7 +139,7 @@ namespace BugsnagUnity.Payload
       else
       {
         // include the type somehow in there
-        return new Exception($"UnityLog{logMessage.Type}", logMessage.Condition, lines);
+        return new Exception($"UnityLog{logMessage.Type}", logMessage.Condition, lines, handledState);
       }
     }
   }

--- a/tests/BugsnagUnity.Tests/ConfigurationTests.cs
+++ b/tests/BugsnagUnity.Tests/ConfigurationTests.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using System.Linq;
+using System.Threading;
+using UnityEngine;
+
+namespace BugsnagUnity.Payload.Tests
+{
+  class TestConfig : AbstractConfiguration
+  {
+    internal TestConfig(string apiKey) : base(apiKey) {}
+  }
+
+  [TestFixture]
+  class ConfigurationTests
+  {
+    [Test]
+    public void ReportUncaughtExceptionsAsHandledIsDefault()
+    {
+      var config = new TestConfig("foo");
+      Assert.IsTrue(config.ReportUncaughtExceptionsAsHandled);
+    }
+  }
+}


### PR DESCRIPTION
## Goal

Make severe errors captured on the Unity platform result in a reduced stability score in a configurable manner.

## Changeset

* Added `ReportUncaughtExceptionsAsHandled` option in `IConfiguration`. The option is true by default.
* If the option is false, force `Exception` constructor to use an "unhandled" `HandledState`

Usage:
```cs
Bugsnag.Configuration.ReportUncaughtExceptionsAsHandled = false;
```

## Tests

Existing automated tests cover:

* When Configuration.ReportUncaughtExceptionsAsHandled = true, an uncaught exception reports as handled (default behavior)
* When Configuration.ReportUncaughtExceptionsAsHandled = true, logging an exception with Debug.LogException() reports as handled

Added new end-to-end tests to verify:
* When Configuration.ReportUncaughtExceptionsAsHandled = false, an uncaught exception reports as unhandled
* When Configuration.ReportUncaughtExceptionsAsHandled = false, logging an exception with Debug.LogException() reports as unhandled
* When Configuration.ReportUncaughtExceptionsAsHandled = true and Configuration.NotifyLevel = LogType.Warning, logging with Debug.LogWarning() reports as handled (default behavior)
* When Configuration.ReportUncaughtExceptionsAsHandled = false and Configuration.NotifyLevel = LogType.Warning, logging with Debug.LogWarning() reports as handled

Manually verified behavior on iOS and macOS.

## Review

What I most need reviewed is that the changeset is that the changeset is idiomatic, easy to understand, and that there aren't any missing test cases. 🙇‍♀️ 

Pre-built package:

[Bugsnag.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/2699498/Bugsnag.unitypackage.zip)
sha1 d5caa37ec86093fa9484e53c6310404ab5870524
md5 d9588f66dddc8fdcf476fe1c62bf489c
