### PR TITLE
Add breadcrumb log level from spec

### DIFF
--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -127,7 +127,7 @@ namespace BugsnagUnity
       {
         var logMessage = new UnityLogMessage(condition, stackTrace, logType);
         var shouldSend = Exception.ShouldSend(logMessage)
-          && UniqueCounter.ShouldSend(logMessage) 
+          && UniqueCounter.ShouldSend(logMessage)
           && LogTypeCounter.ShouldSend(logMessage);
         if (shouldSend)
         {
@@ -138,7 +138,7 @@ namespace BugsnagUnity
           Notify(new Exception[]{exception}, exception.HandledState, null, logType);
         }
       }
-      else
+      else if (logType.IsGreaterThanOrEqualTo(Configuration.BreadcrumbLogLevel))
       {
         Breadcrumbs.Leave(logType.ToString(), BreadcrumbType.Log, new Dictionary<string, string> {
           { "message", condition },

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -35,6 +35,8 @@ namespace BugsnagUnity
 
     public virtual TimeSpan UniqueLogsTimePeriod { get; set; } = TimeSpan.FromSeconds(5);
 
+    public virtual LogType BreadcrumbLogLevel { get; set; } = LogType.Log;
+
     public virtual string ApiKey { get; protected set; }
 
     public virtual int MaximumBreadcrumbs { get; set; } = 25;

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -12,6 +12,8 @@ namespace BugsnagUnity
 
     TimeSpan MaximumLogsTimePeriod { get; }
 
+    LogType BreadcrumbLogLevel { get; set; }
+
     Dictionary<LogType, int> MaximumTypePerTimePeriod { get; }
 
     TimeSpan UniqueLogsTimePeriod { get; set; }


### PR DESCRIPTION
Adds the breadcrumb log level configuration option from the notifier spec to allow people to control breadcrumb creation.