### PR TITLE
fix(android): Delete stale refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* (Android) Fix a crash which could occur if large amounts of metadata or
+  breadcrumbs (>500 key/value pairs) are attached at once, or if `Notify()` is
+  called concurrently several times.
+  [#132](https://github.com/bugsnag/bugsnag-unity/pull/132)
+
 ## 4.2.1 (2019-02-21)
 
 ### Bug fixes

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -390,9 +390,13 @@ namespace BugsnagUnity
             dict.AddToPayload(key, AndroidJNI.CallStringMethod(value, ObjectToString, new jvalue[]{}));
           }
           AndroidJNI.DeleteLocalRef(value);
+          AndroidJNI.DeleteLocalRef(valueClass);
         }
         AndroidJNI.DeleteLocalRef(entry);
       }
+      AndroidJNI.DeleteLocalRef(entries);
+      AndroidJNI.DeleteLocalRef(iterator);
+
       return dict;
     }
   }


### PR DESCRIPTION
## Goal

Avoid overflowing the reference table on Android when passing objects from the Java to C# layer.

## Changeset

Updated the Android `NativeInterface` function to convert a Java `Map` into a C# `Dictionary` to remove JNI reference once they are done being used.

## Tests

Reproduced the crash reported in #129 by attaching large amounts of metadata on the native side then calling `notify()` using a Nexus 5X running API 23.

## Discussion

Deleting the `valueClass` reference in particular reduces the likelihood of encountering this issue significantly, however, given enough other JNI activity at the same time (hundreds of `notify()` calls at once, other plugins processing large collections of objects) this problem would remain. There doesn't seem to be an API for checking how much of the reference table is still free though.

### Linked issues

Fixes #129
