### PR TITLE
Implement SetAutoNotify for Cocoa

### DIFF
--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -25,7 +25,11 @@ extern "C" {
 
   void bugsnag_setAppVersion(const void *configuration, char *appVersion);
 
-  void bugsnag_setAutoNotify(const void *configuration, bool autoNotify);
+  void bugsnag_setAutoNotifyConfig(const void *configuration, bool autoNotify);
+
+  void bugsnag_setAppHangs(const void *configuration, bool appHangs);
+
+  void bugsnag_setAutoNotify(bool autoNotify);
 
   void bugsnag_setContext(const void *configuration, char *context);
 
@@ -82,8 +86,16 @@ void bugsnag_setContext(const void *configuration, char *context) {
   ((__bridge BugsnagConfiguration *)configuration).context = ns_Context;
 }
 
-void bugsnag_setAutoNotify(const void *configuration, bool autoNotify) {
+void bugsnag_setAutoNotifyConfig(const void *configuration, bool autoNotify) {
   ((__bridge BugsnagConfiguration *)configuration).autoDetectErrors = autoNotify;
+}
+
+void bugsnag_setAppHangs(const void *configuration, bool appHangs) {
+  ((__bridge BugsnagConfiguration *)configuration).enabledErrorTypes.appHangs = appHangs;
+}
+
+void bugsnag_setAutoNotify(bool autoNotify) {
+  Bugsnag.client.autoNotify = autoNotify;
 }
 
 void bugsnag_setNotifyUrl(const void *configuration, char *notifyURL) {

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -28,7 +28,8 @@ namespace BugsnagUnity
      */
     IntPtr CreateNativeConfig(IConfiguration config) {
       IntPtr obj = NativeCode.bugsnag_createConfiguration(config.ApiKey);
-      NativeCode.bugsnag_setAutoNotify(obj, config.AutoNotify);
+      NativeCode.bugsnag_setAppHangs(obj, false);
+      NativeCode.bugsnag_setAutoNotifyConfig(obj, config.AutoNotify);
       NativeCode.bugsnag_setReleaseStage(obj, config.ReleaseStage);
       NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);
       NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
@@ -177,7 +178,7 @@ namespace BugsnagUnity
 
     public void SetAutoNotify(bool autoNotify)
     {
-      NativeCode.bugsnag_setAutoNotify(NativeConfiguration, autoNotify);
+      NativeCode.bugsnag_setAutoNotify(autoNotify);
     }
 
     public void SetAutoDetectAnrs(bool autoDetectAnrs)

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -36,7 +36,13 @@ namespace BugsnagUnity
     internal static extern void bugsnag_setReleaseStage(IntPtr configuration, string releaseStage);
 
     [DllImport(Import)]
-    internal static extern void bugsnag_setAutoNotify(IntPtr configuration, bool autoNotify);
+    internal static extern void bugsnag_setAutoNotify(bool autoNotify);
+
+    [DllImport(Import)]
+    internal static extern void bugsnag_setAutoNotifyConfig(IntPtr configuration, bool autoNotify);
+
+    [DllImport(Import)]
+    internal static extern void bugsnag_setAppHangs(IntPtr configuration, bool appHangs);
 
     [DllImport(Import)]
     internal static extern void bugsnag_setContext(IntPtr configuration, string context);


### PR DESCRIPTION
## Goal

Alters bugsnag-unity so that it is capable of supporting [Unity's AutoNotify](https://docs.bugsnag.com/platforms/unity/configuration-options/#autonotify) API, which allows automatic error detection to be enabled/disabled after Bugsnag has initialized. This builds on the following changes: https://github.com/bugsnag/bugsnag-cocoa/pull/1093

## Changeset

- Disabled app hang detection by default for parity with v5 cocoa behaviour
- Added separate methods for calling `autoNotify` on the Cocoa config/client objects

## Testing

Tested manually with verification on the dashboard:
- Bugsnag embedded in a game object with autoNotify true / false
- Bugsnag initialised in code with config.autoNotify true / false
