### PR TITLE
Migrate version information to device.runtimeVersions

### DIFF
--- a/src/Assets/Standard Assets/Bugsnag/BugsnagBehaviour.cs
+++ b/src/Assets/Standard Assets/Bugsnag/BugsnagBehaviour.cs
@@ -44,6 +44,10 @@ namespace BugsnagUnity
       Bugsnag.Configuration.NotifyLevel = NotifyLevel;
       Bugsnag.Configuration.ReleaseStage = Debug.isDebugBuild ? "development" : "production";
       Bugsnag.Configuration.MaximumBreadcrumbs = MaximumBreadcrumbs;
+
+      Bugsnag.Configuration.ScriptingBackend = FindScriptingBackend();
+      Bugsnag.Configuration.DotnetScriptingRuntime = FindDotnetScriptingRuntime();
+      Bugsnag.Configuration.DotnetApiCompatibility = FindDotnetApiCompatibility();
     }
 
     /// <summary>
@@ -64,6 +68,34 @@ namespace BugsnagUnity
     {
       var hasFocus = !paused;
       Bugsnag.SetApplicationState(hasFocus);
+    }
+
+    /*** Determine runtime versions ***/
+
+    private static string FindScriptingBackend() {
+#if ENABLE_MONO
+      return "Mono";
+#elif ENABLE_IL2CPP
+      return "IL2CPP";
+#else
+      return "Unknown";
+#endif
+    }
+
+    private static string FindDotnetScriptingRuntime() {
+#if NET_4_6
+      return ".NET 4.6 equivalent";
+#else
+      return ".NET 3.5 equivalent";
+#endif
+    }
+
+    private static string FindDotnetApiCompatibility() {
+#if NET_2_0_SUBSET
+      return ".NET 2.0 Subset";
+#else
+      return ".NET 2.0";
+#endif
     }
   }
 

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -263,7 +263,7 @@ void bugsnag_retrieveDeviceData(const void *deviceData, void (*callback)(const v
   callback(deviceData, "model", [sysInfo[@BSG_KSSystemField_Machine] UTF8String]);
   callback(deviceData, "modelNumber", [sysInfo[@BSG_KSSystemField_Model] UTF8String]);
   callback(deviceData, "osName", [sysInfo[@BSG_KSSystemField_SystemName] UTF8String]);
-  callback(deviceData, "osVersion", [sysInfo[@BSG_KSSystemField_SystemVersion] UTF8String]);
+  callback(deviceData, "osBuild", [sysInfo[@BSG_KSSystemField_SystemVersion] UTF8String]);
 }
 
 void bugsnag_populateUser(bugsnag_user *user) {

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -177,6 +177,8 @@ namespace BugsnagUnity
       NativeClient.PopulateApp(app);
       var device = new Device();
       NativeClient.PopulateDevice(device);
+      device.AddRuntimeVersions(Configuration);
+
       var metadata = new Metadata();
       NativeClient.PopulateMetadata(metadata);
 

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -60,6 +60,12 @@ namespace BugsnagUnity
     public virtual bool AutoCaptureSessions { get; set; }
 
     public virtual LogTypeSeverityMapping LogTypeSeverityMapping { get; } = new LogTypeSeverityMapping();
+
+    public virtual string ScriptingBackend { get; set; }
+
+    public virtual string DotnetScriptingRuntime { get; set; }
+
+    public virtual string DotnetApiCompatibility { get; set; }
   }
 }
 

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -41,5 +41,10 @@ namespace BugsnagUnity
     bool AutoCaptureSessions { get; set; }
 
     LogTypeSeverityMapping LogTypeSeverityMapping { get; }
