### PR TITLE
Propagate context changes to native clients

### DIFF
--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -107,6 +107,9 @@ namespace BugsnagUnity
      if (!_contextSetManually)
      {
         Configuration.Context = scene.name;
+
+        // propagate the change to the native property also
+        NativeClient.SetContext(scene.name);
      }
       Breadcrumbs.Leave("Scene Loaded", BreadcrumbType.State, new Dictionary<string, string> { { "sceneName", scene.name } });
     }


### PR DESCRIPTION
## Goal

When the context changed via a scene load it was not set on the native client, meaning the context defaulted to `UnityPlayerActivity` on these events. The change has now been propagated to the native client for both iOS + Android so that the context is correct.

## Testing

Manually verified on the Android example app.