### PR TITLE
chore(test setup) update cocoa sub module and remove linker setting in build script

### DIFF
--- a/test/mobile/features/fixtures/maze_runner/Assets/Scripts/Builder.cs
+++ b/test/mobile/features/fixtures/maze_runner/Assets/Scripts/Builder.cs
@@ -25,7 +25,6 @@ public class Builder : MonoBehaviour
     {
         Debug.Log("Building iOS app...");
         PlayerSettings.SetApplicationIdentifier(BuildTargetGroup.iOS, "com.bugsnag.unity.mazerunner");
-        PlayerSettings.SetAdditionalIl2CppArgs("--linker-flags=ObjC");
         PlayerSettings.iOS.appleDeveloperTeamID = "372ZUL2ZB7";
         PlayerSettings.iOS.appleEnableAutomaticSigning = true;
         PlayerSettings.iOS.allowHTTPDownload = true;


### PR DESCRIPTION

## Goal

Needed update to fix manual linker flag issue in test fixtures

## Changeset

Update cocoa sub mod to point at next, removed line in build script for adding the linker flag

## Testing

Manually built and tested on iphone and macos