### PR TITLE
fix: Support disabling native crashes via AutoNotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * (Android) Fix behavior of `Configuration.NotifyReleaseStages` to disable
   native C/C++ crash reporting if the current `ReleaseStage` is not in the array
+* Fix the behavior of `Configuration.AutoNotify` to disable native crash
+  reporting if false
 
 ## 4.6.4 (2019-09-06)
 

--- a/features/fixtures/Main.cs
+++ b/features/fixtures/Main.cs
@@ -157,6 +157,27 @@ public class Main : MonoBehaviour {
       case "NativeCrash":
         crashy_signal_runner(8);
         break;
+      case "UncaughtExceptionWithoutAutoNotify":
+        Bugsnag.Configuration.AutoNotify = false;
+        DoUnhandledException(0);
+        break;
+      case "NotifyWithoutAutoNotify":
+        Bugsnag.Configuration.AutoNotify = false;
+        DoNotify();
+        break;
+      case "LoggedExceptionWithoutAutoNotify":
+        Bugsnag.Configuration.AutoNotify = false;
+        DoLogUnthrownAsUnhandled();
+        break;
+      case "NativeCrashWithoutAutoNotify":
+        Bugsnag.Configuration.AutoNotify = false;
+        crashy_signal_runner(8);
+        break;
+      case "NativeCrashReEnableAutoNotify":
+        Bugsnag.Configuration.AutoNotify = false;
+        Bugsnag.Configuration.AutoNotify = true;
+        crashy_signal_runner(8);
+        break;
       case "AutoSessionNativeCrash":
         new Thread(() => {
           Thread.Sleep(900);

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -164,3 +164,24 @@ Feature: Handled Errors and Exceptions
             | Main.DoLogWarningWithHandledConfig()  |
             | Main.LoadScenario()  |
             | Main.Update()        |
+
+    Scenario: Reporting a handled exception when AutoNotify = false
+        When I run the game in the "NotifyWithoutAutoNotify" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "Exception"
+        And the exception "message" equals "blorb"
+        And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main.DoNotify()      |
+            | Main.LoadScenario()  |
+            | Main.Update()        |
+
+
+    Scenario: Logging an exception when AutoNotify = false
+        When I run the game in the "LoggedExceptionWithoutAutoNotify" state
+        Then I should receive no requests

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -65,3 +65,28 @@ Feature: Reporting unhandled events
             | __pthread_kill       |
             | abort                |
             | crashy_signal_runner |
+
+    Scenario: Reporting an uncaught exception when AutoNotify = false
+        When I run the game in the "UncaughtExceptionWithoutAutoNotify" state
+        Then I should receive no requests
+
+    Scenario: Reporting a native crash when AutoNotify = false
+        When I run the game in the "NativeCrashWithoutAutoNotify" state
+        And I run the game in the "(noop)" state
+        Then I should receive no requests
+
+    Scenario: Reporting a native crash after toggling AutoNotify off then on again
+        When I run the game in the "NativeCrashReEnableAutoNotify" state
+        And I run the game in the "(noop)" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Bugsnag Unity (Cocoa)"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "SIGABRT"
+        And the event "unhandled" is true
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | __pthread_kill       |
+            | abort                |
+            | crashy_signal_runner |

--- a/src/BugsnagUnity/Native/Android/Configuration.cs
+++ b/src/BugsnagUnity/Native/Android/Configuration.cs
@@ -6,6 +6,10 @@ namespace BugsnagUnity
 {
   class Configuration : AbstractConfiguration
   {
+    // Cached value of native-layer auto notify configuration setting to reduce the
+    // number of native calls required when reporting a Unity error
+    private bool _autoNotify;
+
     internal NativeInterface NativeInterface { get; }
 
     internal Configuration(string apiKey, bool autoNotify) : base()
@@ -22,7 +26,7 @@ namespace BugsnagUnity
       JavaObject.Call("setAppVersion", Application.version);
       NativeInterface = new NativeInterface(JavaObject);
       SetupDefaults(apiKey);
-      AutoNotify = autoNotify;
+      _autoNotify = autoNotify;
     }
 
     protected override void SetupDefaults(string apiKey)
@@ -31,6 +35,15 @@ namespace BugsnagUnity
       ReleaseStage = "production";
       Endpoint = new Uri(DefaultEndpoint);
       SessionEndpoint = new Uri(DefaultSessionEndpoint);
+    }
+
+    public override bool AutoNotify
+    {
+      get => _autoNotify;
+      set {
+        _autoNotify = value;
+        NativeInterface.SetAutoNotify(value);
+      }
     }
 
     public override string ReleaseStage

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -152,6 +152,16 @@ namespace BugsnagUnity
       return CallNativeStringMethod("getContext", "()Ljava/lang/String;", new object[]{});
     }
 
+    public void SetAutoNotify(bool newValue) {
+      if (newValue) {
+        CallNativeVoidMethod("enableUncaughtJavaExceptionReporting", "()V", new object[]{});
+        CallNativeVoidMethod("enableNdkCrashReporting", "()V", new object[]{});
+      } else {
+        CallNativeVoidMethod("disableUncaughtJavaExceptionReporting", "()V", new object[]{});
+        CallNativeVoidMethod("disableNdkCrashReporting", "()V", new object[]{});
+      }
+    }
+
     public void SetContext(string newValue) {
       CallNativeVoidMethod("setContext", "(Ljava/lang/String;)V", new object[]{MakeJavaString(newValue)});
     }

--- a/src/BugsnagUnity/Native/Cocoa/Configuration.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Configuration.cs
@@ -8,6 +8,10 @@ namespace BugsnagUnity
 {
   class Configuration : AbstractConfiguration
   {
+    // Cached value of native-layer auto notify configuration setting to reduce the
+    // number of native calls required when reporting a Unity error
+    private bool _autoNotify;
+
     internal IntPtr NativeConfiguration { get; }
 
     internal Configuration(string apiKey, bool autoNotify) : base()
@@ -15,7 +19,7 @@ namespace BugsnagUnity
       NativeConfiguration = NativeCode.bugsnag_createConfiguration(apiKey);
       SetupDefaults(apiKey);
       NativeCode.bugsnag_setAutoNotify(NativeConfiguration, autoNotify);
-      AutoNotify = autoNotify;
+      _autoNotify = autoNotify;
     }
 
     protected override void SetupDefaults(string apiKey)
@@ -29,6 +33,15 @@ namespace BugsnagUnity
     {
       get => Marshal.PtrToStringAuto(NativeCode.bugsnag_getApiKey(NativeConfiguration));
       protected set {}
+    }
+
+    public override bool AutoNotify
+    {
+      get => _autoNotify;
+      set {
+        _autoNotify = value;
+        NativeCode.bugsnag_setAutoNotify(NativeConfiguration, value);
+      }
     }
 
     public override string ReleaseStage


### PR DESCRIPTION
The current behavior of `Configuration.AutoNotify` is to disable further reports generated from Unity logs. This change makes it possible to disable future crash reports as well, disabling the native integrations if `AutoNotify` is false.

Depends on bugsnag/bugsnag-cocoa#410