### PR TITLE
Update mazerunner instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,8 +81,9 @@ We have a very simple maze-runner setup, which builds a MacOS X Unity game that 
 NOTE: This does not currently run on Windows
 
 ```
+cd test/desktop
 bundle install
-bundle exec rake plugin:maze_runner
+bundle exec maze-runner features/handled_errors.feature
 ```
 
 ## Releasing a new version

--- a/Rakefile
+++ b/Rakefile
@@ -299,11 +299,6 @@ namespace :plugin do
     Rake::Task["plugin:build:all_android64"].invoke
     export_package("Bugsnag-with-android-64bit.unitypackage")
   end
-
-  desc "Run integration tests"
-  task maze_runner: %w[plugin:export] do
-    sh "bundle", "exec", "bugsnag-maze-runner"
-  end
 end
 
 namespace :example do
@@ -335,5 +330,3 @@ namespace :example do
     task all: %w[example:build:ios example:build:android]
   end
 end
-
-task default: %w[plugin:maze_runner]


### PR DESCRIPTION
## Goal

Updates the instructions for running mazerunner so that it's possible to run from just using the contributing guide. The old task has also been removed from the Rakefile to avoid any potential source of confusion.