### PR TITLE
fix(android): Fix null pointer deref in StopSession()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* (Android) Fix null pointer dereference when calling Bugsnag.StopSession()
+
 ## 4.5.1 (2019-05-28)
 
 ### Bug fixes

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -183,7 +183,7 @@ namespace BugsnagUnity
       if (session == null) {
         // Clear session
         CallNativeVoidMethod("registerSession", "(JLjava/lang/String;II)V", new object[]{
-          IntPtr.Zero, session.Id.ToString(), 0, 0
+          IntPtr.Zero, IntPtr.Zero, 0, 0
         });
       } else {
         // The ancient version of the runtime used doesn't have an equivalent to GetUnixTime()


### PR DESCRIPTION
## Changeset

* `Android/NativeInterface.SetSession()` referenced `session.Id` when session was null. Replaced the call with `IntPtr.Zero`.

## Tests

* Reproduced manually using the v4.5.1 release
* Verified change using package built against this changeset:
  * [Bugsnag-with-android-64bit.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/3286950/Bugsnag-with-android-64bit.unitypackage.zip)
  * [Bugsnag.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/3286951/Bugsnag.unitypackage.zip)
