### PR TITLE
fix: Support Notify() on background threads by caching Application metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Fix failure to include session info in native reports after stopping/resuming
   a session
 * (iOS) Fix session start date formatting
+* Support `Notify()` on background threads by caching values from
+  `UnityEngine.Application` required for reports during Client initialization
+  [#147](https://github.com/bugsnag/bugsnag-unity/pull/147)
+
 
 ## 4.4.0 (2019-04-05)
 

--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -65,6 +65,9 @@ public class Main : MonoBehaviour {
       case "Notify":
         DoNotify();
         break;
+      case "NotifyBackground":
+        new System.Threading.Thread(() => DoNotify()).Start();
+        break;
       case "NotifyCallback":
         DoNotifyWithCallback();
         break;

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -15,6 +15,22 @@ Feature: Handled Errors and Exceptions
             | Main.LoadScenario()  |
             | Main.Update()        |
 
+    Scenario: Reporting a handled exception from a background thread
+        When I run the game in the "NotifyBackground" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "Exception"
+        And the exception "message" equals "blorb"
+        And the event "unhandled" is false
+        And the event "metaData.Unity.unityVersion" is not null
+        And the event "metaData.Unity.platform" equals "OSXPlayer"
+        And the first significant stack frame methods and files should match:
+            | Main.DoNotify()           |
+            | Main.<LoadScenario>m__0() |
+
     Scenario: Reporting a handled exception with a callback
         When I run the game in the "NotifyCallback" state
         Then I should receive a request

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -48,6 +48,7 @@ namespace BugsnagUnity
       UniqueCounter = new UniqueLogThrottle(Configuration);
       LogTypeCounter = new MaximumLogTypeCounter(Configuration);
       SessionTracking = new SessionTracker(this);
+      UnityMetadata.InitDefaultMetadata();
       NativeClient.SetMetadata(UnityMetadataKey, UnityMetadata.ForNativeClient());
 
       NativeClient.PopulateUser(User);

--- a/src/BugsnagUnity/UnityMetadata.cs
+++ b/src/BugsnagUnity/UnityMetadata.cs
@@ -5,6 +5,20 @@ namespace BugsnagUnity
 {
   class UnityMetadata
   {
+    private static Dictionary<string, string> DefaultMetadata = new Dictionary<string, string>();
+
+    internal static void InitDefaultMetadata() {
+      if (DefaultMetadata.Count > 0) {
+        return; // Already initialized
+      }
+      DefaultMetadata.Add("unityVersion", Application.unityVersion);
+      DefaultMetadata.Add("osLanguage", Application.systemLanguage.ToString());
+      DefaultMetadata.Add("platform", Application.platform.ToString());
+      DefaultMetadata.Add("version", Application.version);
+      DefaultMetadata.Add("companyName", Application.companyName);
+      DefaultMetadata.Add("productName", Application.productName);
+    }
+
     internal static Dictionary<string, string> ForNativeClient() => ForUnityException(false);
 
     internal static Dictionary<string, string> WithLogType(LogType? logType) {
@@ -18,14 +32,16 @@ namespace BugsnagUnity
       return data;
     }
 
-    private static Dictionary<string, string> ForUnityException(bool unityException) => new Dictionary<string, string> {
-      { "unityVersion", Application.unityVersion },
-      { "unityException", unityException.ToString().ToLowerInvariant() },
-      { "platform", Application.platform.ToString() },
-      { "osLanguage", Application.systemLanguage.ToString() },
-      { "version", Application.version },
-      { "companyName", Application.companyName },
-      { "productName", Application.productName },
-    };
+    private static Dictionary<string, string> ForUnityException(bool unityException) {
+      var metadata = new Dictionary<string, string> {
+        { "unityException", unityException.ToString().ToLowerInvariant() },
+      };
+
+      foreach (var pair in DefaultMetadata) {
+        metadata.Add(pair.Key, pair.Value);
+      }
+
+      return metadata;
+    }
   }
 }


### PR DESCRIPTION
## Goal

The existing implementation for loading metadata about the unity runtime accesses `Application.unityVersion` (and other properties) which should only be accessed from the main thread. Since the metadata was fetched each time `Notify()` was called, this could result in exceptions being thrown during the reporting process. This change:

1. Caches all static unity metadata during client initialization
2. Copies the metadata cache to subsequent reports

Fixing exceptions.

## Reproduction case

Add the following script to a project:

```c#
using System.Collections;
using System.Collections.Generic;
using System.Threading;
using UnityEngine;
using BugsnagUnity;

public class Runner : MonoBehaviour {
  void Start () {
    (new Thread(() => {
        Bugsnag.Notify(new System.Exception("well well well well"));
    })).Start();
  }
}
```

Then launch the project in the Unity Editor. There should be the following runtime exception:

```
get_unityVersion can only be called from the main thread.
Constructors and field initializers will be executed from the loading thread when loading a scene.
Don't use this function in the constructor or field initializers, instead move initialization code to the Awake or Start function.
UnityEngine.Application:get_unityVersion()
BugsnagUnity.UnityMetadata:ForUnityException(Boolean)
BugsnagUnity.UnityMetadata:WithLogType(Nullable`1)
BugsnagUnity.Client:Notify(Exception[], HandledState, Middleware, Nullable`1)
BugsnagUnity.Client:Notify(Exception, HandledState, Middleware, Int32)
BugsnagUnity.Client:Notify(Exception, Int32)
BugsnagUnity.Bugsnag:Notify(Exception)
Runner:<Start>m__0() (at Assets/Runner.cs:12)
```

## Changeset

* Added `UnityMetadata.DefaultMetadata` - (private) an initially empty static collection
* Added `UnityMetadata.InitDefaultMetadata()` - (internal), called during client initialization

## Tests

* Added test assertions for the metadata values
* Verified the change manually in the unity editor running Unity 5.6

## Discussion

### Alternative Approaches

* There is an annotation for automatically running a method called [`RuntimeInitializeOnLoad`](https://docs.unity3d.com/ScriptReference/RuntimeInitializeOnLoadMethodAttribute.html), however it supports only Unity 2017+

## Review

The primary concerns for this review are:

- [ ] Performance implications. Are there any?
- [ ] Is there any way to incorrectly initialize a client given this new initialization code?
- [ ] Idiomatic use of the language

For the pull request reviewer(s), this changeset has been reviewed for:
