### PR TITLE
Unity iphone ipa name fix

### DIFF
--- a/test/mobile/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
+++ b/test/mobile/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: DefaultCompany
-  productName: maze_runner
+  productName: Unity-iPhone
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}


### PR DESCRIPTION
## Goal

Different xcode version were putting out different named ipas and breaking tests

## Design

Simple and quick fix with no consequences 

## Changeset

Changed the player setting Product Name in the mobile fixture to Unity-iPhone

## Testing

Manually built and checked the name of the ipa from xcode 12