### PR TITLE
Avoid JNI crash in leaveBreadcrumb by pushing local frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Avoid JNI crash in leaveBreadcrumb by pushing local frame
+  [#214](https://github.com/bugsnag/bugsnag-unity/pull/214)
+
 * Respect autoNotify flag on Android
   [#207](https://github.com/bugsnag/bugsnag-unity/pull/207)
 


### PR DESCRIPTION
## Goal

Creates a new local reference frame when leaving breadcrumbs. In extreme situations (logging thousands of breadcrumbs per second)  `AndroidJavaObject`'s implementation does not seem to delete local references quickly enough on older Android devices, resulting in the local table reference being blown. Calling [PushLocalFrame](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#pushlocalframe) is sufficient to avoid this crash as it increases the size of the reference table.

## Testing

Tested on a Nexus 7 running Android 6 with the following snippet. Before the changeset this would crash the app:


```
void Update () {
if (Time.frameCount % 10 == 0)
      {
          for(var i = 0; i < 1000; i++) {
              BugsnagUnity.Bugsnag.LeaveBreadcrumb("Test");
          }
      }
}
```