### PR TITLE
6600 6599 refactor unity metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@
 This version contains **breaking** changes, as bugsnag-unity has been updated to use the latest available versions of bugsnag-android (v4.22.2 -> v5.9.4) and bugsnag-cocoa (v5.23.5 -> v6.9.3).
 
 
+### Enhancements
+
+* Added more metadata to events and removed duplicate/unnecessary metadata
+	[#297](https://github.com/bugsnag/bugsnag-unity/pull/297)
+	
 ### Bug fixes
+
 * Fix an issue where timestamps and other `:`-containing log message content was interpreted as the error class
   [#292](https://github.com/bugsnag/bugsnag-unity/pull/292)
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This version contains **breaking** changes, as bugsnag-unity has been updated to
 
 ### Enhancements
 
-* Added more metadata to events and removed duplicate/unnecessary metadata
+* Added event metadata for CPU and graphics capabilities and removed duplicate/unnecessary metadata
 	[#297](https://github.com/bugsnag/bugsnag-unity/pull/297)
 	
 ### Bug fixes

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -146,23 +146,23 @@ void bugsnag_setMetadata(const void *configuration, const char *tab, const char 
 void bugsnag_retrieveMetaData(const void *metadata, void (*callback)(const void *instance, const char *tab,const char *keys[], int keys_size, const char *values[], int values_size)) {
     
     for (NSString* sectionKey in [Bugsnag.client metadata].dictionary.allKeys) {
-              NSLog(@"Found Section Key: %@", sectionKey);
-                   
-             NSDictionary* sectionDictionary = [[Bugsnag.client metadata].dictionary valueForKey:sectionKey];
-             NSArray *keys = [sectionDictionary allKeys];
-             NSArray *values = [sectionDictionary allValues];
-             int count = 0;
-             if ([keys count] <= INT_MAX) {
-               count = (int)[keys count];
-             }
-             const char **c_keys = (const char **) malloc(sizeof(char *) * ((size_t)count + 1));
-             const char **c_values = (const char **) malloc(sizeof(char *) * ((size_t)count + 1));
-             for (NSUInteger i = 0; i < (NSUInteger)count; i++) {
-               c_keys[i] = [[keys objectAtIndex: i] UTF8String];
-               c_values[i] = [[[values objectAtIndex: i]description] UTF8String];
-             }
-             callback(metadata, [sectionKey UTF8String],c_keys,count,c_values,count);
-       }
+                 NSDictionary* sectionDictionary = [[Bugsnag.client metadata].dictionary valueForKey:sectionKey];
+                 NSArray *keys = [sectionDictionary allKeys];
+                 NSArray *values = [sectionDictionary allValues];
+                 int count = 0;
+                 if ([keys count] <= INT_MAX) {
+                   count = (int)[keys count];
+                 }
+                 const char **c_keys = (const char **) malloc(sizeof(char *) * ((size_t)count + 1));
+                 const char **c_values = (const char **) malloc(sizeof(char *) * ((size_t)count + 1));
+                 for (NSUInteger i = 0; i < (NSUInteger)count; i++) {
+                   c_keys[i] = [[keys objectAtIndex: i] UTF8String];
+                   c_values[i] = [[[values objectAtIndex: i]description] UTF8String];
+                 }
+                callback(metadata, [sectionKey UTF8String],c_keys,count,c_values,count);
+                free(c_keys);
+                free(c_values);
+           }
     
 }
 
@@ -238,6 +238,8 @@ void bugsnag_retrieveBreadcrumbs(const void *managedBreadcrumbs, void (*breadcru
     }
 
     breadcrumb(managedBreadcrumbs, message, timestamp, type, c_keys, count, c_values, count);
+    free(c_keys);
+    free(c_values);
   }];
 }
 

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -39,9 +39,9 @@ namespace BugsnagUnity
 
     bool InForeground => ForegroundStopwatch.IsRunning;
 
-    const string AppMetadataKey = "App";
+    const string AppMetadataKey = "app";
 
-    const string DeviceMetadataKey = "Device";
+    const string DeviceMetadataKey = "device";
 
     private Thread MainThread;
 

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -39,7 +39,9 @@ namespace BugsnagUnity
 
     bool InForeground => ForegroundStopwatch.IsRunning;
 
-    const string UnityMetadataKey = "Unity";
+    const string AppMetadataKey = "App";
+
+    const string DeviceMetadataKey = "Device";
 
     private Thread MainThread;
 
@@ -63,9 +65,12 @@ namespace BugsnagUnity
       UniqueCounter = new UniqueLogThrottle(Configuration);
       LogTypeCounter = new MaximumLogTypeCounter(Configuration);
       SessionTracking = new SessionTracker(this);
+
       UnityMetadata.InitDefaultMetadata();
+      NativeClient.SetMetadata(AppMetadataKey, UnityMetadata.DefaultAppMetadata);
+      NativeClient.SetMetadata(DeviceMetadataKey, UnityMetadata.DefaultDeviceMetadata);
+
       Device.InitUnityVersion();
-      NativeClient.SetMetadata(UnityMetadataKey, UnityMetadata.ForNativeClient());
       NativeClient.PopulateUser(User);
       if (!string.IsNullOrEmpty(nativeClient.Configuration.Context))
       {
@@ -232,13 +237,11 @@ namespace BugsnagUnity
 
       var metadata = new Metadata();
       NativeClient.PopulateMetadata(metadata);
-
+     
       foreach (var item in Metadata)
       {
         metadata.AddToPayload(item.Key, item.Value);
       }
-
-      metadata.AddToPayload(UnityMetadataKey, UnityMetadata.WithLogType(logType));
 
       var @event = new Payload.Event(
         Configuration.Context,

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -26,6 +26,10 @@ namespace BugsnagUnity
     [DllImport(Import)]
     internal static extern void bugsnag_retrieveDeviceData(IntPtr instance, Action<IntPtr, string, string> populate);
 
+    internal delegate void MetadataInformation(IntPtr instance, string tab, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] string[] keys, int keysSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)] string[] values, int valuesSize);
+    [DllImport(Import)]
+    internal static extern void bugsnag_retrieveMetaData(IntPtr instance, MetadataInformation visitor);
+
     [DllImport(Import)]
     internal static extern void bugsnag_populateUser(ref NativeUser user);
 

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -11,6 +11,8 @@ namespace BugsnagUnity
 
     public IDelivery Delivery { get; }
 
