### PR TITLE
fix(Config.context): Setting context on Unity does not update C# errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * Add SetAutoDetectAnrs method to Bugsnag interface
   [#246](https://github.com/bugsnag/bugsnag-unity/pull/246)
+  
+* Stop scene changes overiding context when manually set
+  [#255](https://github.com/bugsnag/bugsnag-unity/pull/255)
 
 * Dont Destroy TimingTrackerObject, so it persists across scenes
   [#239](https://github.com/bugsnag/bugsnag-unity/pull/239)

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -66,9 +66,11 @@ namespace BugsnagUnity
       UnityMetadata.InitDefaultMetadata();
       Device.InitUnityVersion();
       NativeClient.SetMetadata(UnityMetadataKey, UnityMetadata.ForNativeClient());
-
       NativeClient.PopulateUser(User);
-
+      if (!string.IsNullOrEmpty(nativeClient.Configuration.Context))
+      {
+        _contextSetManually = true;
+      }
       SceneManager.sceneLoaded += SceneLoaded;
       Application.logMessageReceivedThreaded += MultiThreadedNotify;
       Application.logMessageReceived += Notify;

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -49,6 +49,8 @@ namespace BugsnagUnity
 
     private static object autoSessionLock = new object();
 
+    private static bool _contextSetManually;
+
     public Client(INativeClient nativeClient)
     {
       MainThread = Thread.CurrentThread;
@@ -100,7 +102,10 @@ namespace BugsnagUnity
     /// <param name="loadSceneMode"></param>
     void SceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
     {
-      Configuration.Context = scene.name;
+     if (!_contextSetManually)
+     {
+        Configuration.Context = scene.name;
+     }
       Breadcrumbs.Leave("Scene Loaded", BreadcrumbType.State, new Dictionary<string, string> { { "sceneName", scene.name } });
     }
 
@@ -320,6 +325,9 @@ namespace BugsnagUnity
 
     public void SetContext(string context)
     {
+
+      _contextSetManually = true;
+
       // set the context property on Configuration, as it currently holds the global state
       Configuration.Context = context;
 

--- a/test/desktop/features/context.feature
+++ b/test/desktop/features/context.feature
@@ -1,0 +1,12 @@
+Feature: Checking the context of requests
+
+
+ Scenario: Manually setting the context and then loading a scene
+        When I run the game in the "CheckForManualContextAfterSceneLoad" state
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the payload field "events" is an array with 1 element
+        And the payload field "notifier.name" equals "Unity Bugsnag Notifier"
+        And the event "context" equals "Manually-Set"

--- a/test/desktop/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/test/desktop/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using BugsnagUnity;
 using BugsnagUnity.Payload;
+using UnityEngine.SceneManagement;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -286,6 +287,9 @@ public class Main : MonoBehaviour {
       case "NativeCrashReEnableAutoNotify":
         crashy_signal_runner(8);
         break;
+            case "CheckForManualContextAfterSceneLoad":
+                StartCoroutine(SetManualContextReloadSceneAndNotify());
+                break;
       case "AutoSessionNativeCrash":
         new Thread(() => {
           Thread.Sleep(900);
@@ -358,6 +362,14 @@ public class Main : MonoBehaviour {
     yield return new WaitForSeconds(1);
     Bugsnag.Notify(new ExecutionEngineException("Invalid runtime"));
   }
+
+    IEnumerator SetManualContextReloadSceneAndNotify()
+    {
+        Bugsnag.SetContext("Manually-Set");
+        SceneManager.LoadScene(0);
+        yield return new WaitForSeconds(0.5f);
+        Bugsnag.Notify(new System.Exception("ManualContext"));
+    }
 
   void LeaveMessageBreadcrumbAndNotify() {
     Bugsnag.LeaveBreadcrumb("Initialize bumpers");


### PR DESCRIPTION
## Goal

Scene changes were overriding the manually set context values

## Design

It's a simple flag setup that fixes the current setup

## Changeset

Added a bool that is set ot true when Bugsnag.SetContext is called. Then check for that bool in the Scene loaded listener

## Testing

Tested manually in editor