### PR TITLE
fix: Synchronize C# metadata changes with native layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Bug fixes
 
+* Show report metadata added using `Bugsnag.Metadata.Add()` in native crash
+  reports
+  [#157](https://github.com/bugsnag/bugsnag-unity/pull/157)
 * (Android) Fix null pointer dereference when calling Bugsnag.StopSession()
 * Update bugsnag-cocoa dependency to v5.22.2:
   * Fix trimming the stacktraces of handled error/exceptions using the

--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -33,6 +33,24 @@ public class Main : MonoBehaviour {
 
   bool sent = false;
 
+  public void Start() {
+    // Add different varieties of custom metadata
+    Bugsnag.Metadata.Add("init", new Dictionary<string, string>(){
+      {"foo", "bar" },
+    });
+    Bugsnag.Metadata.Add("custom", new Dictionary<string, object>(){
+      {"letter", "QX" },
+      {"better", 400 },
+      {"setter", new OtherMetadata() },
+    });
+    Bugsnag.Metadata.Add("app", new Dictionary<string, string>(){
+      {"buildno", "0.1" },
+      {"cache", null },
+    });
+    // Remove a tab
+    Bugsnag.Metadata.Remove("init");
+  }
+
   void Update() {
     // only send one crash
     if (!sent) {
@@ -224,6 +242,9 @@ public class Main : MonoBehaviour {
     Bugsnag.Notify(new System.Exception("blorb"), report => {
       report.Exceptions[0].ErrorClass = "FunnyBusiness";
       report.Exceptions[0].ErrorMessage = "cake";
+      report.Metadata.Add("shape", new Dictionary<string, string>() {
+        { "arc", "yes" },
+      });
     });
   }
 
@@ -253,6 +274,12 @@ public class Main : MonoBehaviour {
   void MakeAssertionFailure(int counter) {
     var items = new int[]{1, 2, 3};
     Debug.Log("Item4 is: " + items[counter]);
+  }
+}
+
+class OtherMetadata {
+  public override string ToString() {
+    return "more stuff";
   }
 }
 

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -10,6 +10,7 @@ Feature: Handled Errors and Exceptions
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "blorb"
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.DoNotify()      |
             | Main.LoadScenario()  |
@@ -25,6 +26,7 @@ Feature: Handled Errors and Exceptions
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "blorb"
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the event "device.runtimeVersions.unity" is not null
         And the event "device.runtimeVersions.unityScriptingBackend" is not null
         And the event "device.runtimeVersions.dotnetScriptingRuntime" is not null
@@ -44,6 +46,8 @@ Feature: Handled Errors and Exceptions
         And the exception "errorClass" equals "FunnyBusiness"
         And the exception "message" equals "cake"
         And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the event "metaData.shape.arc" equals "yes"
         And the first significant stack frame methods and files should match:
             | Main.DoNotifyWithCallback() |
             | Main.LoadScenario()         |
@@ -61,6 +65,7 @@ Feature: Handled Errors and Exceptions
         And the event "severity" equals "info"
         And the event "severityReason.type" equals "userSpecifiedSeverity"
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.DoNotifyWithSeverity() |
             | Main.LoadScenario()         |
@@ -76,6 +81,7 @@ Feature: Handled Errors and Exceptions
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "auth failed!"
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main:DoLogUnthrown() |
             | Main:LoadScenario()  |
@@ -91,6 +97,7 @@ Feature: Handled Errors and Exceptions
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "WAT"
         And the event "unhandled" is true
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main:DoLogUnthrownAsUnhandled() |
             | Main:LoadScenario()  |
@@ -106,6 +113,7 @@ Feature: Handled Errors and Exceptions
         And the exception "errorClass" equals "UnityLogWarning"
         And the exception "message" equals "Something went terribly awry"
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.DoLogWarning()       |
 
@@ -119,6 +127,7 @@ Feature: Handled Errors and Exceptions
         And the exception "errorClass" equals "UnityLogWarning"
         And the exception "message" equals "Something went terribly awry"
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.DoLogWarning()  |
             | Main.LoadScenario()  |
@@ -134,6 +143,7 @@ Feature: Handled Errors and Exceptions
         And the exception "errorClass" equals "UnityLogError"
         And the exception "message" equals "Bad bad things"
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.DoLogError()  |
             | Main.LoadScenario()  |
@@ -149,6 +159,7 @@ Feature: Handled Errors and Exceptions
         And the exception "errorClass" equals "UnityLogWarning"
         And the exception "message" equals "Something went terribly awry"
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.DoLogWarningWithHandledConfig()  |
             | Main.LoadScenario()  |

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -36,3 +36,13 @@ Then("the events in requests {string} match one of:") do |request_indices, table
     end, "No event matches the following values: #{values}")
   end
 end
+Then("custom metadata is included in the event") do
+  steps %Q{
+    Then the event "metaData.app.buildno" equals "0.1"
+    And the event "metaData.app.cache" is null
+    And the event "metaData.init" is null
+    And the event "metaData.custom.letter" equals "QX"
+    And the event "metaData.custom.better" equals "400"
+    And the event "metaData.custom.setter" equals "more stuff"
+  }
+end

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -10,6 +10,7 @@ Feature: Reporting unhandled events
         And the exception "errorClass" equals "ExecutionEngineException"
         And the exception "message" equals "Promise Rejection"
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.DoUnhandledException(Int64 counter) |
             | Main.LoadScenario()         |
@@ -25,6 +26,7 @@ Feature: Reporting unhandled events
         And the exception "errorClass" equals "ExecutionEngineException"
         And the exception "message" equals "Invariant state failure"
         And the event "unhandled" is true
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.UncaughtExceptionAsUnhandled() |
             | Main.LoadScenario()         |
@@ -40,6 +42,7 @@ Feature: Reporting unhandled events
         And the exception "errorClass" equals "IndexOutOfRangeException"
         And the exception "message" equals "Array index is out of range."
         And the event "unhandled" is false
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.MakeAssertionFailure(Int32 counter) |
             | Main.LoadScenario()                      |
@@ -55,6 +58,7 @@ Feature: Reporting unhandled events
         And the payload field "events" is an array with 1 element
         And the exception "errorClass" equals "SIGABRT"
         And the event "unhandled" is true
+        And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | __pthread_kill       |
             | abort                |

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -36,6 +36,7 @@ extern "C" {
   const char *bugsnag_getNotifyUrl(const void *configuration);
 
   void bugsnag_setMetadata(const void *configuration, const char *tab, const char *metadata[], int metadataCount);
+  void bugsnag_removeMetadata(const void *configuration, const char *tab);
 
   void bugsnag_startBugsnagWithConfiguration(const void *configuration, char *notifierVersion);
 
@@ -134,10 +135,25 @@ void bugsnag_setMetadata(const void *configuration, const char *tab, const char 
   NSString *tabName = [NSString stringWithUTF8String: tab];
 
   for (size_t i = 0; i < metadataCount; i += 2) {
-    [ns_configuration.metaData addAttribute: [NSString stringWithUTF8String: metadata[i]]
-                                  withValue: [NSString stringWithUTF8String: metadata[i+1]]
-                              toTabWithName: tabName];
+    NSString *key = metadata[i] != NULL
+        ? [NSString stringWithUTF8String:metadata[i]]
+        : nil;
+    NSString *value = metadata[i+1] != NULL
+        ? [NSString stringWithUTF8String:metadata[i+1]]
+        : nil;
+    [ns_configuration.metaData addAttribute:key
+                                  withValue:value
+                              toTabWithName:tabName];
   }
+}
+
+void bugsnag_removeMetadata(const void *configuration, const char *tab) {
+  BugsnagConfiguration *ns_configuration = (__bridge BugsnagConfiguration *)configuration;
+  if (tab == NULL)
+    return;
+
+  NSString *tabName = [NSString stringWithUTF8String:tab];
+  [ns_configuration.metaData clearTab:tabName];
 }
 
 void bugsnag_startBugsnagWithConfiguration(const void *configuration, char *notifierVersion) {

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -57,7 +57,7 @@ namespace BugsnagUnity
       NativeClient = nativeClient;
       User = new User { Id = SystemInfo.deviceUniqueIdentifier };
       Middleware = new List<Middleware>();
-      Metadata = new Metadata();
+      Metadata = new Metadata(nativeClient);
       UniqueCounter = new UniqueLogThrottle(Configuration);
       LogTypeCounter = new MaximumLogTypeCounter(Configuration);
       SessionTracking = new SessionTracker(this);

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -56,9 +56,13 @@ namespace BugsnagUnity
 
     public void SetMetadata(string tab, Dictionary<string, string> metadata)
     {
-      foreach (var item in metadata)
-      {
-        NativeInterface.AddToTab(tab, item.Key, item.Value);
+      if (metadata != null) {
+        foreach (var item in metadata)
+        {
+          NativeInterface.AddToTab(tab, item.Key, item.Value);
+        }
+      } else {
+        NativeInterface.RemoveMetadata(tab);
       }
     }
 

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -211,7 +211,17 @@ namespace BugsnagUnity
       return GetJavaMapData("getUserData");
     }
 
+    public void RemoveMetadata(string tab) {
+      if (tab == null) {
+        return;
+      }
+      CallNativeVoidMethod("clearTab", "(Ljava/lang/String;)V", new object[]{tab});
+    }
+
     public void AddToTab(string tab, string key, string value) {
+      if (tab == null || key == null) {
+        return;
+      }
       CallNativeVoidMethod("addToTab", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V", new object[]{tab, key, value});
     }
 

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -15,7 +15,7 @@ namespace BugsnagUnity
     public IDelivery Delivery { get; }
 
     IntPtr NativeConfiguration { get; }
-    
+
     NativeClient(IConfiguration configuration, IntPtr nativeConfiguration, IBreadcrumbs breadcrumbs)
     {
       Configuration = configuration;
@@ -115,16 +115,23 @@ namespace BugsnagUnity
     public void SetMetadata(string tab, Dictionary<string, string> unityMetadata)
     {
       var index = 0;
-      var metadata = new string[unityMetadata.Count * 2];
+      var count = 0;
+      if (unityMetadata != null) {
+        var metadata = new string[unityMetadata.Count * 2];
 
-      foreach (var data in unityMetadata)
-      {
-        metadata[index] = data.Key;
-        metadata[index + 1] = data.Value;
-        index += 2;
+        foreach (var data in unityMetadata)
+        {
+          if (data.Key != null) {
+            metadata[index] = data.Key;
+            metadata[index + 1] = data.Value;
+            count += 2;
+          }
+          index += 2;
+        }
+        NativeCode.bugsnag_setMetadata(NativeConfiguration, tab, metadata, count);
+      } else {
+        NativeCode.bugsnag_removeMetadata(NativeConfiguration, tab);
       }
-
-      NativeCode.bugsnag_setMetadata(NativeConfiguration, tab, metadata, metadata.Length);
     }
 
     public void PopulateMetadata(Metadata metadata)

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -18,6 +18,9 @@ namespace BugsnagUnity
     internal static extern void bugsnag_setMetadata(IntPtr configuration, string tab, string[] metadata, int metadataCount);
 
     [DllImport(Import)]
+    internal static extern void bugsnag_removeMetadata(IntPtr configuration, string tab);
+
+    [DllImport(Import)]
     internal static extern void bugsnag_retrieveAppData(IntPtr instance, Action<IntPtr, string, string> populate);
 
     [DllImport(Import)]

--- a/src/BugsnagUnity/Payload/Metadata.cs
+++ b/src/BugsnagUnity/Payload/Metadata.cs
@@ -1,8 +1,42 @@
 ﻿using System.Collections.Generic;
+using BugsnagUnity;
 
 namespace BugsnagUnity.Payload
 {
   public class Metadata : Dictionary<string, object>, IFilterable
   {
+    private INativeClient NativeClient = null;
+
+    public Metadata() {
+    }
+
+    internal Metadata(INativeClient nativeClient) {
+      NativeClient = nativeClient;
+    }
+
+    public void Add(string section, object newValue) {
+      if (NativeClient != null) {
+        if (newValue is Dictionary<string, string> stringValues) {
+          base.Add(section, stringValues);
+          NativeClient.SetMetadata(section, stringValues);
+        } else if (newValue is Dictionary<string, object> objectValues) {
+          var target = new Dictionary<string, string>();
+          foreach(var pair in objectValues) {
+            target.Add(pair.Key, pair.Value.ToString());
+          }
+          base.Add(section, target);
+          NativeClient.SetMetadata(section, target);
+        }
+      } else {
+        base.Add(section, newValue);
+      }
+    }
+
+    public void Remove(string section) {
+      base.Remove(section);
+      if (NativeClient != null) {
+        NativeClient.SetMetadata(section, null);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Goal

When using `Bugsnag.Metadata.Add()`, any added metadata should be synchronized with the native layer to ensure the values are sent with native crash reports as well as Unity log reports.

Example usage:

```c#
void Start() {
    Bugsnag.Metadata.Add("app", new Dictionary<string, string>(){
      {"buildno", "0.1" },
      {"package", "C" }
    });
}
```

## Changeset

* Added a `INativeClient` ref to the `Metadata` initializer
* Enhanced the `Metadata` class with custom `Add()` and `Remove()` implementations which propagate changes to the native layer
* Switches the `Report.Metadata` class to `Dictionary<string, object>` instead of `Metadata` since it requires no synchronization

Requires bugsnag/bugsnag-android#505

### Artifacts

* [Bugsnag.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/3345158/Bugsnag.unitypackage.zip) (md5: 7ff0149c7d62ab8bf74bac0650aa6190, sha1: 2e234891e3c8217ee677e401b75a481afa9f0aae)
* [Bugsnag-with-android-64bit.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/3345159/Bugsnag-with-android-64bit.unitypackage.zip) (md5: b900643ada1ca9d7d932fd742be45cd0, sha1: 408e9ac22c375d6efc41f664ad1716fdd25a2e26)


## Tests

Test handled and unhandled, native and C# crashes on each:

* [x] Test change on iOS
* [x] Test change on macOS
* [x] Test change on Android
