### PR TITLE
Fix Android ReleaseStage not being set

### DIFF
--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -43,8 +43,6 @@ namespace BugsnagUnity
 
     public virtual string AppVersion { get; set; }
 
-    private string RealAppVersion { get; set; }
-
     public virtual Uri Endpoint { get; set; } = new Uri(DefaultEndpoint);
 
     public virtual string PayloadVersion { get; } = "4.0";

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -10,17 +10,19 @@ namespace BugsnagUnity
 
     public const string DefaultSessionEndpoint = "https://sessions.bugsnag.com";
 
-    public AbstractConfiguration(string apiKey)
+    public AbstractConfiguration() {}
+
+    protected void SetupDefaults(string apiKey)
     {
       ApiKey = apiKey;
       AppVersion = Application.version;
     }
 
-    public bool ReportUncaughtExceptionsAsHandled { get; set; } = true;
+    public virtual bool ReportUncaughtExceptionsAsHandled { get; set; } = true;
 
-    public TimeSpan MaximumLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(1);
+    public virtual TimeSpan MaximumLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(1);
 
-    public Dictionary<LogType, int> MaximumTypePerTimePeriod { get; set; } = new Dictionary<LogType, int>
+    public virtual Dictionary<LogType, int> MaximumTypePerTimePeriod { get; set; } = new Dictionary<LogType, int>
     {
         { LogType.Assert, 5 },
         { LogType.Error, 5 },
@@ -29,35 +31,37 @@ namespace BugsnagUnity
         { LogType.Warning, 5 },
     };
 
-    public TimeSpan UniqueLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(5);
+    public virtual TimeSpan UniqueLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(5);
 
-    public string ApiKey { get; }
+    public virtual string ApiKey { get; protected set; }
 
-    public int MaximumBreadcrumbs { get; set; } = 25;
+    public virtual int MaximumBreadcrumbs { get; set; } = 25;
 
-    public string ReleaseStage { get; set; } = "production";
+    public virtual string ReleaseStage { get; set; } = "production";
 
-    public string[] NotifyReleaseStages { get; set; }
+    public virtual string[] NotifyReleaseStages { get; set; }
 
-    public string AppVersion { get; set; }
+    public virtual string AppVersion { get; set; }
 
-    public Uri Endpoint { get; set; } = new Uri(DefaultEndpoint);
+    private string RealAppVersion { get; set; }
 
-    public string PayloadVersion { get; } = "4.0";
+    public virtual Uri Endpoint { get; set; } = new Uri(DefaultEndpoint);
 
-    public Uri SessionEndpoint { get; set; } = new Uri(DefaultSessionEndpoint);
+    public virtual string PayloadVersion { get; } = "4.0";
 
-    public string SessionPayloadVersion { get; } = "1.0";
+    public virtual Uri SessionEndpoint { get; set; } = new Uri(DefaultSessionEndpoint);
 
-    public string Context { get; set; }
+    public virtual string SessionPayloadVersion { get; } = "1.0";
 
-    public LogType NotifyLevel { get; set; } = LogType.Exception;
+    public virtual string Context { get; set; }
 
-    public bool AutoNotify { get; set; } = true;
+    public virtual LogType NotifyLevel { get; set; } = LogType.Exception;
 
-    public bool AutoCaptureSessions { get; set; }
+    public virtual bool AutoNotify { get; set; } = true;
 
-    public LogTypeSeverityMapping LogTypeSeverityMapping { get; } = new LogTypeSeverityMapping();
+    public virtual bool AutoCaptureSessions { get; set; }
+
+    public virtual LogTypeSeverityMapping LogTypeSeverityMapping { get; } = new LogTypeSeverityMapping();
   }
 }
 

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -12,7 +12,7 @@ namespace BugsnagUnity
 
     public AbstractConfiguration() {}
 
