### PR TITLE
fix(C# API): remove Bugsnag.Client from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Remove Bugsnag.Client from public API 
+  [#259](https://github.com/bugsnag/bugsnag-unity/pull/259)
+
 * Add SetAutoDetectAnrs method to Bugsnag interface
   [#246](https://github.com/bugsnag/bugsnag-unity/pull/246)
   

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,7 +43,7 @@ config.AutoNotify = true;
 
 ### Bugsnag.Configuration accessor removed
 
-The `Bugsnag.Configuration` accessor has been removed. You should supply all your configuration options up-front as recommended [here](#new-recommended-way-for-initializing-bugsnag).
+The `Bugsnag.Configuration` and `Bugsnag.Client.Configuration` accessors have been removed. You should supply all your configuration options up-front as recommended [here](#new-recommended-way-for-initializing-bugsnag).
 
 ### AutoNotify and Context replaced
 

--- a/example/Assets/Main.cs
+++ b/example/Assets/Main.cs
@@ -135,14 +135,14 @@ public class Main : MonoBehaviour
 			int b = 1;
 			int c = b / a;
 		} catch (Exception e) {
-			BugsnagUnity.Bugsnag.Client.Notify(e);
+			BugsnagUnity.Bugsnag.Notify(e);
 		}
 	}
 
 	private void OnNotifyClick()
 	{
 		Debug.Log ("Notify clicked");
-		 BugsnagUnity.Bugsnag.Client.Notify(new Exception ("Notify clicked!"), report =>
+		 BugsnagUnity.Bugsnag.Notify(new Exception ("Notify clicked!"), report =>
 		 	{
 		 		report.Context = "NotifyClicked";
 		 	});

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -28,7 +28,7 @@ namespace BugsnagUnity
 
     static Client InternalClient { get; set; }
 
-    public static IClient Client => InternalClient;
+    private static IClient Client => InternalClient;
 
     public static IBreadcrumbs Breadcrumbs => Client.Breadcrumbs;
 


### PR DESCRIPTION
## Goal

The Exposed Client class was not necessary and potentially confusing

## Design

I just made it private, any functionality we need will be added to the BugSnag class

## Changeset

Changed BugSnag.Client to private

## Testing

Manually tested