### PR TITLE
Allow assembling with Android Studio 4.1.1

### DIFF
--- a/bugsnag-android-unity/build.gradle
+++ b/bugsnag-android-unity/build.gradle
@@ -27,7 +27,7 @@ android {
             if (project.hasProperty("ABI_FILTERS")) {
                 abiFilters project.ABI_FILTERS.split(",")
             } else {
-                abiFilters 'arm64-v8a', 'armeabi-v7a', 'armeabi', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
             }
         }
     }


### PR DESCRIPTION
## Goal

The build script on Unity fails as modern versions of Android Studio (4.1.1) are unable to build the armeabi ABI. This fixes the buildscript by removing armeabi from the targets. This brings Unity into line with Android on the architectures it supports.