### PR TITLE
Update macOS test fixture to build and run in separate CI steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,6 +17,7 @@ steps:
     concurrency_group: 'unity-license'
 
   - label: Build Unity 2017 desktop test fixture
+    key: 'cocoa-2017-fixture'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
@@ -37,6 +38,7 @@ steps:
       - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
 
   - label: Build Unity 2018 desktop test fixture
+    key: 'cocoa-2018-fixture'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
@@ -55,7 +57,7 @@ steps:
       - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
 
   - label: Run e2e tests for Unity 2017.4.40f1
-    depends_on: 'build-artifacts'
+    depends_on: 'cocoa-2017-fixture'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa
@@ -73,7 +75,7 @@ steps:
     concurrency_group: 'unity-license'
 
   - label: Run e2e tests for Unity 2018.4.34f1
-    depends_on: 'build-artifacts'
+    depends_on: 'cocoa-2018-fixture'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
           - test/desktop/maze_output/*
     commands:
       - cd test/desktop
-      - ./features/scripts/create_unity_project.sh
+      - ./features/scripts/build_maze_runner.sh
     artifact_paths:
       - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
 
@@ -52,7 +52,7 @@ steps:
           - Bugsnag-with-android-64bit.unitypackage
     commands:
       - cd test/desktop
-      - ./features/scripts/create_unity_project.sh
+      - ./features/scripts/build_maze_runner.sh
     artifact_paths:
       - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
     concurrency: 2
     concurrency_group: 'unity-license'
 
-  - label: Run e2e tests for Unity 2017.4.40f1
+  - label: Build Unity 2017 desktop test fixture
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
@@ -32,12 +32,11 @@ steps:
           - test/desktop/maze_output/*
     commands:
       - cd test/desktop
-      - bundle install
-      - bundle exec bugsnag-maze-runner
-    concurrency: 2
-    concurrency_group: 'unity-license'
+      - ./features/scripts/create_unity_project.sh
+    artifact_paths:
+      - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app
 
-  - label: Run e2e tests for Unity 2018.4.34f1
+  - label: Build Unity 2018 desktop test fixture
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
@@ -49,8 +48,41 @@ steps:
         download:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
-        upload:
-          - test/desktop/maze_output/*
+    commands:
+      - cd test/desktop
+      - ./features/scripts/create_unity_project.sh
+    artifact_paths:
+      - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app
+
+  - label: Run e2e tests for Unity 2017.4.40f1
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa
+    env:
+      UNITY_VERSION: "2017.4.40f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app
+    commands:
+      - cd test/desktop
+      - bundle install
+      - bundle exec bugsnag-maze-runner
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  - label: Run e2e tests for Unity 2018.4.34f1
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa
+    env:
+      UNITY_VERSION: "2018.4.34f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app
     commands:
       - cd test/desktop
       - bundle install

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,7 @@ steps:
       - cd test/desktop
       - ./features/scripts/create_unity_project.sh
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app
+      - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
 
   - label: Build Unity 2018 desktop test fixture
     depends_on: 'build-artifacts'
@@ -52,7 +52,7 @@ steps:
       - cd test/desktop
       - ./features/scripts/create_unity_project.sh
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app
+      - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
 
   - label: Run e2e tests for Unity 2017.4.40f1
     depends_on: 'build-artifacts'
@@ -64,7 +64,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app
+          - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
     commands:
       - cd test/desktop
       - bundle install
@@ -82,7 +82,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app
+          - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
     commands:
       - cd test/desktop
       - bundle install

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ TestResult.xml
 bugsnag-cocoa-build/
 unity.log
 bugsnag-android-unity/.cxx
+test/**/*/*.app.zip

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ TestResult.xml
 bugsnag-cocoa-build/
 unity.log
 bugsnag-android-unity/.cxx
-test/**/*/*.app.zip
+test/**/*.app.zip

--- a/test/desktop/features/scripts/build_maze_runner.sh
+++ b/test/desktop/features/scripts/build_maze_runner.sh
@@ -30,5 +30,9 @@ pushd "${0%/*}"
       -executeMethod Builder.MacOSBuild
     RESULT=$?
     if [ $RESULT -ne 0 ]; then exit $RESULT; fi
+
+    tar -czf "Mazerunner-$UNITY_VERSION.app.zip" "maze_runner/Mazerunner.app"
+    RESULT=$?
+     if [ $RESULT -ne 0 ]; then exit $RESULT; fi
   popd
 popd

--- a/test/desktop/features/scripts/launch_unity_application.sh
+++ b/test/desktop/features/scripts/launch_unity_application.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 pushd "${0%/*}"
-  pushd ../fixtures/maze_runner
-    Mazerunner.app/Contents/MacOS/Mazerunner -batchmode -nographics
+  pushd ../fixtures
+    ${UNITY_TEST_PROJECT}/Contents/MacOS/Mazerunner -batchmode -nographics
   popd
 popd

