### PR TITLE
Session tracking fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+* Fix failure to include session info in native reports after stopping/resuming
+  a session
 * (iOS) Fix session start date formatting
 
 ## 4.4.0 (2019-04-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* (iOS) Fix session start date formatting
+
 ## 4.4.0 (2019-04-05)
 
 * Disable ANR detection in Unity notifier

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -137,7 +137,7 @@ namespace BugsnagUnity
       else
       {
         // The ancient version of the runtime used doesn't have an equivalent to GetUnixTime()
-        var startedAt = (session.StartedAt - new DateTime(1970, 1, 1, 0, 0, 0, 0)).Milliseconds;
+        var startedAt = Convert.ToInt64((session.StartedAt.ToUniversalTime() - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds);
         NativeCode.bugsnag_registerSession(session.Id.ToString(), startedAt, session.UnhandledCount(), session.HandledCount());
       }
     }

--- a/src/BugsnagUnity/SessionTracker.cs
+++ b/src/BugsnagUnity/SessionTracker.cs
@@ -65,8 +65,8 @@ namespace BugsnagUnity
 
       if (session != null) {
         session.Stopped = true;
+        Client.NativeClient.SetSession(null);
       }
-      Client.NativeClient.SetSession(null);
     }
 
     public bool ResumeSession()

--- a/src/BugsnagUnity/SessionTracker.cs
+++ b/src/BugsnagUnity/SessionTracker.cs
@@ -80,6 +80,7 @@ namespace BugsnagUnity
       } else {
         resumed = session.Stopped;
         session.Stopped = false;
+        Client.NativeClient.SetSession(session);
       }
       return resumed;
     }


### PR DESCRIPTION
Fix subtle bugs in the session tracking implementation.

1. (iOS only) Set the correct date for the start of sessions
2. Ensure that resumed sessions notify the native layer to synchronize the change
3. Skips notifying the native layer of a session change when stopping a session if there is no session