### PR TITLE
Add overloaded init method with autoNotify param

### DIFF
--- a/src/Assets/Standard Assets/Bugsnag/BugsnagBehaviour.cs
+++ b/src/Assets/Standard Assets/Bugsnag/BugsnagBehaviour.cs
@@ -37,7 +37,7 @@ namespace BugsnagUnity
     /// </summary>
     void Awake()
     {
-      Bugsnag.Init(BugsnagApiKey);
+      Bugsnag.Init(BugsnagApiKey, AutoNotify);
       Bugsnag.Configuration.AutoNotify = AutoNotify;
       Bugsnag.Configuration.AutoCaptureSessions = AutoCaptureSessions;
       Bugsnag.Configuration.UniqueLogsTimePeriod = TimeSpan.FromSeconds(UniqueLogsPerSecond);

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -117,6 +117,10 @@ const char *bugsnag_getContext(const void *configuration) {
   return [((__bridge BugsnagConfiguration *)configuration).context UTF8String];
 }
 
+void bugsnag_setAutoNotify(const void *configuration, BOOL autoNotify) {
+  ((__bridge BugsnagConfiguration *)configuration).autoNotify = autoNotify;
+}
+
 void bugsnag_setNotifyUrl(const void *configuration, char *notifyURL) {
   if (notifyURL == NULL)
     return;

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -30,6 +30,8 @@ extern "C" {
   void bugsnag_setAppVersion(const void *configuration, char *appVersion);
   const char *bugsnag_getAppVersion(const void *configuration);
 
+  void bugsnag_setAutoNotify(const void *configuration, bool autoNotify);
+
   void bugsnag_setContext(const void *configuration, char *context);
   const char *bugsnag_getContext(const void *configuration);
 
@@ -117,7 +119,7 @@ const char *bugsnag_getContext(const void *configuration) {
   return [((__bridge BugsnagConfiguration *)configuration).context UTF8String];
 }
 
-void bugsnag_setAutoNotify(const void *configuration, BOOL autoNotify) {
+void bugsnag_setAutoNotify(const void *configuration, bool autoNotify) {
   ((__bridge BugsnagConfiguration *)configuration).autoNotify = autoNotify;
 }
 

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -9,11 +9,16 @@ namespace BugsnagUnity
 
     public static IClient Init(string apiKey)
     {
+      return Init(apiKey, true);
+    }
+
+    public static IClient Init(string apiKey, bool autoNotify)
+    {
       lock (_clientLock)
       {
         if (InternalClient == null)
         {
-          InternalClient = new Client(new NativeClient(new Configuration(apiKey)));
+          InternalClient = new Client(new NativeClient(new Configuration(apiKey, autoNotify)));
         }
       }
 

--- a/src/BugsnagUnity/Native/Android/Configuration.cs
+++ b/src/BugsnagUnity/Native/Android/Configuration.cs
@@ -12,7 +12,7 @@ namespace BugsnagUnity
     {
       var JavaObject = new AndroidJavaObject("com.bugsnag.android.Configuration", apiKey);
       // the bugsnag-unity notifier will handle session tracking
-      JavaObject.Call("setAutoCaptureSessions", autoNotify);
+      JavaObject.Call("setAutoCaptureSessions", false);
       JavaObject.Call("setEnableExceptionHandler", autoNotify);
       JavaObject.Call("setDetectAnrs", false);
       JavaObject.Call("setDetectNdkCrashes", autoNotify);

--- a/src/BugsnagUnity/Native/Android/Configuration.cs
+++ b/src/BugsnagUnity/Native/Android/Configuration.cs
@@ -8,13 +8,14 @@ namespace BugsnagUnity
   {
     internal NativeInterface NativeInterface { get; }
 
-    internal Configuration(string apiKey) : base()
+    internal Configuration(string apiKey, bool autoNotify) : base()
     {
       var JavaObject = new AndroidJavaObject("com.bugsnag.android.Configuration", apiKey);
       // the bugsnag-unity notifier will handle session tracking
-      JavaObject.Call("setAutoCaptureSessions", false);
+      JavaObject.Call("setAutoCaptureSessions", autoNotify);
+      JavaObject.Call("setEnableExceptionHandler", autoNotify);
       JavaObject.Call("setDetectAnrs", false);
-      JavaObject.Call("setDetectNdkCrashes", true);
+      JavaObject.Call("setDetectNdkCrashes", autoNotify);
       JavaObject.Call("setEndpoint", DefaultEndpoint);
       JavaObject.Call("setSessionEndpoint", DefaultSessionEndpoint);
       JavaObject.Call("setReleaseStage", "production");

--- a/src/BugsnagUnity/Native/Android/Configuration.cs
+++ b/src/BugsnagUnity/Native/Android/Configuration.cs
@@ -22,6 +22,7 @@ namespace BugsnagUnity
       JavaObject.Call("setAppVersion", Application.version);
       NativeInterface = new NativeInterface(JavaObject);
       SetupDefaults(apiKey);
+      AutoNotify = autoNotify;
     }
 
     protected override void SetupDefaults(string apiKey)

--- a/src/BugsnagUnity/Native/Cocoa/Configuration.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Configuration.cs
@@ -15,6 +15,7 @@ namespace BugsnagUnity
       NativeConfiguration = NativeCode.bugsnag_createConfiguration(apiKey);
       SetupDefaults(apiKey);
       NativeCode.bugsnag_setAutoNotify(NativeConfiguration, autoNotify);
+      AutoNotify = autoNotify;
     }
 
     protected override void SetupDefaults(string apiKey)

--- a/src/BugsnagUnity/Native/Cocoa/Configuration.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Configuration.cs
@@ -14,6 +14,7 @@ namespace BugsnagUnity
     {
       NativeConfiguration = NativeCode.bugsnag_createConfiguration(apiKey);
       SetupDefaults(apiKey);
+      NativeCode.bugsnag_setAutoNotify(NativeConfiguration, autoNotify);
     }
 
     protected override void SetupDefaults(string apiKey)

--- a/src/BugsnagUnity/Native/Cocoa/Configuration.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Configuration.cs
@@ -10,7 +10,7 @@ namespace BugsnagUnity
   {
     internal IntPtr NativeConfiguration { get; }
 
-    internal Configuration(string apiKey) : base()
+    internal Configuration(string apiKey, bool autoNotify) : base()
     {
       NativeConfiguration = NativeCode.bugsnag_createConfiguration(apiKey);
       SetupDefaults(apiKey);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -42,6 +42,9 @@ namespace BugsnagUnity
     internal static extern IntPtr bugsnag_getReleaseStage(IntPtr configuration);
 
     [DllImport(Import)]
+    internal static extern void bugsnag_setAutoNotify(IntPtr configuration, bool autoNotify);
+
+    [DllImport(Import)]
     internal static extern void bugsnag_setContext(IntPtr configuration, string context);
 
     [DllImport(Import)]

--- a/src/BugsnagUnity/Native/Fallback/Configuration.cs
+++ b/src/BugsnagUnity/Native/Fallback/Configuration.cs
@@ -6,7 +6,7 @@ namespace BugsnagUnity
 {
   class Configuration : AbstractConfiguration
   {
-    internal Configuration(string apiKey) : base() {
+    internal Configuration(string apiKey, bool autoNotify) : base() {
       SetupDefaults(apiKey);
     }
   }

--- a/src/BugsnagUnity/Native/Fallback/Configuration.cs
+++ b/src/BugsnagUnity/Native/Fallback/Configuration.cs
@@ -8,6 +8,7 @@ namespace BugsnagUnity
   {
     internal Configuration(string apiKey, bool autoNotify) : base() {
       SetupDefaults(apiKey);
+      AutoNotify = autoNotify;
     }
   }
 }

--- a/tests/BugsnagUnity.Tests/SessionTrackerTests.cs
+++ b/tests/BugsnagUnity.Tests/SessionTrackerTests.cs
@@ -13,7 +13,7 @@ namespace BugsnagUnity.Payload.Tests
 
     public SessionTrackerTests()
     {
-      Client client = new Client(new NativeClient(new Configuration("api-key")));
+      Client client = new Client(new NativeClient(new Configuration("api-key", true)));
       Tracker = new SessionTracker(client);
       Assert.IsNotNull(Tracker);
     }


### PR DESCRIPTION
## Goal

Allows disabling of `autoNotify` functionality on Android + iOS.