+    private Dictionary<string, object> _editorMetadata = new Dictionary<string, object>();
+
     public NativeClient(IConfiguration configuration)
     {
       Configuration = configuration;
@@ -28,6 +30,14 @@ namespace BugsnagUnity
 
     public void PopulateMetadata(Metadata metadata)
     {
+        MergeDictionaries(metadata,_editorMetadata);
+    }
+    private void MergeDictionaries(Dictionary<string, object> dest, Dictionary<string, object> another)
+    {
+        foreach (var entry in another)
+        {
+            dest.AddToPayload(entry.Key, entry.Value);
+        }
     }
 
     public void PopulateUser(User user)
@@ -36,6 +46,7 @@ namespace BugsnagUnity
 
     public void SetMetadata(string tab, Dictionary<string, string> metadata)
     {
+        _editorMetadata[tab] = metadata;
     }
 
     public void SetSession(Session session)

--- a/src/BugsnagUnity/UnityMetadata.cs
+++ b/src/BugsnagUnity/UnityMetadata.cs
@@ -5,42 +5,32 @@ namespace BugsnagUnity
 {
   class UnityMetadata
   {
-    private static Dictionary<string, string> DefaultMetadata = new Dictionary<string, string>();
+    internal static Dictionary<string, string> DefaultAppMetadata = new Dictionary<string, string>();
+
+    internal static Dictionary<string, string> DefaultDeviceMetadata = new Dictionary<string, string>();
 
     internal static void InitDefaultMetadata() {
-      if (DefaultMetadata.Count > 0) {
-        return; // Already initialized
-      }
-      DefaultMetadata.Add("osLanguage", Application.systemLanguage.ToString());
-      DefaultMetadata.Add("platform", Application.platform.ToString());
-      DefaultMetadata.Add("version", Application.version);
-      DefaultMetadata.Add("companyName", Application.companyName);
-      DefaultMetadata.Add("productName", Application.productName);
+        InitAppMetadata();
+        InitDeviceMetadata();
     }
 
-    internal static Dictionary<string, string> ForNativeClient() => ForUnityException(false);
-
-    internal static Dictionary<string, string> WithLogType(LogType? logType) {
-      var data = ForUnityException(true);
-
-      if (logType.HasValue)
-      {
-        data["unityLogType"] = logType.Value.ToString("G");
-      }
-
-      return data;
+    private static void InitAppMetadata()
+    {
+        DefaultAppMetadata.Add("companyName", Application.companyName);
+        DefaultAppMetadata.Add("name", Application.productName);
     }
 
-    private static Dictionary<string, string> ForUnityException(bool unityException) {
-      var metadata = new Dictionary<string, string> {
-        { "unityException", unityException.ToString().ToLowerInvariant() },
-      };
-
-      foreach (var pair in DefaultMetadata) {
-        metadata.Add(pair.Key, pair.Value);
-      }
-
-      return metadata;
-    }
+    private static void InitDeviceMetadata()
+    {
+        DefaultDeviceMetadata.Add("graphicsDeviceVersion", SystemInfo.graphicsDeviceVersion);
+        DefaultDeviceMetadata.Add("graphicsMemorySize", SystemInfo.graphicsMemorySize.ToString());
+        DefaultDeviceMetadata.Add("graphicsShaderLevel", SystemInfo.graphicsShaderLevel.ToString());
+        var processorType = SystemInfo.processorType;
+        if (!string.IsNullOrEmpty(processorType))
+        {
+            DefaultDeviceMetadata.Add("processorType", processorType);
+        }
+        DefaultDeviceMetadata.Add("osLanguage", Application.systemLanguage.ToString());
+    }   
   }
 }

--- a/test/desktop/features/handled_errors.feature
+++ b/test/desktop/features/handled_errors.feature
@@ -25,7 +25,7 @@ Feature: Handled Errors and Exceptions
         And the event "device.runtimeVersions.unityScriptingBackend" is not null
         And the event "device.runtimeVersions.dotnetScriptingRuntime" is not null
         And the event "device.runtimeVersions.dotnetApiCompatibility" is not null
-        And the event "metaData.Unity.platform" equals "OSXPlayer"
+        And the event "app.type" equals "Mac OS"
         And the first significant stack frame methods and files should match:
             | Main.DoNotify()           | |
             | Main.<RunScenario>m__0() | Main.<RunScenario>b__7_0() |

--- a/test/mobile/features/android/android_csharp_errors.feature
+++ b/test/mobile/features/android/android_csharp_errors.feature
@@ -74,12 +74,10 @@ Feature: Android smoke tests for C# errors
         And the event "context" equals "Callback Context"
 
         # MetaData
-        And the event "metaData.Unity.unityException" equals "true"
-        And the event "metaData.Unity.osLanguage" is not null
-        And the event "metaData.Unity.platform" equals "Android"
-        And the event "metaData.Unity.version" equals "1.0"
-        And the event "metaData.Unity.companyName" equals "DefaultCompany"
-        And the event "metaData.Unity.productName" equals "maze_runner"
+        And the event "metaData.Device.osLanguage" is not null
+        And the event "app.type" equals "android"
+        And the event "metaData.App.companyName" equals "DefaultCompany"
+        And the event "metaData.App.name" equals "maze_runner"
         And the event "metaData.Callback.region" equals "US"
 
         # Runtime versions
@@ -159,12 +157,10 @@ Feature: Android smoke tests for C# errors
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Unity.unityException" equals "true"
-        And the event "metaData.Unity.osLanguage" is not null
-        And the event "metaData.Unity.platform" equals "Android"
-        And the event "metaData.Unity.version" equals "1.0"
-        And the event "metaData.Unity.companyName" equals "DefaultCompany"
-        And the event "metaData.Unity.productName" equals "maze_runner"
+        And the event "metaData.Device.osLanguage" is not null
+        And the event "app.type" equals "android"
+        And the event "metaData.App.companyName" equals "DefaultCompany"
+        And the event "metaData.App.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null

--- a/test/mobile/features/android/android_csharp_errors.feature
+++ b/test/mobile/features/android/android_csharp_errors.feature
@@ -157,10 +157,10 @@ Feature: Android smoke tests for C# errors
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Device.osLanguage" is not null
+        And the event "metaData.device.osLanguage" is not null
         And the event "app.type" equals "android"
-        And the event "metaData.App.companyName" equals "DefaultCompany"
-        And the event "metaData.App.name" equals "maze_runner"
+        And the event "metaData.app.companyName" equals "DefaultCompany"
+        And the event "metaData.app.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null

--- a/test/mobile/features/android/android_csharp_errors.feature
+++ b/test/mobile/features/android/android_csharp_errors.feature
@@ -74,10 +74,10 @@ Feature: Android smoke tests for C# errors
         And the event "context" equals "Callback Context"
 
         # MetaData
-        And the event "metaData.Device.osLanguage" is not null
+        And the event "metaData.device.osLanguage" is not null
         And the event "app.type" equals "android"
-        And the event "metaData.App.companyName" equals "DefaultCompany"
-        And the event "metaData.App.name" equals "maze_runner"
+        And the event "metaData.app.companyName" equals "DefaultCompany"
+        And the event "metaData.app.name" equals "maze_runner"
         And the event "metaData.Callback.region" equals "US"
 
         # Runtime versions

--- a/test/mobile/features/android/android_jvm_errors.feature
+++ b/test/mobile/features/android/android_jvm_errors.feature
@@ -74,10 +74,10 @@ Feature: Android manual smoke tests
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Device.osLanguage" is not null
+        And the event "metaData.device.osLanguage" is not null
         And the event "app.type" equals "android"
-        And the event "metaData.App.companyName" equals "DefaultCompany"
-        And the event "metaData.App.name" equals "maze_runner"
+        And the event "metaData.app.companyName" equals "DefaultCompany"
+        And the event "metaData.app.name" equals "maze_runner"
 
 
         # Runtime versions

--- a/test/mobile/features/android/android_jvm_errors.feature
+++ b/test/mobile/features/android/android_jvm_errors.feature
@@ -62,10 +62,6 @@ Feature: Android manual smoke tests
         And the event "device.brand" is not null
         And the event "device.batteryLevel" is not null
 
-        # Metadata
-        And the event "metaData.Unity.unityException" equals "true"
-        And the event "metaData.Unity.unityLogType" equals "Exception"
-
         # User
         And the event "user.id" is not null
 
@@ -78,13 +74,11 @@ Feature: Android manual smoke tests
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Unity.unityException" equals "true"
-        And the event "metaData.Unity.osLanguage" is not null
-        And the event "metaData.Unity.platform" equals "Android"
-        And the event "metaData.Unity.version" equals "1.0"
-        And the event "metaData.Unity.companyName" equals "DefaultCompany"
-        And the event "metaData.Unity.productName" equals "maze_runner"
-        And the event "metaData.Unity.unityLogType" equals "Exception"
+        And the event "metaData.Device.osLanguage" is not null
+        And the event "app.type" equals "android"
+        And the event "metaData.App.companyName" equals "DefaultCompany"
+        And the event "metaData.App.name" equals "maze_runner"
+
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null

--- a/test/mobile/features/android/android_log_errors.feature
+++ b/test/mobile/features/android/android_log_errors.feature
@@ -75,10 +75,10 @@ Feature: Android smoke tests for C# errors
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Device.osLanguage" is not null
+        And the event "metaData.device.osLanguage" is not null
         And the event "app.type" equals "android"
-        And the event "metaData.App.companyName" equals "DefaultCompany"
-        And the event "metaData.App.name" equals "maze_runner"
+        And the event "metaData.app.companyName" equals "DefaultCompany"
+        And the event "metaData.app.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null
@@ -156,10 +156,10 @@ Feature: Android smoke tests for C# errors
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Device.osLanguage" is not null
+        And the event "metaData.device.osLanguage" is not null
         And the event "app.type" equals "android"
-        And the event "metaData.App.companyName" equals "DefaultCompany"
-        And the event "metaData.App.name" equals "maze_runner"
+        And the event "metaData.app.companyName" equals "DefaultCompany"
+        And the event "metaData.app.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null

--- a/test/mobile/features/android/android_log_errors.feature
+++ b/test/mobile/features/android/android_log_errors.feature
@@ -75,13 +75,10 @@ Feature: Android smoke tests for C# errors
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Unity.unityException" equals "true"
-        And the event "metaData.Unity.osLanguage" is not null
-        And the event "metaData.Unity.platform" equals "Android"
-        And the event "metaData.Unity.version" equals "1.0"
-        And the event "metaData.Unity.companyName" equals "DefaultCompany"
-        And the event "metaData.Unity.productName" equals "maze_runner"
-        And the event "metaData.Unity.unityLogType" equals "Exception"
+        And the event "metaData.Device.osLanguage" is not null
+        And the event "app.type" equals "android"
+        And the event "metaData.App.companyName" equals "DefaultCompany"
+        And the event "metaData.App.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null
@@ -159,13 +156,10 @@ Feature: Android smoke tests for C# errors
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Unity.unityException" equals "true"
-        And the event "metaData.Unity.osLanguage" is not null
-        And the event "metaData.Unity.platform" equals "Android"
-        And the event "metaData.Unity.version" equals "1.0"
-        And the event "metaData.Unity.companyName" equals "DefaultCompany"
-        And the event "metaData.Unity.productName" equals "maze_runner"
-        And the event "metaData.Unity.unityLogType" equals "Error"
+        And the event "metaData.Device.osLanguage" is not null
+        And the event "app.type" equals "android"
+        And the event "metaData.App.companyName" equals "DefaultCompany"
+        And the event "metaData.App.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null

--- a/test/mobile/features/android/android_ndk_errors.feature
+++ b/test/mobile/features/android/android_ndk_errors.feature
@@ -69,5 +69,5 @@ Feature: Android manual smoke tests
         And the event "metaData.device.screenResolution" is not null
         And the event "metaData.Device.osLanguage" is not null
         And the event "app.type" equals "android"
-        And the event "metaData.App.companyName" equals "DefaultCompany"
-        And the event "metaData.App.name" equals "maze_runner"
+        And the event "metaData.app.companyName" equals "DefaultCompany"
+        And the event "metaData.app.name" equals "maze_runner"

--- a/test/mobile/features/android/android_ndk_errors.feature
+++ b/test/mobile/features/android/android_ndk_errors.feature
@@ -67,9 +67,7 @@ Feature: Android manual smoke tests
         And the event "metaData.device.networkAccess" is not null
         And the event "metaData.device.screenDensity" is not null
         And the event "metaData.device.screenResolution" is not null
-        And the event "metaData.Unity.unityException" equals "false"
-        And the event "metaData.Unity.osLanguage" is not null
-        And the event "metaData.Unity.platform" equals "Android"
-        And the event "metaData.Unity.version" equals "1.0"
-        And the event "metaData.Unity.companyName" equals "DefaultCompany"
-        And the event "metaData.Unity.productName" equals "maze_runner"
+        And the event "metaData.Device.osLanguage" is not null
+        And the event "app.type" equals "android"
+        And the event "metaData.App.companyName" equals "DefaultCompany"
+        And the event "metaData.App.name" equals "maze_runner"

--- a/test/mobile/features/android/android_ndk_errors.feature
+++ b/test/mobile/features/android/android_ndk_errors.feature
@@ -67,7 +67,7 @@ Feature: Android manual smoke tests
         And the event "metaData.device.networkAccess" is not null
         And the event "metaData.device.screenDensity" is not null
         And the event "metaData.device.screenResolution" is not null
-        And the event "metaData.Device.osLanguage" is not null
+        And the event "metaData.device.osLanguage" is not null
         And the event "app.type" equals "android"
         And the event "metaData.app.companyName" equals "DefaultCompany"
         And the event "metaData.app.name" equals "maze_runner"

--- a/test/mobile/features/ios/ios_csharp_errors.feature
+++ b/test/mobile/features/ios/ios_csharp_errors.feature
@@ -77,9 +77,9 @@ Feature: iOS smoke tests for C# errors
 
         # MetaData
         And the event "metaData.Callback.region" equals "US"
-        And the event "metaData.Device.osLanguage" is not null
-        And the event "metaData.App.companyName" equals "DefaultCompany"
-        And the event "metaData.App.name" equals "maze_runner"
+        And the event "metaData.device.osLanguage" is not null
+        And the event "metaData.app.companyName" equals "DefaultCompany"
+        And the event "metaData.app.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.osBuild" is not null
@@ -152,9 +152,9 @@ Feature: iOS smoke tests for C# errors
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Device.osLanguage" is not null
-        And the event "metaData.App.companyName" equals "DefaultCompany"
-        And the event "metaData.App.name" equals "maze_runner"
+        And the event "metaData.device.osLanguage" is not null
+        And the event "metaData.app.companyName" equals "DefaultCompany"
+        And the event "metaData.app.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.osBuild" is not null

--- a/test/mobile/features/ios/ios_csharp_errors.feature
+++ b/test/mobile/features/ios/ios_csharp_errors.feature
@@ -76,13 +76,10 @@ Feature: iOS smoke tests for C# errors
         And the event "context" equals "Callback Context"
 
         # MetaData
-        And the event "metaData.Unity.unityException" equals "true"
-        And the event "metaData.Unity.osLanguage" is not null
-        And the event "metaData.Unity.platform" equals "IPhonePlayer"
-        And the event "metaData.Unity.version" equals "1.0"
-        And the event "metaData.Unity.companyName" equals "DefaultCompany"
-        And the event "metaData.Unity.productName" equals "maze_runner"
         And the event "metaData.Callback.region" equals "US"
+        And the event "metaData.Device.osLanguage" is not null
+        And the event "metaData.App.companyName" equals "DefaultCompany"
+        And the event "metaData.App.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.osBuild" is not null
@@ -155,12 +152,9 @@ Feature: iOS smoke tests for C# errors
         And the event "context" equals "My context"
 
         # MetaData
-        And the event "metaData.Unity.unityException" equals "true"
-        And the event "metaData.Unity.osLanguage" is not null
-        And the event "metaData.Unity.platform" equals "IPhonePlayer"
-        And the event "metaData.Unity.version" equals "1.0"
-        And the event "metaData.Unity.companyName" equals "DefaultCompany"
-        And the event "metaData.Unity.productName" equals "maze_runner"
+        And the event "metaData.Device.osLanguage" is not null
+        And the event "metaData.App.companyName" equals "DefaultCompany"
+        And the event "metaData.App.name" equals "maze_runner"
 
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.osBuild" is not null

--- a/tests/UnityEngine/SystemInfo.cs
+++ b/tests/UnityEngine/SystemInfo.cs
@@ -6,6 +6,11 @@ namespace UnityEngine
   {
     public static string deviceModel { get; }
     public static string deviceUniqueIdentifier { get; }
+    public static string graphicsDeviceVersion { get; }
+    public static int graphicsMemorySize { get; }
+    public static int graphicsShaderLevel { get; }
+    public static string processorType { get; }
+    public static string systemLanguage { get; }
   }
   namespace Events {
   }


### PR DESCRIPTION
## Goal

Add more useful metadata and take out unnecessary unity metadata 

## Design

I adapted and fixed what was already there. In the process the setup was simplified quite a lot.
Now we always can expect the metadata from the native side to be correct and no dynamic unity specific data is generated when creating a payload. We just grab the latest from the native side.

## Changeset

- Added UnityEditor implementation for testing in the editor
- Removed dynamic generation of unity c# only payload 
- Fixed Cocoa metadata setting and retrieving of data

## Testing

Tested manually on android and ios and ran the maze runner tests locally for mac os