-    protected void SetupDefaults(string apiKey)
+    protected virtual void SetupDefaults(string apiKey)
     {
       ApiKey = apiKey;
       AppVersion = Application.version;

--- a/src/BugsnagUnity/Native/Android/Configuration.cs
+++ b/src/BugsnagUnity/Native/Android/Configuration.cs
@@ -8,7 +8,7 @@ namespace BugsnagUnity
   {
     internal NativeInterface NativeInterface { get; }
 
-    internal Configuration(string apiKey) : base(apiKey)
+    internal Configuration(string apiKey) : base()
     {
       var JavaObject = new AndroidJavaObject("com.bugsnag.android.Configuration", apiKey);
       // the bugsnag-unity notifier will handle session tracking
@@ -18,9 +18,10 @@ namespace BugsnagUnity
       JavaObject.Call("setReleaseStage", "production");
       JavaObject.Call("setAppVersion", Application.version);
       NativeInterface = new NativeInterface(JavaObject);
+      SetupDefaults(apiKey);
     }
 
-    public new string ReleaseStage
+    public override string ReleaseStage
     {
       set
       {
@@ -32,7 +33,7 @@ namespace BugsnagUnity
       }
     }
 
-    public new string[] NotifyReleaseStages
+    public override string[] NotifyReleaseStages
     {
       set
       {
@@ -44,7 +45,7 @@ namespace BugsnagUnity
       }
     }
 
-    public new string AppVersion
+    public override string AppVersion
     {
       set
       {
@@ -56,7 +57,7 @@ namespace BugsnagUnity
       }
     }
 
-    public new Uri Endpoint
+    public override Uri Endpoint
     {
       set
       {
@@ -68,7 +69,7 @@ namespace BugsnagUnity
       }
     }
 
-    public new Uri SessionEndpoint
+    public override Uri SessionEndpoint
     {
       set
       {
@@ -80,7 +81,7 @@ namespace BugsnagUnity
       }
     }
 
-    public new string Context
+    public override string Context
     {
       set
       {

--- a/src/BugsnagUnity/Native/Android/Configuration.cs
+++ b/src/BugsnagUnity/Native/Android/Configuration.cs
@@ -21,6 +21,14 @@ namespace BugsnagUnity
       SetupDefaults(apiKey);
     }
 
+    protected override void SetupDefaults(string apiKey)
+    {
+      base.SetupDefaults(apiKey);
+      ReleaseStage = "production";
+      Endpoint = new Uri(DefaultEndpoint);
+      SessionEndpoint = new Uri(DefaultSessionEndpoint);
+    }
+
     public override string ReleaseStage
     {
       set

--- a/src/BugsnagUnity/Native/Cocoa/Configuration.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Configuration.cs
@@ -10,20 +10,21 @@ namespace BugsnagUnity
   {
     internal IntPtr NativeConfiguration { get; }
 
-    internal Configuration(string apiKey) : base(apiKey)
+    internal Configuration(string apiKey) : base()
     {
       NativeConfiguration = NativeCode.bugsnag_createConfiguration(apiKey);
+      SetupDefaults(apiKey);
     }
 
-    public new string ApiKey => Marshal.PtrToStringAuto(NativeCode.bugsnag_getApiKey(NativeConfiguration));
+    public override string ApiKey => Marshal.PtrToStringAuto(NativeCode.bugsnag_getApiKey(NativeConfiguration));
 
-    public new string ReleaseStage
+    public override string ReleaseStage
     {
       get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getReleaseStage(NativeConfiguration));
       set => NativeCode.bugsnag_setReleaseStage(NativeConfiguration, value);
     }
 
-    public new string[] NotifyReleaseStages
+    public override string[] NotifyReleaseStages
     {
       get
       {
@@ -59,19 +60,19 @@ namespace BugsnagUnity
       }
     }
 
-    public new string AppVersion
+    public override string AppVersion
     {
       get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getAppVersion(NativeConfiguration));
       set => NativeCode.bugsnag_setAppVersion(NativeConfiguration, value);
     }
 
-    public new Uri Endpoint
+    public override Uri Endpoint
     {
       get => new Uri(Marshal.PtrToStringAuto(NativeCode.bugsnag_getNotifyUrl(NativeConfiguration)));
       set => NativeCode.bugsnag_setNotifyUrl(NativeConfiguration, value.ToString());
     }
 
-    public new string Context
+    public override string Context
     {
       get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getContext(NativeConfiguration));
       set => NativeCode.bugsnag_setContext(NativeConfiguration, value);

--- a/src/BugsnagUnity/Native/Cocoa/Configuration.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Configuration.cs
@@ -16,7 +16,18 @@ namespace BugsnagUnity
       SetupDefaults(apiKey);
     }
 
-    public override string ApiKey => Marshal.PtrToStringAuto(NativeCode.bugsnag_getApiKey(NativeConfiguration));
+    protected override void SetupDefaults(string apiKey)
+    {
+      base.SetupDefaults(apiKey);
+      ReleaseStage = "production";
+      Endpoint = new Uri(DefaultEndpoint);
+    }
+
+    public override string ApiKey
+    {
+      get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getApiKey(NativeConfiguration));
+      protected set {}
+    }
 
     public override string ReleaseStage
     {

--- a/src/BugsnagUnity/Native/Fallback/Configuration.cs
+++ b/src/BugsnagUnity/Native/Fallback/Configuration.cs
@@ -6,6 +6,8 @@ namespace BugsnagUnity
 {
   class Configuration : AbstractConfiguration
   {
-    internal Configuration(string apiKey) : base(apiKey) {}
+    internal Configuration(string apiKey) : base() {
+      SetupDefaults(apiKey);
+    }
   }
 }

--- a/tests/BugsnagUnity.Tests/ConfigurationTests.cs
+++ b/tests/BugsnagUnity.Tests/ConfigurationTests.cs
@@ -7,7 +7,9 @@ namespace BugsnagUnity.Payload.Tests
 {
   class TestConfig : AbstractConfiguration
   {
-    internal TestConfig(string apiKey) : base(apiKey) {}
+    internal TestConfig(string apiKey) : base() {
+      SetupDefaults(apiKey);
+    }
   }
 
   [TestFixture]

--- a/tests/BugsnagUnity.Tests/TestConfiguration.cs
+++ b/tests/BugsnagUnity.Tests/TestConfiguration.cs
@@ -6,6 +6,8 @@ namespace BugsnagUnity.Tests
 {
   public class TestConfiguration : AbstractConfiguration
   {
-    internal TestConfiguration(string apiKey) : base(apiKey) {}
+    internal TestConfiguration(string apiKey) : base() {
+      SetupDefaults(apiKey);
+    }
   }
 }


### PR DESCRIPTION
## Goal
Fixes an issue where the ReleaseStage wasn't being passed into the Android notifier, causing the incorrect stage to be notified.

## Tests
Should be manually verified on:
- [x] Android
- [x] iOS
- [x] Windows
- [x] OSX