### PR TITLE
Add bugsnag prefix to namespace of vendored SimpleJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Add bugsnag prefix to namespace of vendored SimpleJson
+  [#225](https://github.com/bugsnag/bugsnag-unity/pull/225)
+
 ## 4.8.7 (2021-03-30)
 
 ### Bug fixes

--- a/src/BugsnagUnity/IDelivery.cs
+++ b/src/BugsnagUnity/IDelivery.cs
@@ -65,7 +65,7 @@ namespace BugsnagUnity
       using (var reader = new StreamReader(stream))
       using (var writer = new StreamWriter(stream, new UTF8Encoding(false)) { AutoFlush = false })
       {
-        SimpleJson.SimpleJson.SerializeObject(payload, writer);
+        BugsnagUnity.SimpleJson.SerializeObject(payload, writer);
         writer.Flush();
         stream.Position = 0;
         var body = Encoding.UTF8.GetBytes(reader.ReadToEnd());

--- a/src/BugsnagUnity/SimpleJson.cs
+++ b/src/BugsnagUnity/SimpleJson.cs
@@ -67,12 +67,12 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
-using SimpleJson.Reflection;
+using BugsnagUnity.Reflection;
 
 // ReSharper disable LoopCanBeConvertedToQuery
 // ReSharper disable RedundantExplicitArrayCreation
 // ReSharper disable SuggestUseVarKeywordEvident
-namespace SimpleJson
+namespace BugsnagUnity
 {
     /// <summary>
     /// Represents the json array.
@@ -465,7 +465,7 @@ namespace SimpleJson
     }
 }
 
-namespace SimpleJson
+namespace BugsnagUnity
 {
     /// <summary>
     /// This class encodes and decodes JSON strings.


### PR DESCRIPTION
## Goal

Adds a bugsnag prefix to the vendored `SimpleJson.cs`, to avoid symbol clashes if a user has vendored `SimpleJson` themselves.

## Testing

Verified on [the following branch](https://github.com/bugsnag/bugsnag-unity/compare/simple-json-repro) that an example app with a vendored `SimpleJson` class failed to build without these changes, and builds with the changes.