### PR TITLE
Avoid using deprecated AndroidJNI API in Unity 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Avoid using deprecated AndroidJNI API in Unity 2019
+  [#194](https://github.com/bugsnag/bugsnag-unity/pull/194)
+
 ## 4.8.1 (2020-02-04)
 
 ### Bug fixes

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -509,11 +509,22 @@ namespace BugsnagUnity
       try {
         var CharsetClass = new AndroidJavaClass("java.nio.charset.Charset");
         // The default encoding on Android is UTF-8
-        var charset = CharsetClass.CallStatic<AndroidJavaObject>("defaultCharset");
-        return new AndroidJavaObject("java.lang.String", Encoding.UTF8.GetBytes(input), charset);
+        var Charset = CharsetClass.CallStatic<AndroidJavaObject>("defaultCharset");
+        byte[] Bytes = Encoding.UTF8.GetBytes(input);
+        return ConstructJavaString(Bytes, Charset);
       } catch (EncoderFallbackException _) {
         // The input string could not be encoded as UTF-8
         return new AndroidJavaObject("java.lang.String");
+      }
+    }
+
+    private AndroidJavaObject ConstructJavaString(byte[] Bytes, AndroidJavaObject Charset) {
+      try { // should succeed on Unity 2019.1 and above
+        sbyte[] SBytes = new sbyte[Bytes.Length];
+        Buffer.BlockCopy(Bytes, 0, SBytes, 0, Bytes.Length);
+        return new AndroidJavaObject("java.lang.String", SBytes, Charset);
+      } catch (System.Exception _) { // use legacy API on older versions
+        return new AndroidJavaObject("java.lang.String", Bytes, Charset);
       }
     }
 


### PR DESCRIPTION
## Goal

Avoids using a AndroidJniHelper method which was deprecated in Unity 2019. [https://docs.unity3d.com/2019.1/Documentation/ScriptReference/AndroidJNI.FromByteArray.html](AndroidJNI.FromByteArray) was deprecated in favour of a method which takes an [`sbyte`]() instead. This results in a warning being logged to Android logcat whenever the `MakeJavaString` method was invoked, causing lag as the application struggles to write out all the log messages.

## Changeset

Alter the `MakeJavaString` implementation to attempt to use the new API, and fallback to the legacy API if this new API is not available.

Because bugsnag-unity is delivered as a plugin, it is not possible to use the `UNITY_2019_1_OR_NEWER` preprocessor macros to determine whether the new/legacy API should be used. Instead this approach relies on catching an `Exception` thrown when the new constructor cannot be found on earlier versions of Unity, and falling back to use the old constructor instead.

## Tests

Manually verified that no deprecation messages are logged out in Unity 2017.3 and Unity 2019.3, and that both versions are capable of delivering error reports.