### PR TITLE
fix: Match session counts to events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix exception parsing for Android Java exceptions to ensure correct grouping,
   "handled"-ness, and remove extraneous stack frame from the top of the
   backtrace.
+* Fix off-by-one error in event counts in the session tracking implementation
 
 ## 4.0.0 (2018-11-19)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 96190951af9af1c3765bddb1a6fbf24fc3cc2c36
+  revision: 6f5af2c98c6fa1cfb07d6466a5cf3eaca5dcbc90
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)
       cucumber-expressions (= 5.0.15)
       minitest (~> 5.0)
+      os (~> 1.0.0)
       rack (~> 2.0.0)
       rake (~> 12.3.0)
       test-unit (~> 3.2.0)
@@ -41,11 +42,12 @@ GEM
     multi_json (1.13.1)
     multi_test (0.1.2)
     nanaimo (0.2.6)
+    os (1.0.0)
     power_assert (1.1.3)
-    rack (2.0.5)
-    rake (12.3.1)
+    rack (2.0.6)
+    rake (12.3.2)
     rouge (2.0.7)
-    test-unit (3.2.8)
+    test-unit (3.2.9)
       power_assert
     xcodeproj (1.5.9)
       CFPropertyList (>= 2.3.3, < 4.0)

--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -17,6 +17,7 @@ public class Main : MonoBehaviour {
     var obj = new GameObject("Bugsnag");
     var bugsnag = obj.AddComponent<BugsnagBehaviour>();
     bugsnag.BugsnagApiKey = System.Environment.GetEnvironmentVariable("BUGSNAG_APIKEY");
+    bugsnag.AutoCaptureSessions = false;
     obj.AddComponent<Main>();
     UnityEditor.SceneManagement.EditorSceneManager.SaveScene(scene, "Assets/MainScene.unity");
     var scenes = new List<EditorBuildSettingsScene>(EditorBuildSettings.scenes);
@@ -31,8 +32,10 @@ public class Main : MonoBehaviour {
     // only send one crash
     if (!sent) {
       sent = true;
-      Bugsnag.Configuration.Endpoint =
+      var endpoint =
         new System.Uri(Environment.GetEnvironmentVariable("MAZE_ENDPOINT"));
+      Bugsnag.Configuration.Endpoint = endpoint;
+      Bugsnag.Configuration.SessionEndpoint = endpoint;
       LoadScenario();
       // wait for 5 seconds before exiting the application
       StartCoroutine(WaitForBugsnag());
@@ -82,6 +85,23 @@ public class Main : MonoBehaviour {
         break;
       case "ReportLoggedWarningWithHandledConfig":
         DoLogWarningWithHandledConfig();
+        break;
+      case "ManualSession":
+        Bugsnag.StartSession();
+        break;
+      case "ManualSessionCrash":
+        Bugsnag.StartSession();
+        UncaughtExceptionAsUnhandled();
+        break;
+      case "ManualSessionNotify":
+        Bugsnag.StartSession();
+        DoNotify();
+        break;
+      case "ManualSessionMixedEvents":
+        Bugsnag.StartSession();
+        DoNotify();
+        DoLogWarning();
+        UncaughtExceptionAsUnhandled();
         break;
     }
   }

--- a/features/sessions.feature
+++ b/features/sessions.feature
@@ -1,0 +1,55 @@
+Feature: Session Tracking
+
+    Scenario: Manually logging a session
+        When I run the game in the "ManualSession" state
+        Then I should receive a request
+        And the request is a valid for the session tracking API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "sessions" is an array with 1 element
+        And the payload field "app.version" is not null
+        And the payload field "app.releaseStage" equals "production"
+        And the payload field "app.type" equals "Mac OS"
+        And the payload field "device.osVersion" is not null
+        And the payload field "device.osName" equals "Mac OS"
+        And the payload field "device.model" is not null
+        And the payload field "device.manufacturer" equals "Apple"
+
+        And the session "id" is not null
+        And the session "startedAt" is not null
+        And the session "user.id" is not null
+        And the session "user.email" is null
+        And the session "user.name" is null
+
+    Scenario: Manually logging a session before unhandled event
+        When I run the game in the "ManualSessionCrash" state
+        Then I should receive 2 requests
+        And request 0 is valid for the session tracking API
+        And request 1 is valid for the error reporting API
+        And the payload field "events" is an array with 1 element for request 1
+        And the payload field "events.0.session.events.handled" equals 0 for request 1
+        And the payload field "events.0.session.events.unhandled" equals 1 for request 1
+        And the payload field "events.0.session.id" of request 1 equals the payload field "sessions.0.id" of request 0
+
+    Scenario: Manually logging a session before handled events
+        When I run the game in the "ManualSessionNotify" state
+        Then I should receive 2 requests
+        And request 0 is valid for the session tracking API
+        And request 1 is valid for the error reporting API
+        And the payload field "events" is an array with 1 element for request 1
+        And the payload field "events.0.session.events.handled" equals 1 for request 1
+        And the payload field "events.0.session.events.unhandled" equals 0 for request 1
+        And the payload field "events.0.session.id" of request 1 equals the payload field "sessions.0.id" of request 0
+
+    Scenario: Manually logging a session before different types of events
+        When I run the game in the "ManualSessionMixedEvents" state
+        Then I should receive 4 requests
+        And request 0 is valid for the session tracking API
+        And request 1 is valid for the error reporting API
+        And request 2 is valid for the error reporting API
+        And request 3 is valid for the error reporting API
+        And the events in requests "1,2,3" match one of:
+            | message                      | handled | unhandled |
+            | blorb                        | 1       | 0         |
+            | Something went terribly awry | 2       | 0         |
+            | Invariant state failure      | 2       | 1         |

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -19,3 +19,18 @@ Then("the first significant stack frame methods and files should match:") do |ex
     expected_index += 1
   end
 end
+Then("the events in requests {string} match one of:") do |request_indices, table|
+  events = request_indices.split(',').map do |index|
+    read_key_path(find_request(index.to_i)[:body], "events")
+  end.flatten
+  table.hashes.each do |values|
+    assert_not_nil(events.detect do |event|
+      handled_count = read_key_path(event, "session.events.handled")
+      unhandled_count = read_key_path(event, "session.events.unhandled")
+      message = read_key_path(event, "exceptions.0.message")
+      handled_count == values["handled"].to_i &&
+        unhandled_count == values["unhandled"].to_i &&
+        message == values["message"]
+    end, "No event matches the following values: #{values}")
+  end
+end

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -47,7 +47,7 @@ namespace BugsnagUnity
 
     public Uri SessionEndpoint { get; set; } = new Uri(DefaultSessionEndpoint);
 
-    public string SessionPayloadVersion { get; } = "1";
+    public string SessionPayloadVersion { get; } = "1.0";
 
     public string Context { get; set; }
 

--- a/src/BugsnagUnity/Payload/Event.cs
+++ b/src/BugsnagUnity/Payload/Event.cs
@@ -23,6 +23,17 @@ namespace BugsnagUnity.Payload
       this.AddToPayload("metaData", Metadata);
       this.AddToPayload("breadcrumbs", breadcrumbs);
       this.AddToPayload("session", session);
+      if (session != null)
+      {
+        if (handledState.Handled)
+        {
+          session.Events.IncrementHandledCount();
+        }
+        else
+        {
+          session.Events.IncrementUnhandledCount();
+        }
+      }
       this.AddToPayload("user", user);
     }
 


### PR DESCRIPTION
## Goal

Session event counts were being incremented _after_ the event is sent, rather than including a self-referencing increment in a report.

## Changeset

* Increment the session event count in the `Event` constructor based on whether the event is handled or unhandled.

## Tests

Added new end-to-end tests for logging a session and:

* Validating the payload fields
* Adding a handled event
* Adding an unhandled event
* Adding a mix of events

## Review

What's needed for review:

- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
