### PR TITLE
Overwrite old android artefacts when installing package

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -108,10 +108,10 @@ def assemble_android filter_abis=true
   # copy unity lib
   unity_lib = File.join("bugsnag-android-unity", "build", "outputs", "aar", "bugsnag-android-unity-release.aar")
 
-  cp android_core_lib, android_dir
+  cp android_core_lib, File.join(android_dir, "bugsnag-android-release.aar")
   cp ndk_lib, File.join(android_dir, "bugsnag-android-ndk-release.aar")
-  cp anr_lib, android_dir
-  cp unity_lib, android_dir
+  cp anr_lib, File.join(android_dir, "bugsnag-plugin-android-anr-release.aar")
+  cp unity_lib, File.join(android_dir, "bugsnag-android-unity-release.aar")
   cp kotlin_stdlib, File.join(android_dir, "kotlin-stdlib.jar")
   cp kotlin_stdlib_common, File.join(android_dir, "kotlin-stdlib-common.jar")
   cp kotlin_annotations, File.join(android_dir, "kotlin-annotations.jar")


### PR DESCRIPTION
Old bugsnag-android artefacts can be installed in an existing app, and need to be overwritten when installing the new modular artefacts added in #182.

This change explicitly specifies the name of each AAR file that is copied into `Bugsnag.unitypackage` to ensure that any change in the Gradle build output naming convention does not break future releases. It also changes `bugsnag-android-core-release.aar` to `bugsnag-android-release.aar`, which overwrites any previous version of bugsnag-android installed. If this change were not made, it would result in duplicate class definitions causing a crash on Android.

Tested by installing v4.0.0 into an example app, and then installing a locally build package from this changeset on top.