### PR TITLE
feat: Report C/C++ crashes on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Add support for detecting and reporting Android NDK C/C++ crashes
+
 ## 4.1.3 (2019-02-01)
 
 ### Bug fixes

--- a/Rakefile
+++ b/Rakefile
@@ -208,7 +208,7 @@ namespace :plugin do
       android_dir = File.join(assets_path, "Android")
 
       cd "bugsnag-android" do
-        sh "./gradlew", "sdk:assembleRelease", "--quiet"
+        sh "./gradlew", "ndk:assembleRelease", "sdk:assembleRelease", "--quiet", "-PABI_FILTERS=armeabi-v7a,x86"
       end
 
       cd "bugsnag-android-unity" do
@@ -216,9 +216,11 @@ namespace :plugin do
       end
 
       android_lib = File.join("bugsnag-android", "sdk", "build", "outputs", "aar", "bugsnag-android-release.aar")
+      ndk_lib = File.join("bugsnag-android", "ndk", "build", "outputs", "aar", "bugsnag-android-ndk-release.aar")
       unity_lib = File.join("bugsnag-android-unity", "build", "outputs", "aar", "bugsnag-android-unity-release.aar")
 
       cp android_lib, android_dir
+      cp ndk_lib, android_dir
       cp unity_lib, android_dir
     end
   end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,32 @@
 Upgrading
 =========
 
+## 4.1 to 4.2
+
+4.2.0 adds support for reporting C/C++ crashes in Android code. If you are using
+the Gradle build system to export your app, you will need to add the following
+line to your exported project's build.gradle to enable this functionality:
+
+### Gradle 4.2+
+
+```groovy
+dependencies {
+  // ...
+  // add this line:
+	implementation(name: 'bugsnag-android-ndk-release', ext:'aar')
+}
+```
+
+### Gradle 2.10
+
+```groovy
+dependencies {
+  // ...
+  // add this line:
+	compile(name: 'bugsnag-android-ndk-release', ext:'aar')
+}
+```
+
 ## 3.x to 4.x
 
 *Our Unity notifier has gone through some major improvements, and there are some changes you'll need to make to get onto the new version.*

--- a/unity/PackageProject/Assets/Plugins/Android/bugsnag-android-ndk-release.aar.meta
+++ b/unity/PackageProject/Assets/Plugins/Android/bugsnag-android-ndk-release.aar.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 864a9fb00a5504c48b2dbc73a89b4a70
+timeCreated: 1548862513
+licenseType: Free
+PluginImporter:
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+    data:
+      first:
+        Android: Android
+      second:
+        enabled: 1
+        settings: {}
+    data:
+      first:
+        Any: 
+      second:
+        enabled: 0
+        settings: {}
+    data:
+      first:
+        Editor: Editor
+      second:
+        enabled: 0
+        settings:
+          DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Goal

Automatically detect and report C/C++ crashes on Android.

## Changeset

Adds bugsnag-android-ndk as a part of the default installation. No additional configuration is required.

## Tests

Updated the test app to include an NDK crash on the `kattrali/bundle-ndk` branch.

## Discussion

### Linked issues

* Related to bugsnag/docs.bugsnag.com#875
* ~Requires bugsnag/bugsnag-android#427 before release~

[Bugsnag.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/2836898/Bugsnag.unitypackage.zip)

