### PR TITLE
fix(windows): make the rake file windows build friendly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,8 +13,15 @@ def is_windows?; HOST_OS =~ /mingw|mswin|windows/i; end
 # install location for both windows and mac.
 #
 def unity_directory
+
   if ENV.has_key? 'UNITY_VERSION'
+
+    if is_mac?
     "/Applications/Unity/Hub/Editor/#{ENV['UNITY_VERSION']}"
+    elsif is_windows?
+      "C:\\Program Files\\Unity\\Hub\\Editor\\#{ENV['UNITY_VERSION']}"
+    end
+
   elsif ENV.has_key? "UNITY_DIR"
     ENV["UNITY_DIR"]
   else
@@ -136,8 +143,14 @@ end
 namespace :plugin do
   namespace :build do
     cocoa_build_dir = "bugsnag-cocoa-build"
-    task all: [:assets, :cocoa, :csharp, :android]
-    task all_android64: [:assets, :cocoa, :csharp, :android_64bit]
+    if is_windows?
+      task all: [:assets, :csharp]
+      task all_android64: [:assets, :csharp]
+    else
+      task all: [:assets, :cocoa, :csharp, :android]
+      task all_android64: [:assets, :cocoa, :csharp, :android_64bit]
+    end
+
 
     desc "Delete all build artifacts"
     task :clean do
@@ -145,13 +158,15 @@ namespace :plugin do
       sh "git", "clean", "-dfx", "unity"
       # remove cocoa build area
       FileUtils.rm_rf cocoa_build_dir
-      # remove android build area
-      cd "bugsnag-android" do
-        sh "./gradlew", "clean"
-      end
+      unless is_windows?
+        # remove android build area
+        cd "bugsnag-android" do
+          sh "./gradlew", "clean"
+        end
 
-      cd "bugsnag-android-unity" do
-        sh "./gradlew", "clean"
+        cd "bugsnag-android-unity" do
+          sh "./gradlew", "clean"
+        end
       end
     end
     task :assets do

--- a/test/desktop/features/fixtures/maze_runner/Assets/Scripts/Builder.cs
+++ b/test/desktop/features/fixtures/maze_runner/Assets/Scripts/Builder.cs
@@ -17,9 +17,15 @@ public class Builder : MonoBehaviour {
     }
 
     // Generates Mazerunner.app
-    public static void MacOSBuild()
+    public static void MacOS()
     {
         Build("Mazerunner", BuildTarget.StandaloneOSX);
+    }
+
+    // Generates Mazerunner.app
+    public static void Win64()
+    {
+        Build("WindowsBuild/Mazerunner.exe", BuildTarget.StandaloneWindows64);
     }
 }
 #endif

--- a/test/desktop/features/scripts/build_maze_runner.sh
+++ b/test/desktop/features/scripts/build_maze_runner.sh
@@ -5,25 +5,20 @@ if [ -z "$UNITY_VERSION" ]; then
   exit 1
 fi
 
-
 #!/usr/bin/env bash
 
 if [ "$(uname)" == "Darwin" ]; then
-   PLATFORM="MacOS"    
-elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ]; then
-    PLATFORM="Win64"  
-fi
 
-if [ "$PLATFORM" == "MacOS" ]; then
-
+  PLATFORM="MacOS"    
   echo "MacOS Detected"
   UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
 
-else
+elif [ $OS == "Windows_NT" ]; then
 
-  set -m
-  echo "Windows64 Detected"
-  UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe" 
+    PLATFORM="Win64"  
+    set -m
+    echo "Windows64 Detected"
+    UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe" 
 
 fi
 
@@ -61,8 +56,8 @@ pushd "${0%/*}"
     RESULT=$?
     if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 
-    app_location="$(pwd)/Mazerunner.app"
-    echo "Building $app_location"
+    
+    echo "Building the fixture for $PLATFORM"
 
     "$UNITY_PATH" $DEFAULT_CLI_ARGS \
       -projectPath $project_path \
@@ -78,11 +73,9 @@ pushd "${0%/*}"
          if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 
     else
-      echo "SHOULD ZIP BUILD"
        tar -czf "Mazerunner-$UNITY_VERSION.zip" "maze_runner/WindowsBuild/"
         RESULT=$?
          if [ $RESULT -ne 0 ]; then exit $RESULT; fi
-
     fi
 
 


### PR DESCRIPTION
I have adapted the build_maze_runner.sh script to support building a 64bit windows build of the fixture.
It automatically detects if it's running on windows or mac and builds the correct fixture.
At the moment, it does the build, and then zips the build folder into the same location as the Mac one
Important note: For windows Unity outputs a folder with a bunch of stuff instead of just an app. In that folder is the exe that needs to be run