### PR TITLE
fix(android session start time): change session start to total milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,9 @@ Please see the [upgrade guide](UPGRADING.md) for details of all the changes and 
 
 ### Bug fixes
   
-* Stop scene changes overiding context when manually set
-  [#255](https://github.com/bugsnag/bugsnag-unity/pull/255)
+* Correct android session start times
+  [#291](https://github.com/bugsnag/bugsnag-unity/pull/291)
 
-* Dont Destroy TimingTrackerObject, so it persists across scenes
-  [#239](https://github.com/bugsnag/bugsnag-unity/pull/239)
 
 ## 4.8.8 (2021-04-21)
 

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -264,7 +264,7 @@ namespace BugsnagUnity
         });
       } else {
         // The ancient version of the runtime used doesn't have an equivalent to GetUnixTime()
-        var startedAt = (long)Math.Floor( (session.StartedAt - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalMilliseconds);
+        var startedAt = (long)(session.StartedAt - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalMilliseconds;
         CallNativeVoidMethod("registerSession", "(JLjava/lang/String;II)V", new object[]{
           startedAt, session.Id.ToString(), session.UnhandledCount(),
           session.HandledCount()

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -264,7 +264,7 @@ namespace BugsnagUnity
         });
       } else {
         // The ancient version of the runtime used doesn't have an equivalent to GetUnixTime()
-        var startedAt = (session.StartedAt - new DateTime(1970, 1, 1, 0, 0, 0, 0)).Milliseconds;
+        var startedAt = (long)Math.Floor( (session.StartedAt - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalMilliseconds);
         CallNativeVoidMethod("registerSession", "(JLjava/lang/String;II)V", new object[]{
           startedAt, session.Id.ToString(), session.UnhandledCount(),
           session.HandledCount()


### PR DESCRIPTION
## Goal

Session start times on android were 1970

## Design

Simple fix to past mistake

## Changeset

Changed from sending the current milliseconds to the total, and cast it to a long

## Testing

Manually tested on device 