### PR TITLE
fix(log messages): adapt regex to ignore timestamps at the start of log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This version contains **breaking** changes, as bugsnag-unity has been updated to
 
 
 ### Bug fixes
+* Timestamps in log messages
+  [#292](https://github.com/bugsnag/bugsnag-unity/pull/292)
   
 * Fix MaxBreadcrumbs config setting
   [#275](https://github.com/bugsnag/bugsnag-unity/pull/275)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This version contains **breaking** changes, as bugsnag-unity has been updated to
 
 
 ### Bug fixes
-* Timestamps in log messages
+* Fix an issue where timestamps and other `:`-containing log message content was interpreted as the error class
   [#292](https://github.com/bugsnag/bugsnag-unity/pull/292)
   
 * Fix MaxBreadcrumbs config setting

--- a/src/BugsnagUnity/Payload/Exception.cs
+++ b/src/BugsnagUnity/Payload/Exception.cs
@@ -65,7 +65,7 @@ namespace BugsnagUnity.Payload
     internal HandledState HandledState { get; }
 
     private static string AndroidJavaErrorClass = "AndroidJavaException";
-    private static string ErrorClassMessagePattern = @"^(?<errorClass>\S+):\s*(?<message>.*)";
+    private static string ErrorClassMessagePattern = @"^(?<errorClass>\S+):\s+(?<message>.*)";
     private static string BugsnagStackTraceMarker = "libbugsnag";
 
     internal Exception(string errorClass, string message, StackTraceLine[] stackTrace)


### PR DESCRIPTION
## Goal

The current regex was mistaking timestamps for the error class

## Design

A simple fix

## Changeset

Changed the regex that looks for an error class name

## Testing

Manually tested in editor