### PR TITLE
Add upgrade note for event payload

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -61,6 +61,11 @@ Bugsnag.SetAutoNotify(false);
 Bugsnag.SetContext("MyContext");
 ```
 
+### Event payload changes
+
+- (Android) Removed `packageName` from the app metadata tab, as the field is duplicated by `app.id`
+- (Android) Removed `versionName` from the app metadata tab, as the field is duplicated by `app.version` and this has been known to cause confusion amongst users in the past
+
 ## 4.1 to 4.2
 
 4.2.0 adds support for reporting C/C++ crashes in Android code. If you are using


### PR DESCRIPTION
## Goal

Adds a note that a couple of event payload fields have been removed on Android. This mirrors the upgrading notes from the Android notifier: https://github.com/bugsnag/bugsnag-android/blob/next/UPGRADING.md