### PR TITLE
Build unity project twice to ensure -ObjC flag is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ bugsnag-cocoa-build/
 unity.log
 bugsnag-android-unity/.cxx
 test/**/*.app.zip
+*.ipa
+**/maze_runner/output/

--- a/test/mobile/features/scripts/generate_xcode_project.sh
+++ b/test/mobile/features/scripts/generate_xcode_project.sh
@@ -23,3 +23,11 @@ project_path=`pwd`/maze_runner
 $UNITY_PATH/Unity $DEFAULT_CLI_ARGS -projectPath $project_path -executeMethod Builder.IosBuild
 RESULT=$?
 if [ $RESULT -ne 0 ]; then exit $RESULT; fi
+
+# Unity needs an -ObjC linker flag but using the undocumented SetAdditionalIl2CppArgs method appears to have no effect
+# a clean build. Building the project twice is a temporary workaround that circumnavigates what
+# appears to be a platform bug.
+# For further context see https://answers.unity.com/questions/1610105/how-to-add-compiler-or-linker-flags-for-il2cpp-inv.html
+$UNITY_PATH/Unity $DEFAULT_CLI_ARGS -projectPath $project_path -executeMethod Builder.IosBuild
+RESULT=$?
+if [ $RESULT -ne 0 ]; then exit $RESULT; fi


### PR DESCRIPTION
## Goal

Builds the unity iOS test fixture twice, which circumvents an apparent platform bug where the `-ObjC` linker flag is not set on a clean IL2CPP build.

## Testing

Tested by manually building the project before and after the changeset, after running `git clean -dfx`.