### PR TITLE
Coerce non-string breadcrumbs into strings

### DIFF
--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -524,7 +524,8 @@ namespace BugsnagUnity
 
         if (key != IntPtr.Zero && value != IntPtr.Zero)
         {
-          metadata.Add(AndroidJNI.GetStringUTFChars(key), AndroidJNI.GetStringUTFChars(value));
+          var obj = AndroidJNI.CallStringMethod(value, ObjectToString, new jvalue[]{});
+          metadata.Add(AndroidJNI.GetStringUTFChars(key), obj);
         }
         AndroidJNI.DeleteLocalRef(key);
         AndroidJNI.DeleteLocalRef(value);


### PR DESCRIPTION
## Goal

When calling `Bugsnag.Notify()` on an Android emulator a JNI error was detected when attempting to call `GetStringUTFChars` on a `java/lang/Boolean`. The cause was found to be a boolean metadata value on a breadcrumb - previously the notifier had assumed that these values would always be of type `jstring`.

## Changeset

Called `toString()` on the object rather than `GetStringUTFChars`.

## Testing

Manually verified on an emulator that errors can be sent.