### PR TITLE
Attach Maze Output as build artifacts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,6 +28,8 @@ steps:
         download:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
+        upload:
+          - test/desktop/maze_output/*
     commands:
       - cd test/desktop
       - bundle install
@@ -47,6 +49,8 @@ steps:
         download:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
+        upload:
+          - test/desktop/maze_output/*
     commands:
       - cd test/desktop
       - bundle install


### PR DESCRIPTION
## Goal

Attach any files that appear in `test/desktop/maze_output` as Buildkite build step artifacts.  Maze Runner writes log files in this location if a scenario fails, which should be useful for debugging tests.