### PR TITLE
Avoid using jcenter() in Unity gradle scripts

### DIFF
--- a/bugsnag-android-unity/build.gradle
+++ b/bugsnag-android-unity/build.gradle
@@ -2,18 +2,16 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.2"
+        classpath "com.android.tools.build:gradle:4.2.1"
     }
 }
 
 repositories {
     google()
     mavenCentral()
-    jcenter()
 }
 
 apply plugin: "com.android.library"

--- a/example/android-lib-proj/android-lib/build.gradle
+++ b/example/android-lib-proj/android-lib/build.gradle
@@ -4,6 +4,7 @@ android {
     compileSdkVersion 30
     defaultConfig {
         minSdkVersion 14
+        ndkVersion = "16.1.4479499"
     }
 
     externalNativeBuild {

--- a/example/android-lib-proj/build.gradle
+++ b/example/android-lib-proj/build.gradle
@@ -4,11 +4,10 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.0"
+        classpath "com.android.tools.build:gradle:4.2.1"
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -19,7 +18,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 

--- a/test/mobile/features/fixtures/maze_runner/nativeplugin/android/build.gradle
+++ b/test/mobile/features/fixtures/maze_runner/nativeplugin/android/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.0"
+        classpath "com.android.tools.build:gradle:4.2.1"
     }
 }
 
@@ -13,7 +13,6 @@ apply plugin: "com.android.library"
 repositories {
     google()
     mavenCentral()
-    jcenter()
 }
 
 android {
@@ -22,6 +21,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 30
+        ndkVersion = "16.1.4479499"
     }
     externalNativeBuild.cmake.path "CMakeLists.txt"
 }


### PR DESCRIPTION
## Goal

Removes jcenter() from gradle build scripts in bugsnag-unity. Note that the bugsnag-android submodule does still contain jcenter() - this will be addressed in a separate ticket and then brought across as part of a bugsnag-android dependency update.

## Testing

Assembled each changed project, and relied on existing test coverage.
