### PR TITLE
chore(example) rout native cocoa code for macos and tvos

### DIFF
--- a/example/Assets/Plugins/OSX/native_code_osx.mm
+++ b/example/Assets/Plugins/OSX/native_code_osx.mm
@@ -1,0 +1,27 @@
+#include <stdexcept>
+#include <stdlib.h>
+#include <unistd.h>
+
+#import <dispatch/dispatch.h>
+
+
+extern "C" {
+  void RaiseCocoaSignal();
+  void TriggerCocoaCppException();
+  void TriggerCocoaAppHang();
+}
+
+void RaiseCocoaSignal() {
+    abort();
+}
+
+void TriggerCocoaCppException() {
+    throw std::runtime_error("CocoaCppException");
+}
+
+void TriggerCocoaAppHang() {
+    dispatch_async(dispatch_get_global_queue(0,0), ^{
+        sleep(10000);
+    });
+}
+

--- a/example/Assets/Plugins/OSX/native_code_osx.mm
+++ b/example/Assets/Plugins/OSX/native_code_osx.mm
@@ -20,7 +20,7 @@ void TriggerCocoaCppException() {
 }
 
 void TriggerCocoaAppHang() {
-    dispatch_async(dispatch_get_global_queue(0,0), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         sleep(10000);
     });
 }

--- a/example/Assets/Plugins/OSX/native_code_osx.mm.meta
+++ b/example/Assets/Plugins/OSX/native_code_osx.mm.meta
@@ -1,0 +1,111 @@
+fileFormatVersion: 2
+guid: 452530c90d50a4f43925f4328f1072d1
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      '': Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 1
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: LinuxUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CompileFlags: 
+        FrameworkDependencies: 
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/example/Assets/Scripts/Main.cs
+++ b/example/Assets/Scripts/Main.cs
@@ -36,7 +36,7 @@ public class Main : MonoBehaviour
 	}
 #endif
 
-#if UNITY_IOS
+#if UNITY_IOS || UNITY_STANDALONE_OSX || UNITY_TVOS
 	[DllImport("__Internal")]
 	private static extern void RaiseCocoaSignal();
 
@@ -127,7 +127,7 @@ public class Main : MonoBehaviour
 	{
 		Debug.Log("OnNativeSignalClicked");
 
-#if UNITY_IOS && !UNITY_EDITOR
+#if UNITY_IOS || UNITY_STANDALONE_OSX || UNITY_TVOS && !UNITY_EDITOR
 		RaiseCocoaSignal();
 #elif UNITY_ANDROID && !UNITY_EDITOR
 		using (var java = new AndroidJavaObject("com.example.lib.BugsnagCrash")) {
@@ -142,7 +142,7 @@ public class Main : MonoBehaviour
 	{
 		Debug.Log("OnNativeCppExceptionClicked");
 
-#if UNITY_IOS && !UNITY_EDITOR
+#if UNITY_IOS || UNITY_STANDALONE_OSX || UNITY_TVOS && !UNITY_EDITOR
 		TriggerCocoaCppException();
 #elif UNITY_ANDROID && !UNITY_EDITOR
 		using (var java = new AndroidJavaObject("com.example.lib.BugsnagCrash")) {
@@ -182,7 +182,7 @@ public class Main : MonoBehaviour
 	{
 		Debug.Log("OnOutOfMemoryClicked");
 
-#if UNITY_IOS && !UNITY_EDITOR
+#if UNITY_IOS || UNITY_STANDALONE_OSX || UNITY_TVOS && !UNITY_EDITOR
 		var list = new List<object>();
 		while (true)
 		{
@@ -205,7 +205,7 @@ public class Main : MonoBehaviour
 	{
 		Debug.Log("OnAppHangClicked");
 
-#if UNITY_IOS && !UNITY_EDITOR
+#if UNITY_IOS || UNITY_STANDALONE_OSX || UNITY_TVOS && !UNITY_EDITOR
 		TriggerCocoaAppHang();
 #else
 		WarnPlatformNotSupported();


### PR DESCRIPTION
## Goal

The native code was not setup for MacOS and TV_OS

## Design

Had to create a new native file for MacOS due to differing API

## Changeset

create a new native file for MacOS and added extra conditional compilation checks for macos and tvos in the main example script

## Testing

Manually built and tested on MacOS, build tested for tvos but not tested on device