### PR TITLE
Remove duplicate native android events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Correct android session start times
   [#291](https://github.com/bugsnag/bugsnag-unity/pull/291)
 
+* Fix duplicate events being sent for Android C/C++ crashes
 
 ## 5.0.0 (2021-06-08)
 

--- a/bugsnag-android-unity/build.gradle
+++ b/bugsnag-android-unity/build.gradle
@@ -37,3 +37,7 @@ android {
         }
     }
 }
+
+dependencies {
+    api "com.bugsnag:bugsnag-android-core:5.9.4"
+}

--- a/bugsnag-android-unity/gradle.properties
+++ b/bugsnag-android-unity/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/BugsnagUnity.java
+++ b/bugsnag-android-unity/src/main/java/com/bugsnag/android/unity/BugsnagUnity.java
@@ -1,9 +1,33 @@
 package com.bugsnag.android.unity;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.bugsnag.android.Error;
+import com.bugsnag.android.Event;
+import com.bugsnag.android.OnErrorCallback;
+
 public class BugsnagUnity {
     static {
         System.loadLibrary("bugsnag-unity");
     }
 
     public static native boolean isJNIAttached();
+
+    public static OnErrorCallback getNativeCallback() {
+        String discardedEventErrorClass = "java.lang.Error";
+        Pattern pattern = Pattern.compile("signal \\d+ \\(SIG\\w+\\)", Pattern.CASE_INSENSITIVE);
+        return new OnErrorCallback() {
+            @Override
+            // Discard any messages matching native Android events as they are captured (and more
+            // accurate) via bugsnag-android. For Unity 2018.3+
+            public boolean onError(Event event) {
+                Error error = event.getErrors().get(0);
+                String errorClass = error.getErrorClass();
+                String message = error.getErrorMessage();
+                return discardedEventErrorClass.equals(errorClass) &&
+                    (message == null || !pattern.matcher(message).find());
+            }
+        };
+    }
 }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -214,6 +214,10 @@ namespace BugsnagUnity
             obj.Call("setContext", config.Context);
             obj.Call("setMaxBreadcrumbs", config.MaximumBreadcrumbs);
 
+            // add unity event callback
+            var BugsnagUnity = new AndroidJavaClass("com.bugsnag.android.unity.BugsnagUnity");
+            obj.Call("addOnError", BugsnagUnity.CallStatic<AndroidJavaObject>("getNativeCallback", new object[] { }));
+
             return obj;
         }
 

--- a/test/mobile/features/android/android_ndk_errors.feature
+++ b/test/mobile/features/android/android_ndk_errors.feature
@@ -3,10 +3,17 @@ Feature: Android manual smoke tests
     Background:
         Given I wait for the game to start
 
-    @skip_unity_android_2020
     Scenario: NDK Signal raised
         When I tap the "NDK signal" button
+
+        # Intentionally adding long wait times here - a core component of this
+        # feature is ensuring that only a SINGLE event is sent. Unity includes
+        # a handler for NDK events which are delivered immediately and should
+        # be intentionally ignored and the event discarded, since the same
+        # event has already been captured and will be sent next launch
+        And I wait for 5 seconds
         And I relaunch the Unity app
+        And I wait for 5 seconds
         Then I wait to receive 1 error
 
         # Exception details

--- a/test/mobile/features/scripts/prepare_fixture.sh
+++ b/test/mobile/features/scripts/prepare_fixture.sh
@@ -6,7 +6,7 @@ then
   exit 1
 fi
 
-echo "\`which Unity\`=`which Unity`"
+echo "\`Unity\` executable = $UNITY_PATH/Unity"
 
 pushd "${0%/*}"
   script_path=`pwd`

--- a/tests/BugsnagUnity.Tests/ExceptionTests.cs
+++ b/tests/BugsnagUnity.Tests/ExceptionTests.cs
@@ -58,7 +58,6 @@ namespace BugsnagUnity.Payload.Tests
             string stacktrace = @"java.lang.Error: signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0102192a9accb1876a
 libunity.0033c25b(Unknown:-2)
 libunity.003606e3(Unknown:-2)
-libbugsnag-ndk.bsg_handle_signal(bsg_handle_signal:472)
 app_process64.000d1b11(Unknown:-2)";
             var logType = UnityEngine.LogType.Error;
             var log = new UnityLogMessage(condition, stacktrace, logType);


### PR DESCRIPTION
## Goal

Avoid sending "duplicate" native crash reports, one from native detection and a second from the Unity error handler, which converts a native crash into either a log message (2017-2018.2) or an uncaught Java exception (2018.3+). This is an extension of #162.

As a part of this change, I made a few improvements to the unity path detection and error messaging in the Rakefile to make it clearer what's going on when builds fail to start.

## Design

Added a native callback to reject any events matching a native crash pattern, and updated the log message detector to check.

## Changeset

* `BugsnagUnity` class now exposes a `getNativeCallback` function, which returns on `OnErrorCallback` to perform event filtering. It might also be handy later, if we ever alter initialization to be done through a native plugin earlier in the launch cycle.
* As a result of the last point, the `bugsnag-android-unity` package now depends on `bugsnag-android-core` (and should be kept up to date when updating the `bugsnag-android` dependency).
* `Exception` class now verifies both the error class and message to detect C/C++ exceptions on Android and filter them out
* Updated the unit test for filtering to be more generic and not depend on the presence of `libbugsnag` (which was reliable in early versions but now not necessary).

## Testing

Added slowdowns to the native crash tests to ensure that if a second event is generated, it is detected and fails the test, in addition to ridiculous amounts of manual testing.