### PR TITLE
build: Add task for rebuilding the plugin using a cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,12 +51,21 @@ A simple project can be found at [example](https://github.com/bugsnag/bugsnag-un
 
 ## Building Plugin
 
-The plugin can be built by running
+The plugin can be built for release by running `rake plugin:export`. The
+`export` task does a full clean build.
 
 ```
 bundle install
 bundle exec rake plugin:export
 ```
+
+The plugin can be built with a cache using `rake plugin:quick_export`.
+
+```
+bundle exec rake plugin:rebuild
+```
+
+List available tasks using `rake -T`.
 
 ## Building Example
 

--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ def assemble_android filter_abis=true
   android_dir = File.join(assets_path, "Android")
 
   cd "bugsnag-android" do
-    sh "./gradlew", "assembleRelease", abi_filters
+    sh "./gradlew", "bugsnag-android-core:assembleRelease", "bugsnag-plugin-android-ndk:assembleRelease", "bugsnag-plugin-android-anr:assembleRelease", abi_filters
   end
 
   cd "bugsnag-android-unity" do


### PR DESCRIPTION
Adds a build task for building the Unity package without clearing the cache. Also added some documentation to the main tasks for `rake -T`:

```
rake plugin:build:clean   # Delete all build artifacts
rake plugin:export        # Generate release artifacts
rake plugin:maze_runner   # Run integration tests
rake plugin:quick_export  # Generate release artifacts from cache (using Android 64-bit)
```

Sample build time on 2018 MBP
```sh
$ time bundle exec rake plugin:export
      112.89 real        34.35 user         5.92 sys
$ time bundle exec rake plugin:quick_export
       24.13 real        13.17 user         1.72 sys
```

