### PR TITLE
fix(android): Remove unneeded ABIs included

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,9 @@ jobs:
       provider: releases
       api_key:
         secure: 1TJ75ixrnryedpCBA/a3mnaHoVO6zK/vMEzjJ2mkLa/EIRVnH3MEeifetXqIf05vANF7TnqcUF4/gAt/NLNZc2Sa3NktPsXQ4lyWI4BhJuCR+BGGbbB+tlU6VAXunCljIcu3WC5OqojtYVfNqwgCfnwqg8HRlfM8XSIH0qFaYH6UG4S6iD7gkgolAouJTpZsYs0sRmxAyjLq5f6o1ZQtwjTDC6Lm3SmAVPJ0oGDFFFqVwMfTVagq1hAkja1S5YoxNrO8XU9iKW+Rd8JB4CL0CGAQ/qRnyzU/ABQnYhb4lu0eBqMo9Up7ENAarVOwkuWlbHtx7TsiOvI1+BQReqfg73D/TSMra4aTPeEaq8DGYoQc7dsRy4hS/XUKfkVrGe6UeIdcgiZvENbTcmfzsOSsbdTqJhB6zVcSLus1C5n8ZRFIZ81JS65P7vQU6VMyQTTG19xUoU3DozRPdOjnCbOeBmMWFa/ffl5N1N/KQq+CEPpHdtopcDv6iSKTShu9tm5uUoM7pj8vqI7FM9Aj3NqBaJtgJqZAtD83LbKCEBfifIAgz1uDLRoNxnbx1ua9n54ifPOiGX1mQ/LWgBhAUsyLUjaor8I1j1pVoYcpf4f9HNu/VJsUrBrK5uDwJNo/J3vDhfniYuBhsyFcsZkOtddwOdUOM6BGAOXWwJM2G3zsmKI=
-      file: build_artifacts/Bugsnag.unitypackage
+      file:
+      - build_artifacts/Bugsnag.unitypackage
+      - build_artifacts/Bugsnag-with-android-64bit.unitypackage
       draft: true
       skip_cleanup: true
       on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ env:
   - TERM=dumb
   - PATH=$HOME/Library/Python/2.7/bin:$PATH
 stages:
-- test
+- name: test
+  if: tag IS blank
 - name: deploy
   if: tag IS present
 before_install:
@@ -26,10 +27,11 @@ before_install:
 - pip install --user awscli
 - mkdir -p $TRAVIS_BUILD_DIR/build_artifacts
 - aws s3 sync s3://bugsnag-unity-artifacts/$TRAVIS_BUILD_NUMBER $TRAVIS_BUILD_DIR/build_artifacts
+install:
+- scripts/travis_build_package.sh
 after_success:
 - aws s3 sync $TRAVIS_BUILD_DIR/build_artifacts s3://bugsnag-unity-artifacts/$TRAVIS_BUILD_NUMBER
 script:
-- scripts/travis_build_package.sh
 - bundle exec rake travis:maze_runner
 jobs:
   include:
@@ -41,6 +43,8 @@ jobs:
     - UNITY_VERSION=unity-2017-4-1f1
   - stage: deploy
     script: skip
+    env:
+    - UNITY_VERSION=unity-2017-4-1f1
     deploy:
       provider: releases
       api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - ANDROID_NDK_HOME=/usr/local/share/android-ndk
   - TERM=dumb
   - PATH=$HOME/Library/Python/2.7/bin:$PATH
+  - HOMEBREW_NO_INSTALL_CLEANUP=1
 stages:
 - name: test
   if: tag IS blank

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+This release is the first to distribute Unity packages with and without 64-bit
+ABI libraries for Android. In most cases, `Bugsnag.unitypackage` is the correct
+package to use, as by default most Unity Android apps only can use 32-bit
+binaries.
+
 ### Bug fixes
 
 * [Android] Remove references to 64-bit ABIs included in the package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* [Android] Remove references to 64-bit ABIs included in the package
+
 ## 4.2.2 (2019-02-26)
 
 ### Bug fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,12 +82,7 @@ bundle exec rake plugin:maze_runner
 
 #### Pre-release
 
