### PR TITLE
test: support different .ipa outputs in MR build

### DIFF
--- a/test/mobile/features/scripts/build_ios.sh
+++ b/test/mobile/features/scripts/build_ios.sh
@@ -6,6 +6,9 @@ popd
 pushd "$script_path/../fixtures"
 project_path=`pwd`/maze_runner
 
+# Clean any previous builds
+find $project_path/output/ -name "*.ipa" -exec rm '{}' \;
+
 # Archive and export the project
 xcrun xcodebuild -project $project_path/mazerunner_xcode/Unity-iPhone.xcodeproj \
                  -scheme Unity-iPhone \
@@ -33,4 +36,5 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-mv $project_path/output/Unity-iPhone.ipa $project_path/mazerunner_$UNITY_VERSION.ipa
+# Move to known location for running (note - the name of the .ipa differs between Xcode versions)
+find $project_path/output/ -name "*.ipa" -exec mv '{}' $project_path/mazerunner_$UNITY_VERSION.ipa \;


### PR DESCRIPTION
## Goal

Xcode 11 and Xcode 12 output different .ipa names - the product name "maze_runner" in Xcode 11 and the bundle name "Unity-iPhone" in Xcode 12. We move it to a versioned path anyway, so a simple fix is just to wildcard the `mv` command.

## Testing

Run this in a dummy set of files as I don't have e2e tests running locally.