+    string ScriptingBackend { get; set; }
+
+    string DotnetScriptingRuntime { get; set; }
+
+    string DotnetApiCompatibility { get; set; }
   }
 }

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -38,7 +38,13 @@ namespace BugsnagUnity
 
     public void PopulateDevice(Device device)
     {
-      MergeDictionaries(device, NativeInterface.GetDeviceData());
+      Dictionary<string, object> runtimeVersions = (Dictionary<string, object>) device.Get("runtimeVersions");
+      Dictionary<string, object> deviceData = NativeInterface.GetDeviceData();
+      Dictionary<string, object> nativeVersions = (Dictionary<string, object>) deviceData.Get("runtimeVersions");
+
+      deviceData.Remove("runtimeVersions"); // don't overwrite the unity version values
+      MergeDictionaries(device, deviceData);
+      MergeDictionaries(runtimeVersions, nativeVersions); // merge the native version values
     }
 
     public void PopulateUser(User user)

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -92,6 +92,10 @@ namespace BugsnagUnity
                 break;
             }
             break;
+          case "osBuild": // add to nested runtimeVersions dictionary
+            Dictionary<string, object> runtimeVersions = (Dictionary<string, object>) device.Get("runtimeVersions");
+            runtimeVersions.AddToPayload(key, value);
+            break;
           default:
             device.AddToPayload(key, value);
             break;

--- a/src/BugsnagUnity/Payload/Device.cs
+++ b/src/BugsnagUnity/Payload/Device.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using UnityEngine;
+using BugsnagUnity;
 
 namespace BugsnagUnity.Payload
 {
@@ -31,6 +33,18 @@ namespace BugsnagUnity.Payload
         this.AddToPayload("osName", matches.Groups["osName"].Value);
         this.AddToPayload("osVersion", matches.Groups["osVersion"].Value);
       }
+
+      var versions = new Dictionary<string, object>() {
+        {"unity", Application.unityVersion}
+      };
+      this.AddToPayload("runtimeVersions", versions);
+    }
+
+    internal void AddRuntimeVersions(IConfiguration config) {
+      var versions = (Dictionary<string, object>) this.Get("runtimeVersions");
+      versions.AddToPayload("unityScriptingBackend", config.ScriptingBackend);
+      versions.AddToPayload("dotnetScriptingRuntime", config.DotnetScriptingRuntime);
+      versions.AddToPayload("dotnetApiCompatibility", config.DotnetApiCompatibility);
     }
 
     /// <summary>

--- a/src/BugsnagUnity/SessionTracker.cs
+++ b/src/BugsnagUnity/SessionTracker.cs
@@ -53,6 +53,7 @@ namespace BugsnagUnity
       Client.NativeClient.PopulateApp(app);
       var device = new Device();
       Client.NativeClient.PopulateDevice(device);
+      device.AddRuntimeVersions(Client.Configuration);
 
       var payload = new SessionReport(Client.Configuration, app, device, Client.User, session);
 

--- a/src/BugsnagUnity/UnityMetadata.cs
+++ b/src/BugsnagUnity/UnityMetadata.cs
@@ -11,7 +11,6 @@ namespace BugsnagUnity
       if (DefaultMetadata.Count > 0) {
         return; // Already initialized
       }
-      DefaultMetadata.Add("unityVersion", Application.unityVersion);
       DefaultMetadata.Add("osLanguage", Application.systemLanguage.ToString());
       DefaultMetadata.Add("platform", Application.platform.ToString());
       DefaultMetadata.Add("version", Application.version);


### PR DESCRIPTION
## Goal
We should collect the unity version in `device.runtimeVersions.unity` for all error reports and sessions, and also capture additional runtime version metadata:

`unityScriptingBackend`: Mono or IL2CPP
`dotNetScriptingRuntime`: 3.5 or 4.6
`dotNetApiCompatibility`: 2.0 or 2.0 subset

## Changeset
- Moved existing `unity` field to `device.runtimeVersions.unity`
- Collected new runtime version information through use of [preprocessor macros](https://docs.unity3d.com/Manual/PlatformDependentCompilation.html) in the user script, which set fields on `Configuration`
- Collect existing fields from native layers on iOS + Android

## Tests
Ran existing tests. Mazerunner scenarios will be added in a separate PR. I have only tested these changes on iOS + Android.