-- [ ] Are all changes committed?
-- [ ] Does the build pass on the CI server?
-- [ ] Has the changelog been updated?
-- [ ] Have all the version numbers been incremented? Update the version number by running `make VERSION=[number] bump`.
-- [ ] Has all new functionality been manually tested on a release build? Use `rake build` to generate an artifact to install in a new app.
-  - [ ] Is development mode disabled? Disable development mode in the Unity Build dialog when testing release builds.
+- [ ] Has all new functionality been manually tested on a release build? Disable development mode in the Unity Build dialog when testing release builds.
   - [ ] Test that a log message formatted as `SomeTitle: rest of message` generates an error titled `SomeTitle` with message `rest of message`
   - [ ] Test that a log message formatted without a colon generates an error titled `LogError<level>` with message `rest of message`
   - [ ] Ensure the example app sends the correct error for each type on iOS
@@ -107,23 +102,29 @@ bundle exec rake plugin:maze_runner
 
 #### Making the release
 
+0. Set the version number in the change log and `build.cake`
 1. Commit the changelog and version updates:
 
     ```
-    git add CHANGELOG.md
+    git add CHANGELOG.md build.cake
     git commit -m "Release v4.x.x"
-    git tag "v4.x.x"
-    git push origin master --tags
     ```
-2. [Create a new release on GitHub](https://github.com/bugsnag/bugsnag-unity/releases/new), copying the changelog entry.
-    * set the title to the tag name
-    * upload `Bugsnag.unitypackage`
+2. Make a pull request to merge the changes
+3. Once merged, tag the new release version, pushing the tag to GitHub:
+
+   ```
+   git tag v4.x.x
+   git push origin v4.x.x
+   ```
+4. Wait. The CI build will build the new package and create a draft release.
+   Verify that the release looks good, copy in the changelog entry and publish
+   the draft.
 
 #### Post-release
 
 - [ ] Have all Docs PRs been merged?
-- [ ] Can the latest release be installed by downloading the artifact from the releases page?
-- [ ] Do the installation instructions on the dashboard work using the released artefact?
-- [ ] Do the installation instructions on the docs site work using the released artefact?
-- [ ] Can a freshly created example app send an error report from a release build, using the released artefact?
-- [ ] Do the existing example apps send an error report using the released artefact?
+- [ ] Can the latest release be installed by downloading the artifacts from the releases page?
+- [ ] Do the installation instructions on the dashboard work using the released artifact?
+- [ ] Do the installation instructions on the docs site work using the released artifact?
+- [ ] Can a freshly created example app send an error report from a release build, using the released artifact?
+- [ ] Do the existing example apps send an error report using the released artifact?

--- a/Rakefile
+++ b/Rakefile
@@ -206,13 +206,14 @@ namespace :plugin do
     end
     task android: [:clean] do
       android_dir = File.join(assets_path, "Android")
+      abi_filters = "-PABI_FILTERS=armeabi-v7a,x86"
 
       cd "bugsnag-android" do
-        sh "./gradlew", "ndk:assembleRelease", "sdk:assembleRelease", "--quiet", "-PABI_FILTERS=armeabi-v7a,x86"
+        sh "./gradlew", "ndk:assembleRelease", "sdk:assembleRelease", "--quiet", abi_filters
       end
 
       cd "bugsnag-android-unity" do
-        sh "./gradlew", "assembleRelease", "--quiet"
+        sh "./gradlew", "assembleRelease", "--quiet", abi_filters
       end
 
       android_lib = File.join("bugsnag-android", "sdk", "build", "outputs", "aar", "bugsnag-android-release.aar")

--- a/bugsnag-android-unity/build.gradle
+++ b/bugsnag-android-unity/build.gradle
@@ -24,7 +24,11 @@ android {
         minSdkVersion 16
         targetSdkVersion 27
         ndk {
-            abiFilters 'arm64-v8a', 'armeabi-v7a', 'armeabi', 'x86', 'x86_64'
+            if (project.hasProperty("ABI_FILTERS")) {
+                abiFilters project.ABI_FILTERS.split(",")
+            } else {
+                abiFilters 'arm64-v8a', 'armeabi-v7a', 'armeabi', 'x86', 'x86_64'
+            }
         }
     }
 

--- a/scripts/travis_build_package.sh
+++ b/scripts/travis_build_package.sh
@@ -20,3 +20,4 @@ bundle exec rake travis:export_plugin
 
 # copy it to the directory that is being synchronised with S3
 cp Bugsnag.unitypackage $TRAVIS_BUILD_DIR/build_artifacts
+cp Bugsnag-with-android-64bit.unitypackage $TRAVIS_BUILD_DIR/build_artifacts


### PR DESCRIPTION
By default, including 64-bit libs on Android will break usability on 64-bit Android devices. This change removes them by default, but also packages a second release artifact with all ABIs included for unusual cases.
