### PR TITLE
Replace Bugsnag.init with Bugsnag.start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Replace Bugsnag.init with Bugsnag.start
+  [#227](https://github.com/bugsnag/bugsnag-unity/pull/227)
+
 ## 4.8.8 (2021-04-21)
 
 ### Bug fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,31 @@
 Upgrading
 =========
 
+## v5.0.0
+
+v5.0.0 contains breaking changes to Bugsnag's API that improve the reliability of the SDK and resolve several painpoints.
+
+### New recommended way for initializing Bugsnag
+
+The API has changed for initializing Bugsnag. It is now recommended that you supply all your configuration options up-front, and then call `Bugsnag.start()`:
+
+```c#
+Configuration config = new Configuration("your-api-key");
+// alter all configuration options here, before Bugsnag.Start()
+config.ReleaseStage = "beta"
+
+// initialize Bugsnag
+Bugsnag.Start(config);
+```
+
+If you initialize Bugsnag using a `GameObject` then no migration is necessary - the `BugsnagBehaviour.cs` script will be copied over when importing the `BugsnagUnity.package`.
+
+### Configuration options must be supplied before Bugsnag.Start()
+
+If you alter Bugsnag's default behaviour via `Configuration`, you must supply all values before calling `Bugsnag.Start()`.
+
+Any change to the value of `Configuration` options after `Bugsnag.Start()` is called will have no effect on Bugsnag's behaviour.
+
 ## 4.1 to 4.2
 
 4.2.0 adds support for reporting C/C++ crashes in Android code. If you are using

--- a/src/Assets/Standard Assets/Bugsnag/BugsnagBehaviour.cs
+++ b/src/Assets/Standard Assets/Bugsnag/BugsnagBehaviour.cs
@@ -46,7 +46,7 @@ namespace BugsnagUnity
     /// </summary>
     void Awake()
     {
-      Bugsnag.Init(BugsnagApiKey, AutoNotify);
+      Bugsnag.Start(BugsnagApiKey);
       Bugsnag.Configuration.AutoNotify = AutoNotify;
       Bugsnag.Configuration.AutoDetectAnrs = AutoNotify && AutoDetectAnrs;
       Bugsnag.Configuration.AutoCaptureSessions = AutoCaptureSessions;

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -7,18 +7,19 @@ namespace BugsnagUnity
   {
     static object _clientLock = new object();
 
-    public static IClient Init(string apiKey)
+    public static IClient Start(string apiKey)
     {
-      return Init(apiKey, true);
+      return Start(new Configuration(apiKey, true));
     }
 
-    public static IClient Init(string apiKey, bool autoNotify)
+    public static IClient Start(IConfiguration configuration)
     {
       lock (_clientLock)
       {
         if (InternalClient == null)
         {
-          InternalClient = new Client(new NativeClient(new Configuration(apiKey, autoNotify)));
+          var nativeClient = new NativeClient(configuration);
+          InternalClient = new Client(nativeClient);
         }
       }
 

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -14,9 +14,11 @@ namespace BugsnagUnity
 
     private NativeInterface NativeInterface;
 
-    public NativeClient(Configuration configuration)
+    public NativeClient(IConfiguration configuration)
     {
-      NativeInterface = configuration.NativeInterface;
+      // temporary cast to concrete class, will be removed in later changeset as part of this work
+      Configuration config = (Configuration) configuration;
+      NativeInterface = config.NativeInterface;
       Configuration = configuration;
 
       using (var notifier = new AndroidJavaClass("com.bugsnag.android.Notifier"))

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -27,7 +27,8 @@ namespace BugsnagUnity
       Breadcrumbs = breadcrumbs;
     }
 
-    public NativeClient(Configuration configuration) : this(configuration, configuration.NativeConfiguration, new Breadcrumbs(configuration))
+    // temporary cast to concrete class, will be removed in later changeset as part of this work
+    public NativeClient(IConfiguration configuration) : this(configuration, ((Configuration) configuration).NativeConfiguration, new Breadcrumbs(((Configuration) configuration)))
     {
     }
 

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -11,7 +11,7 @@ namespace BugsnagUnity
 
     public IDelivery Delivery { get; }
 
-    public NativeClient(Configuration configuration)
+    public NativeClient(IConfiguration configuration)
     {
       Configuration = configuration;
       Breadcrumbs = new Breadcrumbs(configuration);

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -12,7 +12,7 @@ namespace BugsnagUnity
 
     public IDelivery Delivery { get; }
 
-    public NativeClient(Configuration configuration)
+    public NativeClient(IConfiguration configuration)
     {
       Configuration = configuration;
       Breadcrumbs = new Breadcrumbs(configuration);


### PR DESCRIPTION
## Goal

In Unity it’s currently not possible to alter `Configuration` without initializing Bugsnag. The C# API should therefore be updated to provide Bugsnag.Start(config), and all `Bugsnag.Init()` calls should be replaced by `Bugsnag.Start()`.

## Changeset

Removed all `Bugsnag.Init()` calls, and added the following replacement calls:

`Start(string apiKey)` - for initializing bugsnag with the defaults
`Start(IConfiguration config)` - for initializing bugsnag with a configuration object

Note: it was necessary to perform a cast to the concrete `Configuration` type to get this change compiling. This is a temporary change which will be removed in the next PR - which will be delivered separately due to its size.

## Testing

Verified that the example app compiles.