### PR TITLE
Set context correctly for Cocoa native layer

### DIFF
--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -32,6 +32,7 @@ extern "C" {
   void bugsnag_setAutoNotify(bool autoNotify);
 
   void bugsnag_setContext(const void *configuration, char *context);
+  void bugsnag_setContextConfig(const void *configuration, char *context);
 
   void bugsnag_setNotifyUrl(const void *configuration, char *notifyURL);
 
@@ -82,6 +83,11 @@ void bugsnag_setAppVersion(const void *configuration, char *appVersion) {
 }
 
 void bugsnag_setContext(const void *configuration, char *context) {
+  NSString *ns_Context = context == NULL ? nil : [NSString stringWithUTF8String: context];
+  [Bugsnag.client setContext:ns_Context];
+}
+
+void bugsnag_setContextConfig(const void *configuration, char *context) {
   NSString *ns_Context = context == NULL ? nil : [NSString stringWithUTF8String: context];
   ((__bridge BugsnagConfiguration *)configuration).context = ns_Context;
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -35,7 +35,7 @@ namespace BugsnagUnity
       NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
 
       if (config.Context != null) {
-        NativeCode.bugsnag_setContext(obj, config.Context);
+        NativeCode.bugsnag_setContextConfig(obj, config.Context);
       }
       var releaseStages = config.NotifyReleaseStages;
       if (releaseStages != null) {

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -48,6 +48,9 @@ namespace BugsnagUnity
     internal static extern void bugsnag_setContext(IntPtr configuration, string context);
 
     [DllImport(Import)]
+    internal static extern void bugsnag_setContextConfig(IntPtr configuration, string context);
+
+    [DllImport(Import)]
     internal static extern void bugsnag_setAppVersion(IntPtr configuration, string appVersion);
 
     [DllImport(Import)]


### PR DESCRIPTION
## Goal

Sets the context correctly for crashes which occur in the native layer of Cocoa. The current implementation was calling `config.context`, whereas it should be calling `[Bugsnag setContext]` - as this updates the information that is serialized into Cocoa crash reports.

## Testing

TODO: test on a physical device