### PR TITLE
fix(android): Avoid using AndroidJavaObject from background threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+* (Android) Disable reporting for crashes on background threads on x86 devices
+  [#161](https://github.com/bugsnag/bugsnag-unity/pull/161)
 * (Android) Discard duplicate reports for C/C++ exceptions reporting when Unity
   Cloud Diagnostics is enabled
 


### PR DESCRIPTION
## Goal

Work around an [issue](https://issuetracker.unity3d.com/issues/androidjava-star-is-crashing-when-used-from-custom-threads) present in Unity 2017/2018 where instantiating `AndroidJavaObject` or using `AndroidJavaObject.Call()` (event indirectly using `AndroidJNI` helpers) crashes when called from a background thread on x86. This change removes use of JNI APIs when on background threads and running on x86 Android.

## Changeset

Added a reference to the main thread to the Android `NativeInterface` class, which is checked by functions before invoking the JNI, exiting early if the current thread is not the main thread.

## Tests

Tested manually in Unity 2018 / Unity 2017 by calling `Notify()`, logging, leaving breadcrumbs, and causing unhandled crashes from C#, Java, and C++ code and verifying:

* the report contents match before and after the change on arm7/arm64 devices
* the report contents match before and after the change on x86 devices on the main thread
* attempted to log / `Notify()` / report a crash does not crash the app on background threads on Android x86 (though no report is sent)

The crash is known to affect:

* 2017.4.30f1
* 2018.4.2f1
* 2018.4.3f1
* 2019.1.6f1

The Android x86 target no longer builds on 2019.2 (possibly related to its [deprecation](https://unity3d.com/alpha/2019.3)), and the target is removed altogether in 2019.3 ([announcement](https://blogs.unity3d.com/2019/03/05/android-support-update-64-bit-and-app-bundles-backported-to-2017-4-lts/), [release notes](https://unity3d.com/unity/whats-new/2019.2.0)).


## Builds

[Bugsnag.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/3508910/Bugsnag.unitypackage.zip)
```
md5 31242f4a72103c68f61d54606f732a9c
8308d01be795a00fd7877eb516e8a2175279de0d
```

[Bugsnag-with-android-64bit.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/3508911/Bugsnag-with-android-64bit.unitypackage.zip)
```
md5 099c31d986190ae73236229d297a1395
sha 9b1d3423023988dad05183ca2f35d6ff19c5de10
```