### PR TITLE
fix: Subscribe to logMessageReceived for better stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 * Support `Notify()` on background threads by caching values from
   `UnityEngine.Application` required for reports during Client initialization
   [#147](https://github.com/bugsnag/bugsnag-unity/pull/147)
+* Improve the number of stacktrace frames gathered on Unity 2017.x by
+  subscribing to the `logMessageReceived` callback in addition to
+  `logMessageReceivedThreaded` and filtering by thread to remove duplicates. The
+  main thread-only `logMessageReceived` callback receives more stackframes on
+  some versions of Unity 2017, improving the debugging experience.
 
 
 ## 4.4.0 (2019-04-05)

--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -89,6 +89,9 @@ public class Main : MonoBehaviour {
       case "LogUnthrownAsUnhandled":
         DoLogUnthrownAsUnhandled();
         break;
+      case "ReportLoggedWarningThreaded":
+        new System.Threading.Thread(() => DoLogWarning()).Start();
+        break;
       case "ReportLoggedWarning":
         DoLogWarning();
         break;

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -93,6 +93,19 @@ Feature: Handled Errors and Exceptions
             | Main:LoadScenario()  |
             | Main:Update()        |
 
+    Scenario: Logging a warning from a background thread to Bugsnag
+        When I run the game in the "ReportLoggedWarningThreaded" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "UnityLogWarning"
+        And the exception "message" equals "Something went terribly awry"
+        And the event "unhandled" is false
+        And the first significant stack frame methods and files should match:
+            | Main.DoLogWarning()       |
+
     Scenario: Logging a warning to Bugsnag
         When I run the game in the "ReportLoggedWarning" state
         Then I should receive a request

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -15,6 +15,7 @@ Then("the first significant stack frame methods and files should match:") do |ex
     next if expected_index >= expected_frame_values.length
     expected_frame = expected_frame_values[expected_index]
     next if item["method"].start_with? "UnityEngine"
+    next if item["method"].start_with? "BugsnagUnity"
 
     assert_equal(expected_frame[0], item["method"])
     expected_index += 1

--- a/tests/UnityEngine/Application.cs
+++ b/tests/UnityEngine/Application.cs
@@ -45,8 +45,12 @@ namespace UnityEngine
 
     public static void logMessageReceivedThreaded() {}
 
+    public static void logMessageReceived() {}
+
     public static void add_logMessageReceivedThreaded(LogCallback cb) {}
-    
+
+    public static void add_logMessageReceived(LogCallback cb) {}
+
     public delegate void LogCallback(string condition, string stackTrace, LogType type);
   }
 }


### PR DESCRIPTION
## Goal

Improve the number of stacktrace frames gathered on Unity 2017.x by subscribing to the `logMessageReceived` callback in addition to `logMessageReceivedThreaded` and filtering by thread to remove duplicates. The main thread-only `logMessageReceived` callback receives more stackframes on some versions of Unity 2017 when using IL2CPP on Android, improving the debugging experience.

## Changeset

* Added `Client.MultiThreadedNotify` (internal): Subscribes to `logMessageReceivedThreaded` and only reports log messages on background threads of a sufficient log level
* Subscribed to `Application.logMessageReceived`

## Tests

* Tested manually on Unity 5.6, 2017.4, 2018.3, 2019.1 by logging in the foreground and background

## Review Topics

* [ ] Concurrency concerns
* [ ] Usage friction
- [ ] Idiomatic use of the language