### PR TITLE
Enable ios app hangs

### DIFF
--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -28,7 +28,7 @@ namespace BugsnagUnity
      */
     IntPtr CreateNativeConfig(IConfiguration config) {
       IntPtr obj = NativeCode.bugsnag_createConfiguration(config.ApiKey);
-      NativeCode.bugsnag_setAppHangs(obj, false);
+      NativeCode.bugsnag_setAppHangs(obj, true);
       NativeCode.bugsnag_setAutoNotifyConfig(obj, config.AutoNotify);
       NativeCode.bugsnag_setReleaseStage(obj, config.ReleaseStage);
       NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);


### PR DESCRIPTION
## Goal

PLAT-6566

Enable app hang notification in ios by default.

## Testing

Manual testing by triggering app hangs
