### PR TITLE
Add mazerunner scenarios for StopSession and ResumeSession

### DIFF
--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -106,7 +106,42 @@ public class Main : MonoBehaviour {
         DoLogWarning();
         UncaughtExceptionAsUnhandled();
         break;
+      case "StoppedSession":
+        Bugsnag.StartSession();
+        Bugsnag.StopSession();
+        DoNotify();
+        break;
+      case "ResumedSession":
+        RunResumedSession();
+        break;
+      case "NewSession":
+        RunNewSession();
+        break;
     }
+  }
+
+  void RunResumedSession() {
+    // send 1st exception which should include session info
+    Bugsnag.StartSession();
+    Bugsnag.Notify(new System.Exception("First Error"));
+
+    // send 2nd exception after resuming a session
+    Bugsnag.StopSession();
+    Bugsnag.ResumeSession();
+    Bugsnag.Notify(new System.Exception("Second Error"));
+  }
+
+  void RunNewSession() {
+    // send 1st exception which should include session info
+    Bugsnag.StartSession();
+    Bugsnag.Notify(new System.Exception("First Error"));
+
+    // stop tracking the existing session
+    Bugsnag.StopSession();
+    Bugsnag.StartSession();
+
+    // send 2nd exception which should contain new session info
+    Bugsnag.Notify(new System.Exception("Second Error"));
   }
 
   void UncaughtExceptionAsUnhandled() {

--- a/features/stopping_sessions.feature
+++ b/features/stopping_sessions.feature
@@ -1,0 +1,32 @@
+Feature: Stopping and resuming sessions
+
+Scenario: When a session is stopped the error has no session information
+    When I run the game in the "StoppedSession" state
+    Then I should receive 2 requests
+    And the request 0 is valid for the session tracking API
+    And the request 1 is valid for the error reporting API
+    And the payload field "events.0.session" is null for request 1
+
+Scenario: When a session is resumed the error uses the previous session information
+    When I run the game in the "ResumedSession" state
+    Then I should receive 3 requests
+    And the request 0 is valid for the session tracking API
+    And the request 1 is valid for the error reporting API
+    And the request 2 is valid for the error reporting API
+    And the payload field "events.0.session.id" of request 1 equals the payload field "events.0.session.id" of request 2
+    And the payload field "events.0.session.startedAt" of request 1 equals the payload field "events.0.session.startedAt" of request 2
+    And the events in requests "1,2" match one of:
+        | message      | handled | unhandled |
+        | First Error  | 1       | 0         |
+        | Second Error | 2       | 0         |
+
+Scenario: When a new session is started the error uses different session information
+    When I run the game in the "NewSession" state
+    Then I should receive 4 requests
+    And the request 0 is valid for the session tracking API
+    And the request 1 is valid for the session tracking API
+    And the request 2 is valid for the error reporting API
+    And the request 3 is valid for the error reporting API
+    And the payload field "events.0.session.events.handled" equals 1 for request 2
+    And the payload field "events.0.session.events.handled" equals 1 for request 3
+    And the payload field "events.0.session.id" of request 2 does not equal the payload field "events.0.session.id" of request 3


### PR DESCRIPTION
## Goal
Adds mazerunner coverage for verifying the `StopSession` and `ResumeSession` implementation in #136 

## Changeset
Added scenarios to:
- Start then stop a session, and verify errors sent afterwards do not contain session information
- Start then resume a session, and verify that an error sent afterwards contains the previous session information
- Stop then start a new session, and verify that an error sent afterwards does not contain the same session information as one sent previously