### PR TITLE
Silence iOS test fixtures build warnings

### DIFF
--- a/test/mobile/features/scripts/build_ios.sh
+++ b/test/mobile/features/scripts/build_ios.sh
@@ -17,6 +17,7 @@ xcrun xcodebuild -project $project_path/mazerunner_xcode/Unity-iPhone.xcodeproj 
                  -allowProvisioningUpdates \
                  -allowProvisioningDeviceRegistration \
                  -quiet \
+                 GCC_WARN_INHIBIT_ALL_WARNINGS=YES \
                  archive
 
 if [ $? -ne 0 ]


### PR DESCRIPTION
## Goal

Use `GCC_WARN_INHIBIT_ALL_WARNINGS` for the iOS e2e test fixture builds to substantially rebuild the build log output.