### PR TITLE
feat: disable ANR detection in Unity notifier

### DIFF
--- a/src/BugsnagUnity/Native/Android/Configuration.cs
+++ b/src/BugsnagUnity/Native/Android/Configuration.cs
@@ -13,6 +13,7 @@ namespace BugsnagUnity
       var JavaObject = new AndroidJavaObject("com.bugsnag.android.Configuration", apiKey);
       // the bugsnag-unity notifier will handle session tracking
       JavaObject.Call("setAutoCaptureSessions", false);
+      JavaObject.Call("setDetectAnrs", false);
       JavaObject.Call("setEndpoint", DefaultEndpoint);
       JavaObject.Call("setSessionEndpoint", DefaultSessionEndpoint);
       JavaObject.Call("setReleaseStage", "production");


### PR DESCRIPTION
## Goal

Disables ANR detection in the Unity notifier until we decide to enable it at a later date.

## Changeset

Called `setDetectAnrs` on the Android Configuration object when initialising the Unity client.

## Tests

Manually tested that an ANR was not sent but other error types were in the example project.
