### PR TITLE
Fix build script to work with modern versions of Android Studio

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,7 +82,7 @@ def export_package name="Bugsnag.unitypackage"
 end
 
 def assemble_android filter_abis=true
-  abi_filters = filter_abis ? "-PABI_FILTERS=armeabi-v7a,x86" : "-Pnoop_filters=true"
+  abi_filters = filter_abis ? "-PABI_FILTERS=armeabi-v7a,x86" : "-PABI_FILTERS=armeabi-v7a,arm64-v8a,x86,x86_64"
   android_dir = File.join(assets_path, "Android")
 
   cd "bugsnag-android" do
@@ -131,11 +131,11 @@ namespace :plugin do
       FileUtils.rm_rf cocoa_build_dir
       # remove android build area
       cd "bugsnag-android" do
-        sh "./gradlew", "clean"
+        sh "./gradlew", "clean", "-PABI_FILTERS=armeabi-v7a,x86"
       end
 
       cd "bugsnag-android-unity" do
-        sh "./gradlew", "clean"
+        sh "./gradlew", "clean", "-PABI_FILTERS=armeabi-v7a,x86"
       end
     end
     task :assets do


### PR DESCRIPTION
## Goal

The build script fails as modern versions of Android Studio (4.1.1) are unable to build the armeabi ABI. This fixes the buildscript by removing armeabi from the targets. This brings Unity into line with Android on the architectures it supports.

