### PR TITLE
Respect autoNotify flag on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Respect autoNotify flag on Android
+  [#207](https://github.com/bugsnag/bugsnag-unity/pull/207)
+
 ## 4.8.4 (2020-10-05)
 
 ### Enhancements

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -12,12 +12,12 @@ namespace BugsnagUnity
 
     public AbstractConfiguration() {}
 
-    protected virtual void SetupDefaults(string apiKey)
+    protected virtual void SetupDefaults(string apiKey, bool autoNotify)
     {
       ApiKey = apiKey;
       AppVersion = Application.version;
       AutoCaptureSessions = true;
-      AutoNotify = true;
+      AutoNotify = autoNotify;
     }
 
     public virtual bool ReportUncaughtExceptionsAsHandled { get; set; } = true;

--- a/src/BugsnagUnity/Native/Android/Configuration.cs
+++ b/src/BugsnagUnity/Native/Android/Configuration.cs
@@ -27,13 +27,13 @@ namespace BugsnagUnity
       JavaObject.Call("setReleaseStage", "production");
       JavaObject.Call("setAppVersion", Application.version);
       NativeInterface = new NativeInterface(JavaObject);
-      SetupDefaults(apiKey);
       _autoNotify = autoNotify;
+      SetupDefaults(apiKey, _autoNotify);
     }
 
-    protected override void SetupDefaults(string apiKey)
+    protected override void SetupDefaults(string apiKey, bool autoNotify)
     {
-      base.SetupDefaults(apiKey);
+      base.SetupDefaults(apiKey, autoNotify);
       ReleaseStage = "production";
       Endpoint = new Uri(DefaultEndpoint);
       SessionEndpoint = new Uri(DefaultSessionEndpoint);

--- a/src/BugsnagUnity/Native/Cocoa/Configuration.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Configuration.cs
@@ -17,14 +17,14 @@ namespace BugsnagUnity
     internal Configuration(string apiKey, bool autoNotify) : base()
     {
       NativeConfiguration = NativeCode.bugsnag_createConfiguration(apiKey);
-      SetupDefaults(apiKey);
-      NativeCode.bugsnag_setAutoNotify(NativeConfiguration, autoNotify);
       _autoNotify = autoNotify;
+      SetupDefaults(apiKey, autoNotify);
+      NativeCode.bugsnag_setAutoNotify(NativeConfiguration, autoNotify);
     }
 
-    protected override void SetupDefaults(string apiKey)
+    protected override void SetupDefaults(string apiKey, bool autoNotify)
     {
-      base.SetupDefaults(apiKey);
+      base.SetupDefaults(apiKey, autoNotify);
       ReleaseStage = "production";
       Endpoint = new Uri(DefaultEndpoint);
     }

--- a/src/BugsnagUnity/Native/Fallback/Configuration.cs
+++ b/src/BugsnagUnity/Native/Fallback/Configuration.cs
@@ -7,8 +7,7 @@ namespace BugsnagUnity
   class Configuration : AbstractConfiguration
   {
     internal Configuration(string apiKey, bool autoNotify) : base() {
-      SetupDefaults(apiKey);
-      AutoNotify = autoNotify;
+      SetupDefaults(apiKey, autoNotify);
     }
   }
 }

--- a/tests/BugsnagUnity.Tests/ConfigurationTests.cs
+++ b/tests/BugsnagUnity.Tests/ConfigurationTests.cs
@@ -8,7 +8,7 @@ namespace BugsnagUnity.Payload.Tests
   class TestConfig : AbstractConfiguration
   {
     internal TestConfig(string apiKey) : base() {
-      SetupDefaults(apiKey);
+      SetupDefaults(apiKey, true);
     }
   }
 

--- a/tests/BugsnagUnity.Tests/TestConfiguration.cs
+++ b/tests/BugsnagUnity.Tests/TestConfiguration.cs
@@ -7,7 +7,7 @@ namespace BugsnagUnity.Tests
   public class TestConfiguration : AbstractConfiguration
   {
     internal TestConfiguration(string apiKey) : base() {
-      SetupDefaults(apiKey);
+      SetupDefaults(apiKey, true);
     }
   }
 }


### PR DESCRIPTION
## Goal

Fixes Android's handling of the `autoNotify` flag so that it is respected when set as `false` for JVM errors.

## Changeset

`AbstractConfiguration ` set `AutoNotify` to true, which [enabled the JVM exception handler](https://github.com/bugsnag/bugsnag-unity/blob/PLAT-5738/auto-notify-android/src/BugsnagUnity/Native/Android/NativeInterface.cs#L163). This meant that the call to `setEnableExceptionHandler` in the Android implementation of `Configuration` was overridden as soon as the base method of `SetupDefaults()` was called.

This fix passes the autoNotify value supplied through `Bugsnag.Init` to the base method of `SetupDefaults()` so that the handler is not enabled.

## Testing

Manually verified in an example project with `autoNotify = false` that an error is no longer sent.