### PR TITLE
fix: Match minimum supported versions with bugsnag-cocoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Lower minimum supported iOS version to 8.0 from 9.0
+* Lower minimum supported macOS version to 10.8 from 10.11
+
 ## 4.1.0 (2019-01-11)
 
 * Update dependent libraries:

--- a/Rakefile
+++ b/Rakefile
@@ -118,9 +118,9 @@ namespace :plugin do
           when "bugsnag-tvos"
             target = project.new_target(:static_library, "bugsnag-tvos", :tvos, "9.0")
           when "bugsnag-ios"
-            target = project.new_target(:static_library, "bugsnag-ios", :ios, "9.0")
+            target = project.new_target(:static_library, "bugsnag-ios", :ios, "8.0")
           when "bugsnag-osx"
-            target = project.new_target(:bundle, "bugsnag-osx", :osx, "10.11")
+            target = project.new_target(:bundle, "bugsnag-osx", :osx, "10.8")
           end
 
           group = project.new_group("Bugsnag")


### PR DESCRIPTION
## Goal

Support iOS 8+ and macOS 10.8+. The build settings were configured for iOS 9+ and macOS 10.11+.

## Changeset

Updated the build settings to create a static library targeting iOS 8.0/macOS 10.8, the minimum versions supported by bugsnag-cocoa.

## Tests

Tested on an iPhone 5s running iOS 8.4 - prior to this change, the app builds but crashes at runtime, after this change it runs as expected. 

It can also be tested and reproduced on a simulator running iOS 8 by setting Player Settings > Target SDK to "Simulator SDK".