### PR TITLE
build: remove unneeded versioning tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.1.1 (2021-06-24)
+
+* Fixes a packaging issue in the 5.1.0 where the library version was incorrectly
+  reported
+  [#309](https://github.com/bugsnag/bugsnag-unity/pull/309)
+
 ## 5.1.0 (2021-06-24)
 
 ### Enhancements

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@ var target = Argument("target", "Default");
 var solution = File("./BugsnagUnity.sln");
 var configuration = Argument("configuration", "Release");
 var project = File("./src/BugsnagUnity/BugsnagUnity.csproj");
-var version = "5.1.0";
+var version = "5.1.1";
 
 Task("Restore-NuGet-Packages")
     .Does(() => NuGetRestore(solution));

--- a/build.cake
+++ b/build.cake
@@ -12,7 +12,6 @@ Task("Restore-NuGet-Packages")
 
 Task("Build")
   .IsDependentOn("Restore-NuGet-Packages")
-  .IsDependentOn("PopulateVersion")
   .Does(() => {
     MSBuild(solution, settings =>
       settings
@@ -20,38 +19,6 @@ Task("Build")
         .WithProperty("Version", version)
         .SetConfiguration(configuration));
   });
-
-Task("LocalVersion")
-  .WithCriteria(BuildSystem.IsLocalBuild)
-  .Does(() => {
-    var tag = GitDescribe(".", GitDescribeStrategy.Tags).TrimStart('v');
-    if (tag.StartsWith("v"))
-    {
-      version = tag.TrimStart('v');
-    }
-    else
-    {
-      version = tag;
-    }
-  });
-
-Task("TravisVersion")
-  .WithCriteria(!BuildSystem.IsLocalBuild)
-  .Does(() => {
-    if (string.IsNullOrEmpty(TravisCI.Environment.Build.Tag))
-    {
-      version = $"{version}-dev-{TravisCI.Environment.Repository.Commit.Substring(0, 7)}";
-    }
-    else
-    {
-      version = TravisCI.Environment.Build.Tag.TrimStart('v');
-    }
-  });
-
-
-Task("PopulateVersion")
-  .IsDependentOn("LocalVersion")
-  .IsDependentOn("TravisVersion");
 
 Task("Test")
   .IsDependentOn("Build")


### PR DESCRIPTION
## Goal

Fix a potential issue in the packaging/release process where the version number of the library may be reported incorrectly due to timing differences between the time the branch was pushed (kicking off the build) and the time the tag was pushed (previously queried by the build task). This issue was surfaced by changes in the release process.

## Testing

Tested manually to ensure that the reported version is correct.