### PR TITLE
feat (NativeInterface): add SetAutoDetectAnrs method to Bugsnag interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Add SetAutoDetectAnrs method to Bugsnag interface
+  [#246](https://github.com/bugsnag/bugsnag-unity/pull/246)
+
 * Dont Destroy TimingTrackerObject, so it persists across scenes
   [#239](https://github.com/bugsnag/bugsnag-unity/pull/239)
 
@@ -15,6 +18,7 @@
 
 * Update bugsnag-android dependency to v5
   [#233](https://github.com/bugsnag/bugsnag-unity/pull/233)
+  
 
 ## 4.8.8 (2021-04-21)
 

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -97,5 +97,15 @@ namespace BugsnagUnity
     {
       Client.SetAutoNotify(autoNotify);
     }
-  }
+
+    /// <summary>
+    /// Enable or disable Bugsnag reporting any Android not responding errors (ANRs) in your game.
+    /// </summary>
+    /// <param name="autoDetectAnrs"></param>
+    public static void SetAutoDetectAnrs(bool autoDetectAnrs)
+    {
+      Client.SetAutoDetectAnrs(autoDetectAnrs);
+    }
+
+    }
 }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -335,5 +335,11 @@ namespace BugsnagUnity
       // propagate the change to the native property also
       NativeClient.SetAutoNotify(autoNotify);
     }
+
+    public void SetAutoDetectAnrs(bool autoDetectAnrs)
+    {
+      // Set the native property
+      NativeClient.SetAutoDetectAnrs(autoDetectAnrs);
+    }
   }
 }

--- a/src/BugsnagUnity/IClient.cs
+++ b/src/BugsnagUnity/IClient.cs
@@ -39,5 +39,7 @@ namespace BugsnagUnity
     void SetContext(string context);
 
     void SetAutoNotify(bool autoNotify);
+
+    void SetAutoDetectAnrs(bool autoDetectAnrs);
   }
 }

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -73,6 +73,13 @@ namespace BugsnagUnity
     /// Mutates autoNotify.
     /// </summary>
     /// <param name="autoNotify"></param>
-   void SetAutoNotify(bool autoNotify);
-  }
+    void SetAutoNotify(bool autoNotify);
+
+    /// <summary>
+    /// Enables or disables Anr detection.
+    /// </summary>
+    /// <param name="autoDetectAnrs"></param>
+    void SetAutoDetectAnrs(bool autoDetectAnrs);
+
+    }
 }

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -88,6 +88,11 @@ namespace BugsnagUnity
       NativeInterface.SetAutoNotify(autoNotify);
       NativeInterface.SetAutoDetectAnrs(autoNotify && Configuration.AutoDetectAnrs);
     }
+
+    public void SetAutoDetectAnrs(bool autoDetectAnrs)
+    {
+      NativeInterface.SetAutoDetectAnrs(autoDetectAnrs);
+    }
   }
 
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -179,5 +179,9 @@ namespace BugsnagUnity
     {
       NativeCode.bugsnag_setAutoNotify(NativeConfiguration, autoNotify);
     }
-  }
+
+    public void SetAutoDetectAnrs(bool autoDetectAnrs)
+    {
+    }
+    }
 }

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -51,5 +51,9 @@ namespace BugsnagUnity
     public void SetAutoNotify(bool autoNotify)
     {
     }
-  }
+
+    public void SetAutoDetectAnrs(bool autoDetectAnrs)
+    {
+    }
+    }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -74,7 +74,11 @@ namespace BugsnagUnity
     {
     }
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    public void SetAutoDetectAnrs(bool autoDetectAnrs)
+    {
+    }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     static extern bool GetDiskFreeSpaceEx(string lpDirectoryName,
       out ulong lpFreeBytesAvailable,
@@ -85,7 +89,9 @@ namespace BugsnagUnity
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
     static extern bool GlobalMemoryStatusEx([In, Out] MEMORYSTATUSEX lpBuffer);
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+       
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
     private class MEMORYSTATUSEX
     {
       public uint dwLength;


### PR DESCRIPTION
## Goal

To provide a way to enable and disable anr reporting on the fly without using the config.

## Design

Just a simple addition to the interface. I did a check with the team if it was ok to have dummy implementations in the platforms that don't have anrs and was given the go ahead.

## Changeset

I extended the interface and made the method publicly available in the Bugsnag class

## Testing

I tested manually with unity 2018 and android simulator. 