### PR TITLE
Fix Delivery failure Logging

### DIFF
--- a/src/BugsnagUnity/IDelivery.cs
+++ b/src/BugsnagUnity/IDelivery.cs
@@ -110,15 +110,20 @@ namespace BugsnagUnity
         {
           // success!
         }
-        // once we can drop support for unity 5.6 we can use req.isNetworkError
-        // instead of req.error != null. According to the unity docs though this
-        // should have the same effect
+        else if (req.responseCode == 404)
+        {
+          DelayBeforeDelivery = true;
+          Send(payload);
+        }
         else if (req.responseCode >= 500)
         {
           // something is wrong with the server/connection, should retry
           DelayBeforeDelivery = true;
           Send(payload);
         }
+        // once we can drop support for unity 5.6 we can use req.isNetworkError
+        // instead of req.error != null. According to the unity docs though this
+        // should have the same effect
         else if (req.error != null)
         {
           // Something has gone wrong with the delivery

--- a/src/BugsnagUnity/IDelivery.cs
+++ b/src/BugsnagUnity/IDelivery.cs
@@ -110,14 +110,8 @@ namespace BugsnagUnity
         {
           // success!
         }
-        else if (req.responseCode == 404)
+        else if (req.responseCode == 404 || req.responseCode >= 500)
         {
-          DelayBeforeDelivery = true;
-          Send(payload);
-        }
-        else if (req.responseCode >= 500)
-        {
-          // something is wrong with the server/connection, should retry
           DelayBeforeDelivery = true;
           Send(payload);
         }

--- a/src/BugsnagUnity/IDelivery.cs
+++ b/src/BugsnagUnity/IDelivery.cs
@@ -18,6 +18,7 @@ namespace BugsnagUnity
   class Delivery : IDelivery
   {
 
+    const int DeliveryFailureDelay = 10000;
     Boolean DelayBeforeDelivery { get; set; } = false;
     Thread Worker { get; }
 
@@ -45,11 +46,10 @@ namespace BugsnagUnity
         try
         {
           if (Application.internetReachability == NetworkReachability.NotReachable) {
-            Debug.LogWarning("Bugsnag: Network not available, temporarily suspending delivery");
-            System.Threading.Thread.Sleep(10000);
+            System.Threading.Thread.Sleep(DeliveryFailureDelay);
           } else if (DelayBeforeDelivery) {
             DelayBeforeDelivery = false;
-            System.Threading.Thread.Sleep(10000);
+            System.Threading.Thread.Sleep(DeliveryFailureDelay);
           } else {
             SerializeAndDeliverPayload(Queue.Dequeue());
           }

--- a/src/BugsnagUnity/IDelivery.cs
+++ b/src/BugsnagUnity/IDelivery.cs
@@ -45,9 +45,7 @@ namespace BugsnagUnity
       {
         try
         {
-          if (Application.internetReachability == NetworkReachability.NotReachable) {
-            System.Threading.Thread.Sleep(DeliveryFailureDelay);
-          } else if (DelayBeforeDelivery) {
+          if (DelayBeforeDelivery) {
             DelayBeforeDelivery = false;
             System.Threading.Thread.Sleep(DeliveryFailureDelay);
           } else {
@@ -124,7 +122,13 @@ namespace BugsnagUnity
         else if (req.error != null)
         {
           // Something has gone wrong with the delivery
-          Debug.LogWarning("Bugsnag delivery error: " + req.error);
+          if (Application.internetReachability == NetworkReachability.NotReachable) {
+            // Retry after a delay if it's a connectivity issue
+            DelayBeforeDelivery = true;
+            Send(payload);
+          } else {
+            Debug.LogWarning("Bugsnag delivery error: " + req.error);
+          }
         }
       }
     }

--- a/src/BugsnagUnity/IDelivery.cs
+++ b/src/BugsnagUnity/IDelivery.cs
@@ -110,24 +110,14 @@ namespace BugsnagUnity
         {
           // success!
         }
-        else if (req.responseCode == 404 || req.responseCode >= 500)
-        {
-          DelayBeforeDelivery = true;
-          Send(payload);
-        }
         // once we can drop support for unity 5.6 we can use req.isNetworkError
         // instead of req.error != null. According to the unity docs though this
         // should have the same effect
-        else if (req.error != null)
+        else if (req.responseCode >= 500 || req.error != null)
         {
-          // Something has gone wrong with the delivery
-          if (Application.internetReachability == NetworkReachability.NotReachable) {
-            // Retry after a delay if it's a connectivity issue
-            DelayBeforeDelivery = true;
-            Send(payload);
-          } else {
-            Debug.LogWarning("Bugsnag delivery error: " + req.error);
-          }
+          // Something is wrong with the server/connection, retry after a delay
+          DelayBeforeDelivery = true;
+          Send(payload);
         }
       }
     }


### PR DESCRIPTION
## Goal
Ensures that there's a delay between a delivery failing and a retry to avoid log spamming.  Also delays in the case of no network connectivity.

## Test
Attached ZIP features a built package with an extra log included that should trigger in the event of a `500` response, ensuring that the correct delay occurs between delivery attempts.
[Bugsnag.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/2821733/Bugsnag.unitypackage.zip)
