### PR TITLE
fix(event data): correct the format of the device.time parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This version contains **breaking** changes, as bugsnag-unity has been updated to
 	
 ### Bug fixes
 
+* Fix an issue where the Device.time of an event was missing the milliseconds
+  [#298](https://github.com/bugsnag/bugsnag-unity/pull/298)
+
 * Adjust post build script to allow unity 2021 builds
   [#289](https://github.com/bugsnag/bugsnag-unity/pull/289)
   


### PR DESCRIPTION
## Goal

When unity android reports a C# layer event, the Device.time parameter has 000 for milliseconds instead of the correct time.

## Changeset

Added the proper conversion method to the Android NativeInterface

## Testing

Manually on device