### PR TITLE
fix: Use fallback stacktrace for events which have no stacktrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Ensure a stacktrace is attached to reports without underlying exceptions, such
+  as log messages using an 'error' or 'warning' level
+
 ## 4.2.0 (2019-02-07)
 
 ### Enhancements

--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -83,6 +83,9 @@ public class Main : MonoBehaviour {
       case "ReportLoggedWarning":
         DoLogWarning();
         break;
+      case "ReportLoggedError":
+        DoLogError();
+        break;
       case "ReportLoggedWarningWithHandledConfig":
         DoLogWarningWithHandledConfig();
         break;
@@ -114,6 +117,11 @@ public class Main : MonoBehaviour {
   void DoLogWarning() {
     Bugsnag.Configuration.NotifyLevel = LogType.Warning;
     Debug.LogWarning("Something went terribly awry");
+  }
+
+  void DoLogError() {
+    Bugsnag.Configuration.NotifyLevel = LogType.Warning;
+    Debug.LogError("Bad bad things");
   }
 
   void DoLogWarningWithHandledConfig() {

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -56,9 +56,24 @@ Feature: Handled Errors and Exceptions
         And the exception "message" equals "Something went terribly awry"
         And the event "unhandled" is false
         And the first significant stack frame methods and files should match:
-            | Main:DoLogWarning()  |
-            | Main:LoadScenario()  |
-            | Main:Update()        |
+            | Main.DoLogWarning()  |
+            | Main.LoadScenario()  |
+            | Main.Update()        |
+
+    Scenario: Logging an error to Bugsnag
+        When I run the game in the "ReportLoggedError" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "UnityLogError"
+        And the exception "message" equals "Bad bad things"
+        And the event "unhandled" is false
+        And the first significant stack frame methods and files should match:
+            | Main.DoLogError()  |
+            | Main.LoadScenario()  |
+            | Main.Update()        |
 
     Scenario: Logging a warning to Bugsnag with 'ReportAsHandled = false'
         When I run the game in the "ReportLoggedWarningWithHandledConfig" state
@@ -71,7 +86,7 @@ Feature: Handled Errors and Exceptions
         And the exception "message" equals "Something went terribly awry"
         And the event "unhandled" is false
         And the first significant stack frame methods and files should match:
-            | Main:DoLogWarningWithHandledConfig()  |
-            | Main:LoadScenario()  |
-            | Main:Update()        |
+            | Main.DoLogWarningWithHandledConfig()  |
+            | Main.LoadScenario()  |
+            | Main.Update()        |
 

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -10,6 +10,7 @@ Then("the first significant stack frame methods and files should match:") do |ex
   stacktrace = read_key_path(find_request(0)[:body], "events.0.exceptions.0.stacktrace")
   expected_frame_values = expected_values.raw
   expected_index = 0
+  flunk("The stacktrace is empty") if stacktrace.length == 0
   stacktrace.each_with_index do |item, index|
     next if expected_index >= expected_frame_values.length
     expected_frame = expected_frame_values[expected_index]

--- a/src/BugsnagUnity/Payload/Exception.cs
+++ b/src/BugsnagUnity/Payload/Exception.cs
@@ -108,11 +108,14 @@ namespace BugsnagUnity.Payload
       return FromUnityLogMessage(logMessage, stackFrames, severity, false);
     }
 
-    public static Exception FromUnityLogMessage(UnityLogMessage logMessage, System.Diagnostics.StackFrame[] stackFrames, Severity severity, bool forceUnhandled)
+    public static Exception FromUnityLogMessage(UnityLogMessage logMessage, System.Diagnostics.StackFrame[] fallbackStackFrames, Severity severity, bool forceUnhandled)
     {
       var match = Regex.Match(logMessage.Condition, ErrorClassMessagePattern, RegexOptions.Singleline);
 
       var lines = new StackTrace(logMessage.StackTrace).ToArray();
+      if (lines.Length == 0) {
+        lines = new StackTrace(fallbackStackFrames).ToArray();
+      }
 
       var handledState = forceUnhandled
         ? HandledState.ForUnhandledException()


### PR DESCRIPTION
Capture and use a stacktrace from the notify() handle if an event is
reported without a stacktrace (such as logging a string or other non-
Exception object).

## Tests

Manually verified the behavior by logging messages, i.e. `Debug.LogError("foo")`

## Review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Idiomatic use of the language
