### PR TITLE
fix(android): Discard duplicate NDK reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* (Android) Discard duplicate reports for C/C++ exceptions reporting when Unity
+  Cloud Diagnostics is enabled
+
 ## 4.6.1 (2019-07-16)
 
 ### Bug fixes

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -122,17 +122,16 @@ namespace BugsnagUnity
       if (Configuration.AutoNotify && logType.IsGreaterThanOrEqualTo(Configuration.NotifyLevel))
       {
         var logMessage = new UnityLogMessage(condition, stackTrace, logType);
-
-        if (UniqueCounter.ShouldSend(logMessage))
+        var shouldSend = Exception.ShouldSend(logMessage)
+          && UniqueCounter.ShouldSend(logMessage) 
+          && LogTypeCounter.ShouldSend(logMessage);
+        if (shouldSend)
         {
-          if (LogTypeCounter.ShouldSend(logMessage))
-          {
-            var severity = Configuration.LogTypeSeverityMapping.Map(logType);
-            var backupStackFrames = new System.Diagnostics.StackTrace(1, true).GetFrames();
-            var forceUnhandled = logType == LogType.Exception && !Configuration.ReportUncaughtExceptionsAsHandled;
-            var exception = Exception.FromUnityLogMessage(logMessage, backupStackFrames, severity, forceUnhandled);
-            Notify(new Exception[]{exception}, exception.HandledState, null, logType);
-          }
+          var severity = Configuration.LogTypeSeverityMapping.Map(logType);
+          var backupStackFrames = new System.Diagnostics.StackTrace(1, true).GetFrames();
+          var forceUnhandled = logType == LogType.Exception && !Configuration.ReportUncaughtExceptionsAsHandled;
+          var exception = Exception.FromUnityLogMessage(logMessage, backupStackFrames, severity, forceUnhandled);
+          Notify(new Exception[]{exception}, exception.HandledState, null, logType);
         }
       }
       else

--- a/tests/BugsnagUnity.Tests/ExceptionTests.cs
+++ b/tests/BugsnagUnity.Tests/ExceptionTests.cs
@@ -21,6 +21,7 @@ namespace BugsnagUnity.Payload.Tests
    UnityEngine.EventSystems.ExecuteEvents.Execute[IPointerClickHandler] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.EventFunction`1 functor) [0x00000] in <filename unknown>:0";
       var logType = UnityEngine.LogType.Error;
       var log = new UnityLogMessage(condition, stacktrace, logType);
+      Assert.True(Exception.ShouldSend(log));
 
       var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {}, Severity.Info);
       var stack = exception.StackTrace.ToList();
@@ -51,6 +52,20 @@ namespace BugsnagUnity.Payload.Tests
     }
 
     [Test]
+    public void ParseDuplicateAndroidExceptionFromLogMessage()
+    {
+      string condition = "AndroidJavaException: java.lang.Error";
+      string stacktrace = @"java.lang.Error: signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0102192a9accb1876a
+libunity.0033c25b(Unknown:-2)
+libunity.003606e3(Unknown:-2)
+libbugsnag-ndk.bsg_handle_signal(bsg_handle_signal:472)
+app_process64.000d1b11(Unknown:-2)";
+      var logType = UnityEngine.LogType.Error;
+      var log = new UnityLogMessage(condition, stacktrace, logType);
+      Assert.False(Exception.ShouldSend(log));
+    }
+
+    [Test]
     public void ParseAndroidExceptionFromLogMessage()
     {
       string condition = "AndroidJavaException: java.lang.IllegalArgumentException";
@@ -59,6 +74,7 @@ com.example.bugsnagcrashplugin.CrashHelper.UnhandledCrash(CrashHelper.java:11)
 com.unity3d.player.UnityPlayer.nativeRender(Native Method)";
       var logType = UnityEngine.LogType.Error;
       var log = new UnityLogMessage(condition, stacktrace, logType);
+      Assert.True(Exception.ShouldSend(log));
       var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {}, Severity.Warning);
       var stack = exception.StackTrace.ToList();
       Assert.AreEqual("java.lang.IllegalArgumentException", exception.ErrorClass);
@@ -92,6 +108,7 @@ UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData,
 UnityEngine.EventSystems.EventSystem:Update()";
       var logType = UnityEngine.LogType.Error;
       var log = new UnityLogMessage(condition, stacktrace, logType);
+      Assert.True(Exception.ShouldSend(log));
 
       var exception = Exception.FromUnityLogMessage(log, new System.Diagnostics.StackFrame[] {}, Severity.Warning);
       var stack = exception.StackTrace.ToList();


### PR DESCRIPTION
In the event that a crash occurs from C/C++ code and Unity Cloud 
Diagnostics is enabled, an Exception-level log message is generated and
captured by the bugsnag-unity log handler, effectively re-reporting the
same exception but in an unsymbolicated format as a Java Error.

This changeset adds a check for the presence of the bugsnag crash
reporting library in the log message stacktrace, indicating the report
was previously handled by bugsnag-unity.

## Design

 bugsnag-unity error detection includes two components:

* Native crash handling (POSIX signals, C++ exception, etc)
* Unity log handling (specifically for the Exception log level)

When the bugsnag-unity library is installed, it saves a reference to the crash handler which was installed before bugsnag (usually the system handler) which will be called once bugsnag completes crash handling. By default, the system handler terminates the application and calls some cleanup functions. The Unity handler first logs an Exception-level crash to the Unity debug log, then terminates the application normally.

The result of this behavior is that after bugsnag-unity detects a native crash, it invokes the previous handler which allows Unity to log the error, which is captured a second time by Bugsnag because it includes a log handler.

A typical symbolicated stack then logged by Unity from a signal would start with:

    libunity.0033c25b(Unknown:-2)
    libunity.003606e3(Unknown:-2)
    libbugsnag-ndk.bsg_handle_signal(bsg_handle_signal:472)

And include `java.lang.Error` as the reported Java exception class.

The implemented check looks for `libbugsnag` to determine whether this report has been previously recorded. 

## Changeset

* Added `Exception.ShouldSend(UnityLogMessage)` to validate the log message to see if its from Android, is a Java exception, and includes `libbugsnag` in the stacktrace
* Added a check to the log handler (`Client.Notify(string,string,LogType)`) to ensure that `Exception.ShouldSend()` is true prior to delivery

## Tests

* Tested manually by enabling Cloud Diagnostics on a Pro account application then causing various crashes
* Added unit-level tests to `Exception.ShouldSend()`
