### PR TITLE
Add Bugsnag.SetContext and Bugsnag.SetAutoNotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Replace Bugsnag.init with Bugsnag.start
   [#227](https://github.com/bugsnag/bugsnag-unity/pull/227)
 
+* Add Bugsnag.SetContext and Bugsnag.SetAutoNotify
+  [#229](https://github.com/bugsnag/bugsnag-unity/pull/229)
+
 ## 4.8.8 (2021-04-21)
 
 ### Bug fixes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -45,6 +45,21 @@ config.AutoNotify = true;
 
 The `Bugsnag.Configuration` accessor has been removed. You should supply all your configuration options up-front as recommended [here](#new-recommended-way-for-initializing-bugsnag).
 
+### AutoNotify and Context replaced
+
+Previously it was possible to set `AutoNotify` and `Context` after Bugsnag has initialized:
+
+```c#
+Bugsnag.Configuration.AutoNotify = false;
+Bugsnag.Configuration.Context = "MyContext";
+```
+
+This has been replaced by the following API:
+
+```c#
+Bugsnag.SetAutoNotify(false);
+Bugsnag.SetContext("MyContext");
+```
 
 ## 4.1 to 4.2
 

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -75,5 +75,27 @@ namespace BugsnagUnity
     /// </summary>
     /// <param name="inFocus"></param>
     public static void SetApplicationState(bool inFocus) => Client.SetApplicationState(inFocus);
+
+    /// <summary>
+    /// Bugsnag uses the concept of contexts to help display and group your errors.
+    /// Contexts represent what was happening in your game at the time an error
+    /// occurs. By default, this will be set to be your currently active Unity Scene.
+    /// </summary>
+    /// <param name="context"></param>
+    public static void SetContext(string context)
+    {
+      Client.SetContext(context);
+    }
+
+    /// <summary>
+    /// By default, we will automatically notify Bugsnag of any fatal errors (crashes) in your game.
+    /// If you want to stop this from happening, you can set the AutoNotify property to false. It
+    /// is recommended that you set this value by Configuration rather than this method.
+    /// </summary>
+    /// <param name="autoNotify"></param>
+    public static void SetAutoNotify(bool autoNotify)
+    {
+      Client.SetAutoNotify(autoNotify);
+    }
   }
 }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -317,5 +317,23 @@ namespace BugsnagUnity
         SessionTracking.StartSession();
       }
     }
+
+    public void SetContext(string context)
+    {
+      // set the context property on Configuration, as it currently holds the global state
+      Configuration.Context = context;
+
+      // propagate the change to the native property also
+      NativeClient.SetContext(context);
+    }
+
+    public void SetAutoNotify(bool autoNotify)
+    {
+      // set the AutoNotify property on Configuration, as it currently controls whether C# errors are reported
+      Configuration.AutoNotify = autoNotify;
+
+      // propagate the change to the native property also
+      NativeClient.SetAutoNotify(autoNotify);
+    }
   }
 }

--- a/src/BugsnagUnity/IClient.cs
+++ b/src/BugsnagUnity/IClient.cs
@@ -35,5 +35,9 @@ namespace BugsnagUnity
     /// </summary>
     /// <param name="inFocus"></param>
     void SetApplicationState(bool inFocus);
+
+    void SetContext(string context);
+
+    void SetAutoNotify(bool autoNotify);
   }
 }

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -62,5 +62,17 @@ namespace BugsnagUnity
     /// </summary>
     /// <param name="metadata"></param>
     void PopulateMetadata(Metadata metadata);
+
+    /// <summary>
+    /// Mutates the context.
+    /// </summary>
+    /// <param name="context"></param>
+    void SetContext(string context);
+
+    /// <summary>
+    /// Mutates autoNotify.
+    /// </summary>
+    /// <param name="autoNotify"></param>
+   void SetAutoNotify(bool autoNotify);
   }
 }

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -86,6 +86,17 @@ namespace BugsnagUnity
     {
       NativeInterface.SetUser(user);
     }
+
+    public void SetContext(string context)
+    {
+      NativeInterface.SetContext(context);
+    }
+
+    public void SetAutoNotify(bool autoNotify)
+    {
+      NativeInterface.SetAutoNotify(autoNotify);
+      NativeInterface.SetAutoDetectAnrs(autoNotify && Configuration.AutoDetectAnrs);
+    }
   }
 
 }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -186,6 +186,28 @@ namespace BugsnagUnity
       AndroidJNI.PopLocalFrame(System.IntPtr.Zero);
     }
 
+    public void SetAutoNotify(bool newValue) {
+      if (newValue) {
+        CallNativeVoidMethod("enableUncaughtJavaExceptionReporting", "()V", new object[]{});
+        CallNativeVoidMethod("enableNdkCrashReporting", "()V", new object[]{});
+      } else {
+        CallNativeVoidMethod("disableUncaughtJavaExceptionReporting", "()V", new object[]{});
+        CallNativeVoidMethod("disableNdkCrashReporting", "()V", new object[]{});
+      }
+    }
+
+    public void SetAutoDetectAnrs(bool newValue) {
+      if (newValue) {
+        CallNativeVoidMethod("enableAnrReporting", "()V", new object[]{});
+      } else {
+        CallNativeVoidMethod("disableAnrReporting", "()V", new object[]{});
+      }
+    }
+
+    public void SetContext(string newValue) {
+      CallNativeVoidMethod("setContext", "(Ljava/lang/String;)V", new object[]{newValue});
+    }
+
     public void SetUser(User user) {
       var method = "setUser";
       var description = "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V";

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -169,5 +169,15 @@ namespace BugsnagUnity
     {
       NativeCode.bugsnag_setUser(user.Id, user.Name, user.Email);
     }
+
+    public void SetContext(string context)
+    {
+      NativeCode.bugsnag_setContext(NativeConfiguration, context);
+    }
+
+    public void SetAutoNotify(bool autoNotify)
+    {
+      NativeCode.bugsnag_setAutoNotify(NativeConfiguration, autoNotify);
+    }
   }
 }

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -45,5 +45,11 @@ namespace BugsnagUnity
     public void SetUser(User user)
     {
     }
+    public void SetContext(string context)
+    {
+    }
+    public void SetAutoNotify(bool autoNotify)
+    {
+    }
   }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -67,6 +67,12 @@ namespace BugsnagUnity
     public void SetUser(User user)
     {
     }
+    public void SetContext(string context)
+    {
+    }
+    public void SetAutoNotify(bool autoNotify)
+    {
+    }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]


### PR DESCRIPTION
## Goal

Adds `Bugsnag.SetContext(string context)` and `Bugsnag.SetAutoNotify(bool autoNotify)` to the public API. These act as replacements for `Bugsnag.Configuration.Context` and `Bugsnag.Configuration.AutoNotify`.

## Changeset

- Added `Bugsnag.SetContext(string context)` and `Bugsnag.SetAutoNotify(bool autoNotify)` to public API
- Each API invokes the same call on `Client`, which then updates the `Configuration` option and then the `NativeClient` so that changes are reflected in Android/iOS crashes too

## Testing

Manually verified that the context is set and that errors are not automatically reported on Android & iOS.