### PR TITLE
fix(ios): Fix detection of out-of-memory crashes in unity env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* (iOS) Fix a build setting preventing out-of-memory events from being reported
+  [#178](https://github.com/bugsnag/bugsnag-unity/pull/178)
+
 ## 4.6.6 (2019-10-22)
 
 ### Bug fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ bundle exec rake plugin:maze_runner
   - [ ] Test that a log message formatted as `SomeTitle: rest of message` generates an error titled `SomeTitle` with message `rest of message`
   - [ ] Test that a log message formatted without a colon generates an error titled `LogError<level>` with message `rest of message`
   - [ ] Ensure the example app sends the correct error for each type on iOS
+  - [ ] Ensure OOM reports are sent on iOS when the app is unexpectedly terminated
   - [ ] Ensure the example app sends the correct error for each type on tvOS
   - [ ] Ensure the example app sends the correct error for each type on macOS
   - [ ] Ensure the example app sends the correct error for each type on Android


### PR DESCRIPTION
By default, `TARGET_OS_*` macros are not defined for static library
targets. Since the OOM feature was enabled based on the flag, the
feature was disabled entirely. The change updates the build
configuration to set the flag conditionally, and link the required
framework(s).

## Testing

* [x] Tested manually by creating native out-of-memeory events before and after the change
* [x] Archived the app successfully