--- a/test/desktop/features/scripts/launch_unity_application.sh
+++ b/test/desktop/features/scripts/launch_unity_application.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 pushd "${0%/*}"
-  pushd ../fixtures
+  pushd ../fixtures/maze-runner
     ${UNITY_PROJECT_NAME}.app/Contents/MacOS/${UNITY_PROJECT_NAME} -batchmode -nographics
   popd
 popd

--- a/test/desktop/features/scripts/launch_unity_application.sh
+++ b/test/desktop/features/scripts/launch_unity_application.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 pushd "${0%/*}"
-  pushd ../fixtures/maze-runner
+  pushd ../fixtures/maze_runner
     ${UNITY_PROJECT_NAME}.app/Contents/MacOS/${UNITY_PROJECT_NAME} -batchmode -nographics
   popd
 popd

--- a/test/desktop/features/scripts/launch_unity_application.sh
+++ b/test/desktop/features/scripts/launch_unity_application.sh
@@ -2,6 +2,6 @@
 
 pushd "${0%/*}"
   pushd ../fixtures
-    ${UNITY_TEST_PROJECT}/Contents/MacOS/Mazerunner -batchmode -nographics
+    ${UNITY_PROJECT_NAME}.app/Contents/MacOS/${UNITY_PROJECT_NAME} -batchmode -nographics
   popd
 popd

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -7,7 +7,7 @@ ENV['BUGSNAG_APIKEY'] = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
 unity_project_name = ENV['UNITY_PROJECT_NAME'] = "Mazerunner"
 unity_test_project = "features/fixtures/maze-runner/#{unity_project_name}.app"
 
-`cd features/fixtures && tar -xzf #{unity_project_name}.app.zip`
+`cd features/fixtures && tar -xzf #{unity_project_name}-#{ENV['UNITY_VERSION']}.app.zip`
 
 # Scenario hooks
 Before do

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -4,7 +4,7 @@
 # definitions
 
 ENV['BUGSNAG_APIKEY'] = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
-unity_project_name = ENV['UNITY_PROJECT_NAME'] = "Mazerunner-#{ENV['UNITY_VERSION']}"
+unity_project_name = ENV['UNITY_PROJECT_NAME'] = "Mazerunner"
 unity_test_project = "features/fixtures/maze-runner/#{unity_project_name}.app"
 
 `cd features/fixtures && tar -xzf #{unity_project_name}.app.zip`

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -5,7 +5,7 @@
 
 ENV['BUGSNAG_APIKEY'] = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
 unity_project_name = ENV['UNITY_PROJECT_NAME'] = "Mazerunner-#{ENV['UNITY_VERSION']}"
-unity_test_project = "features/fixtures/#{unity_project_name}.app"
+unity_test_project = "features/fixtures/maze-runner/#{unity_project_name}.app"
 
 `cd features/fixtures && tar -xzf #{unity_project_name}.app.zip`
 

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -4,7 +4,10 @@
 # definitions
 
 ENV['BUGSNAG_APIKEY'] = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
-ENV['UNITY_TEST_PROJECT'] = "features/fixtures/Mazerunner-#{ENV['UNITY_VERSION']}.app"
+unity_project_name = ENV['UNITY_PROJECT_NAME'] = "Mazerunner-#{ENV['UNITY_VERSION']}"
+unity_test_project = "features/fixtures/#{unity_project_name}.app"
+
+`cd features/fixtures && tar -xzf #{unity_project_name}.app.zip`
 
 # Scenario hooks
 Before do
@@ -17,5 +20,5 @@ end
 
 at_exit do
   `pkill Mazerunner`
-  FileUtils.rm_rf(ENV['UNITY_TEST_PROJECT'])
+  FileUtils.rm_rf(unity_test_project)
 end

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -4,9 +4,7 @@
 # definitions
 
 ENV['BUGSNAG_APIKEY'] = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
-run_required_commands([
-  ["features/scripts/build_maze_runner.sh"]
-])
+ENV['UNITY_TEST_PROJECT'] = "features/fixtures/Mazerunner-#{ENV['UNITY_VERSION']}.app"
 
 # Scenario hooks
 Before do
@@ -19,5 +17,5 @@ end
 
 at_exit do
   `pkill Mazerunner`
-  FileUtils.rm_rf('features/fixtures/Mazerunner.app')
+  FileUtils.rm_rf(ENV['UNITY_TEST_PROJECT'])
 end

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -5,7 +5,7 @@
 
 ENV['BUGSNAG_APIKEY'] = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
 unity_project_name = ENV['UNITY_PROJECT_NAME'] = "Mazerunner"
-unity_test_project = "features/fixtures/maze-runner/#{unity_project_name}.app"
+unity_test_project = "features/fixtures/maze_runner/#{unity_project_name}.app"
 
 `cd features/fixtures && tar -xzf #{unity_project_name}-#{ENV['UNITY_VERSION']}.app.zip`
 


### PR DESCRIPTION
## Goal

As above, separates the build and run processes for the MacOS desktop end-to-end tests.