### PR TITLE
fix: Correctly set notifier name/version for iOS native crashes

### DIFF
--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -7,6 +7,10 @@
 #import "BSG_KSSystemInfo.h"
 #import "BSG_KSMach.h"
 
+@interface Bugsnag ()
++ (id)notifier;
+@end
+
 extern "C" {
   struct bugsnag_user {
     const char *user_id;
@@ -33,7 +37,7 @@ extern "C" {
 
   void bugsnag_setMetadata(const void *configuration, const char *tab, const char *metadata[], int metadataCount);
 
-  void bugsnag_startBugsnagWithConfiguration(const void *configuration);
+  void bugsnag_startBugsnagWithConfiguration(const void *configuration, char *notifierVersion);
 
   void *bugsnag_createBreadcrumbs(const void *configuration);
   void bugsnag_addBreadcrumb(const void *breadcrumbs, char *name, char *type, char *metadata[], int metadataCount);
@@ -135,8 +139,17 @@ void bugsnag_setMetadata(const void *configuration, const char *tab, const char 
   }
 }
 
-void bugsnag_startBugsnagWithConfiguration(const void *configuration) {
+void bugsnag_startBugsnagWithConfiguration(const void *configuration, char *notifierVersion) {
   [Bugsnag startBugsnagWithConfiguration: (__bridge BugsnagConfiguration *)configuration];
+  if (notifierVersion != NULL) {
+    NSString *ns_version = [NSString stringWithUTF8String:notifierVersion];
+    id notifier = [Bugsnag notifier];
+    [notifier setValue:@{
+        @"version": ns_version,
+        @"name": @"Bugsnag Unity (Cocoa)",
+        @"url": @"https://github.com/bugsnag/bugsnag-unity"
+    } forKey:@"details"];
+  }
 }
 
 void *bugsnag_createBreadcrumbs(const void *configuration) {

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -23,7 +23,7 @@ namespace BugsnagUnity
       using (var info = notifier.CallStatic<AndroidJavaObject>("getInstance"))
       {
         info.Call("setURL", NotifierInfo.NotifierUrl);
-        info.Call("setName", NotifierInfo.NotifierName);
+        info.Call("setName", "Bugsnag Unity (Android)");
         info.Call("setVersion", NotifierInfo.NotifierVersion);
       }
 

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -21,7 +21,7 @@ namespace BugsnagUnity
       Configuration = configuration;
       NativeConfiguration = nativeConfiguration;
 
-      NativeCode.bugsnag_startBugsnagWithConfiguration(NativeConfiguration);
+      NativeCode.bugsnag_startBugsnagWithConfiguration(NativeConfiguration, NotifierInfo.NotifierVersion);
 
       Delivery = new Delivery();
       Breadcrumbs = breadcrumbs;

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -12,7 +12,7 @@ namespace BugsnagUnity
   partial class NativeCode
   {
     [DllImport(Import)]
-    internal static extern void bugsnag_startBugsnagWithConfiguration(IntPtr configuration);
+    internal static extern void bugsnag_startBugsnagWithConfiguration(IntPtr configuration, string notifierVersion);
 
     [DllImport(Import)]
     internal static extern void bugsnag_setMetadata(IntPtr configuration, string tab, string[] metadata, int metadataCount);


### PR DESCRIPTION
Tested by booting an example app and inspecting notifier info in the payload and on the dashboard.