### PR TITLE
Release v4.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 4.6.4 (2019-09-06)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Support disabling native reporting during initialization
+  [#164](https://github.com/bugsnag/bugsnag-unity/pull/164)
+
+  The new API can be used as follows:
+
+  ```c#
+  Bugsnag.Init("your-api=key-here", false /* disable crash reporting */);
+  ```
+
+  or by unchecking "Auto Notify" when initializing Bugsnag via a GameObject in
+  the Unity Inspector.
+
+### Bug fixes
+
+* (Android) Fix possible crash when encoding non-unicode text
+  [#165](https://github.com/bugsnag/bugsnag-unity/pull/165)
+* (Android) Fix crash when deleting global metadata
+  [bugsnag-android#582](https://github.com/bugsnag/bugsnag-android/pull/582)
+
 ## 4.6.3 (2019-08-28)
 
 ### Bug fixes

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@ var target = Argument("target", "Default");
 var solution = File("./BugsnagUnity.sln");
 var configuration = Argument("configuration", "Release");
 var project = File("./src/BugsnagUnity/BugsnagUnity.csproj");
-var version = "4.6.3";
+var version = "4.6.4";
 
 Task("Restore-NuGet-Packages")
     .Does(() => NuGetRestore(solution));


### PR DESCRIPTION
|Builds|md5|sha1|
|-|-|-|
|[Bugsnag.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/3585412/Bugsnag.unitypackage.zip)|ae41e5647e01a37e0236fc6d17938e46|6046c84b78e21baf52efd0db634be108b76ba9ef|
|[Bugsnag-with-android-64bit.unitypackage.zip](https://github.com/bugsnag/bugsnag-unity/files/3585415/Bugsnag-with-android-64bit.unitypackage.zip)|cac5c5d9f02287690f94301444f49dd4|13bf42561da742a648fe8baddeb274d8cf385d33|

Patch release to fix a few issues in the Android implementation and missing support for disabling native crash reporting.