### PR TITLE
Update committed files to avoid dirtying working directory

### DIFF
--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagApp.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagApp.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c6fbc70f2d7604672b4bcf50826cabda
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagAppWithState.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagAppWithState.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 75c61630e86024ff7a21f25843608914
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagClient.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagClient.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4602c3cf7a89946a4a049ee2a6fd2c7d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagDevice.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagDevice.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4898bfe97b4984de7b6af27667220846
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagDeviceWithState.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagDeviceWithState.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ff1b5a20b7f604e458d05558041e1ca5
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagEndpointConfiguration.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagEndpointConfiguration.h.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
-guid: 90144f3aee7ab4c2186dcdb9fda62893
-timeCreated: 1531183623
-licenseType: Free
+guid: 550c3f25c56724846866c6429bcf3524
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagError.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagError.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 29ff5dbad5e634a2ebbc8cbe3541a036
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagErrorTypes.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagErrorTypes.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 92284e84cb22d425aa901366d8743e69
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagEvent.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagEvent.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2844da95875a348bead7f0c261c56003
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagLastRunInfo.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagLastRunInfo.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b7c2c225951de45a9ac72aa22b75cd13
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagMetadataStore.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagMetadataStore.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5ad291ca843924e778938413c8c94f35
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagPlugin.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagPlugin.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3c1bda4ba224846ca85c349490c01a6b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagSession.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagSession.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c2ac6485b5b3148b8be62d4d1ad274eb
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagStackframe.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagStackframe.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9cca2fa73507b424b9cd7e1d3fa68daf
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagThread.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagThread.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f1a38da9a7f7d473c900966b70166a14
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagUser.h.meta
+++ b/unity/PackageProject/Assets/Plugins/OSX/Bugsnag/bugsnag-osx.bundle/Contents/Headers/BugsnagUser.h.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9e3d31448a61a4cc9b4efa533ffcb212
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Goal

Update the `.meta` files committed to git to avoid dirtying the tree when running `rake plugin:export`.

## Design

It looks like this crept in after the native Cocoa notifier was updated.

## Testing

Tested locally to verify that the tree is clean after building the notifier.