### PR TITLE
Propagate non-string arguments to native android layer correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* (Android) Propagate non-string arguments to native android layer correctly
+  [#191](https://github.com/bugsnag/bugsnag-unity/pull/191)
+
 ## 4.8.0 (2020-01-27)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 4.8.1 (2020-02-04)
 
 ### Bug fixes
 

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@ var target = Argument("target", "Default");
 var solution = File("./BugsnagUnity.sln");
 var configuration = Argument("configuration", "Release");
 var project = File("./src/BugsnagUnity/BugsnagUnity.csproj");
-var version = "4.8.0";
+var version = "4.8.1";
 
 Task("Restore-NuGet-Packages")
     .Does(() => NuGetRestore(solution));

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -347,7 +347,7 @@ namespace BugsnagUnity
         AndroidJNI.AttachCurrentThread();
       }
 
-      object[] itemsAsJavaObjects = new AndroidJavaObject[args.Length];
+      object[] itemsAsJavaObjects = new object[args.Length];
       for (int i = 0; i < args.Length; i++) {
         var obj = args[i];
 

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -347,12 +347,14 @@ namespace BugsnagUnity
         AndroidJNI.AttachCurrentThread();
       }
 
-      var itemsAsJavaObjects = new AndroidJavaObject[args.Length];
+      object[] itemsAsJavaObjects = new AndroidJavaObject[args.Length];
       for (int i = 0; i < args.Length; i++) {
         var obj = args[i];
 
         if (obj is string) {
           itemsAsJavaObjects[i] = MakeJavaString(obj as string);
+        } else {
+          itemsAsJavaObjects[i] = obj;
         }
       }
 


### PR DESCRIPTION
## Goal

#187 introduced a bug where non-string arguments were not added to the array of arguments that are used to invoke a JNI method. This notably led to breadcrumb metadata not being displayed in error reports, as the `Dictionary` type was not added to the parameter list.

## Changeset

Added all arguments to the array, regardless of whether they have been converted to a Java string or not.

## Tests

Manually verified the change in an example app and confirmed that breadcrumb messages display correctly.
