### PR TITLE
Add building of mobile test fixture to Rakefile

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,7 +108,7 @@ steps:
         upload:
           - test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk
     commands:
-      - ./test/mobile/features/scripts/build_fixture.sh
+      - rake test:mobile:build
     concurrency: 2
     concurrency_group: 'unity-license'
 
@@ -147,7 +147,7 @@ steps:
         upload:
           - test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.apk
     commands:
-      - ./test/mobile/features/scripts/build_fixture.sh
+      - rake test:mobile:build
     concurrency: 2
     concurrency_group: 'unity-license'
 
@@ -187,7 +187,7 @@ steps:
         upload:
           - test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.apk
     commands:
-      - ./test/mobile/features/scripts/build_fixture.sh
+      - rake test:mobile:build
     concurrency: 2
     concurrency_group: 'unity-license'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,7 +108,7 @@ steps:
         upload:
           - test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk
     commands:
-      - rake test:mobile:build
+      - rake test:android:build
     concurrency: 2
     concurrency_group: 'unity-license'
 
@@ -147,7 +147,7 @@ steps:
         upload:
           - test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.apk
     commands:
-      - rake test:mobile:build
+      - rake test:android:build
     concurrency: 2
     concurrency_group: 'unity-license'
 
@@ -187,7 +187,7 @@ steps:
         upload:
           - test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.apk
     commands:
-      - rake test:mobile:build
+      - rake test:android:build
     concurrency: 2
     concurrency_group: 'unity-license'
 

--- a/Rakefile
+++ b/Rakefile
@@ -343,7 +343,7 @@ namespace :example do
 end
 
 namespace :test do
-  namespace :mobile do
+  namespace :android do
     task :build do
 
       # Check that a Unity version has been selected and the path exists before calling the build script

--- a/Rakefile
+++ b/Rakefile
@@ -341,3 +341,27 @@ namespace :example do
     task all: %w[example:build:ios example:build:android]
   end
 end
+
+namespace :test do
+  namespace :mobile do
+    task :build do
+
+      # Check that a Unity version has been selected and the path exists before calling the build script
+      if ENV.has_key? 'UNITY_VERSION'
+        unity_path = "/Applications/Unity/Hub/Editor/#{ENV['UNITY_VERSION']}/Unity.app/Contents/MacOS"
+      else
+        raise 'UNITY_VERSION must be set'
+      end
+      unity = File.join(unity_path, "Unity")
+      unless File.exists? unity
+        raise "Unity not found at path #{unity}"
+      end
+
+      env = { "UNITY_PATH" => unity_path }
+      script = File.join("test", "mobile", "features", "scripts", "build_fixture.sh")
+      unless system env, script
+        raise 'Maze Runner tests failed'
+      end
+    end
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -360,7 +360,7 @@ namespace :test do
       env = { "UNITY_PATH" => unity_path }
       script = File.join("test", "mobile", "features", "scripts", "build_fixture.sh")
       unless system env, script
-        raise 'Maze Runner tests failed'
+        raise 'Build failed'
       end
     end
   end

--- a/TESTING.md
+++ b/TESTING.md
@@ -25,7 +25,7 @@ This will generate the following files:
 
 To build the Android test fixture:
 ```
-UNITY_VERSION=2018.4.34f1 rake test:mobile:build
+UNITY_VERSION=2018.4.34f1 rake test:android:build
 ```
 Where `UNITY_VERSION` corresponds to the Unity installation path, e.g:
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -25,7 +25,7 @@ This will generate the following files:
 
 To build the Android test fixture:
 ```
-UNITY_VERSION=2018.4.34f1 ./test/mobile/features/scripts/build_fixture.sh
+UNITY_VERSION=2018.4.34f1 rake test:mobile:build
 ```
 Where `UNITY_VERSION` corresponds to the Unity installation path, e.g:
 ```

--- a/test/mobile/features/scripts/build_fixture.sh
+++ b/test/mobile/features/scripts/build_fixture.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
-if [ -z "$UNITY_VERSION" ]
+if [ -z "$UNITY_PATH" ]
 then
-  echo "UNITY_VERSION must be set"
+  echo "UNITY_PATH must be set, to e.g. /Applications/Unity/Hub/Editor/2017.4.40f1/Unity.app/Contents/MacOS"
   exit 1
-else
-  export PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS:$PATH"
-  echo "\`which Unity\`=`which Unity`"
 fi
+
+echo "\`which Unity\`=`which Unity`"
 
 pushd "${0%/*}"
   script_path=`pwd`
@@ -21,16 +20,16 @@ DEFAULT_CLI_ARGS="-quit -batchmode -logFile unity.log -noUpm"
 project_path=`pwd`/maze_runner
 
 # Creating a new project in the MyProject directory
-Unity $DEFAULT_CLI_ARGS -createProject $project_path
+$UNITY_PATH/Unity $DEFAULT_CLI_ARGS -createProject $project_path
 
 # Installing the Bugsnag package
 echo "Importing Bugsnag.unitypackage into $project_path"
-Unity $DEFAULT_CLI_ARGS -projectPath $project_path -importPackage $script_path/../../../../Bugsnag.unitypackage
+$UNITY_PATH/Unity $DEFAULT_CLI_ARGS -projectPath $project_path -importPackage $script_path/../../../../Bugsnag.unitypackage
 RESULT=$?
 if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 
 echo "Importing Bugsnag-with-android-64bit.unitypackage into $project_path"
-Unity $DEFAULT_CLI_ARGS -projectPath $project_path -importPackage $script_path/../../../../Bugsnag-with-android-64bit.unitypackage
+$UNITY_PATH/Unity $DEFAULT_CLI_ARGS -projectPath $project_path -importPackage $script_path/../../../../Bugsnag-with-android-64bit.unitypackage
 RESULT=$?
 if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 
@@ -40,7 +39,7 @@ cp Assets/Editor/Builder.cs maze_runner/Assets/Scripts/
 cp Assets/Plugins/Android/AndroidManifest.xml maze_runner/Assets/Plugins/Android
 
 # Running a custom script - must reference a static method
-Unity $DEFAULT_CLI_ARGS -projectPath $project_path -executeMethod Builder.AndroidBuild
+$UNITY_PATH/Unity $DEFAULT_CLI_ARGS -projectPath $project_path -executeMethod Builder.AndroidBuild
 RESULT=$?
 if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 


### PR DESCRIPTION
## Goal

Add the `test:mobile:build` target to the Rakefile, making the method for building the test fixture more consistent with building the plugin.  Some more checks on the required environment and whether `Unity` exists in the expected location have also been added.

## Testing

Tested locally and on CI.