### PR TITLE
Two stage builds

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -258,7 +258,7 @@ steps:
   #
   # Build iOS test fixtures
   #
-  - label: ':ios: Generate test fixture Xcode project for Unity 2017'
+  - label: ':ios: Generate Xcode project - Unity 2017'
     key: 'generate-fixture-project-2017'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
@@ -301,7 +301,7 @@ steps:
       - tar -zxf project_2017.tgz test/mobile/features/fixtures/maze_runner
       - rake test:ios:build_xcode
 
-  - label: ':ios: Generate test fixture Xcode project for Unity 2018'
+  - label: ':ios: Generate Xcode project - Unity 2018'
     key: 'generate-fixture-project-2018'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
@@ -344,7 +344,7 @@ steps:
       - tar -zxf project_2018.tgz test/mobile/features/fixtures/maze_runner
       - rake test:ios:build_xcode
 
-  - label: ':ios: Generate test fixture Xcode project for Unity 2019'
+  - label: ':ios: Generate Xcode project - Unity 2019'
     key: 'generate-fixture-project-2019'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,0 +1,455 @@
+steps:
+
+  #
+  # Build desktop test fixtures
+  #
+  - label: Build Unity 2017 MacOS test fixture
+    key: 'cocoa-2017-fixture'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-unity
+    env:
+      UNITY_VERSION: "2017.4.40f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+    commands:
+      - cd test/desktop
+      - ./features/scripts/build_maze_runner.sh
+    artifact_paths:
+      - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  - label: Build Unity 2018 MacOS test fixture
+    key: 'cocoa-2018-fixture'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-unity
+    env:
+      UNITY_VERSION: "2018.4.34f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+    commands:
+      - cd test/desktop
+      - ./features/scripts/build_maze_runner.sh
+    artifact_paths:
+      - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  - label: Build Unity 2019 MacOS test fixture
+    key: 'cocoa-2019-fixture'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-unity
+    env:
+      UNITY_VERSION: "2019.4.25f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+    commands:
+      - cd test/desktop
+      - ./features/scripts/build_maze_runner.sh
+    artifact_paths:
+      - test/desktop/features/fixtures/Mazerunner-2019.4.25f1.app.zip
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  #
+  # Run desktop tests
+  #
+  - label: Run MacOS e2e tests for Unity 2017.4.40f1
+    depends_on: 'cocoa-2017-fixture'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-10.15
+    env:
+      UNITY_VERSION: "2017.4.40f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
+        upload:
+          - test/desktop/maze_output/*
+          - test/desktop/Mazerunner.log
+    commands:
+      - cd test/desktop
+      - bundle install
+      - bundle exec maze-runner --app=Mazerunner
+
+  - label: Run MacOS e2e tests for Unity 2018.4.34f1
+    depends_on: 'cocoa-2018-fixture'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-10.15
+    env:
+      UNITY_VERSION: "2018.4.34f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
+        upload:
+          - test/desktop/maze_output/*
+          - test/desktop/Mazerunner.log
+    commands:
+      - cd test/desktop
+      - bundle install
+      - bundle exec maze-runner --app=Mazerunner
+
+  - label: Run MacOS e2e tests for Unity 2019.4.25f1
+    depends_on: 'cocoa-2019-fixture'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-10.15
+    env:
+      UNITY_VERSION: "2019.4.25f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - test/desktop/features/fixtures/Mazerunner-2019.4.25f1.app.zip
+        upload:
+          - test/desktop/maze_output/*
+          - test/desktop/Mazerunner.log
+    commands:
+      - cd test/desktop
+      - bundle install
+      - bundle exec maze-runner --app=Mazerunner
+
+  #
+  # Build Android test fixtures
+  #
+  - label: ':android: Build Android test fixture for Unity 2017'
+    key: 'build-android-fixture-2017'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-unity
+    env:
+      UNITY_VERSION: "2017.4.40f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+        upload:
+          - test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk
+          - test/mobile/features/fixtures/unity.log
+    commands:
+      - rake test:android:build
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  - label: ':android: Build Android test fixture for Unity 2018'
+    key: 'build-android-fixture-2018'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-unity
+    env:
+      UNITY_VERSION: "2018.4.34f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+        upload:
+          - test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.apk
+          - test/mobile/features/fixtures/unity.log
+    commands:
+      - rake test:android:build
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  - label: ':android: Build Android test fixture for Unity 2019'
+    key: 'build-android-fixture-2019'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-unity
+    env:
+      UNITY_VERSION: "2019.4.25f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+        upload:
+          - test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.apk
+          - test/mobile/features/fixtures/unity.log
+    commands:
+      - rake test:android:build
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  #
+  # Run Android tests
+  #
+  - label: ':android: Run Android e2e tests for Unity 2017'
+    depends_on: 'build-android-fixture-2017'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download:
+          - "test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk"
+      docker-compose#v3.3.0:
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_9_0"
+          - "--fail-fast"
+          - "features/android"
+    concurrency: 9
+    concurrency_group: browserstack-app
+
+  - label: ':android: Run Android e2e tests for Unity 2018'
+    depends_on: 'build-android-fixture-2018'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download:
+          - "test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.apk"
+      docker-compose#v3.3.0:
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.34f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_9_0"
+          - "--fail-fast"
+          - "features/android"
+    concurrency: 9
+    concurrency_group: browserstack-app
+
+  - label: ':android: Run Android e2e tests for Unity 2019'
+    depends_on: 'build-android-fixture-2019'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download:
+          - "test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.apk"
+      docker-compose#v3.3.0:
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.25f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_9_0"
+          - "--fail-fast"
+          - "features/android"
+    concurrency: 9
+    concurrency_group: browserstack-app
+
+  #
+  # Build iOS test fixtures
+  #
+  - label: ':ios: Generate test fixture Xcode project for Unity 2017'
+    key: 'generate-fixture-project-2017'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-unity
+    env:
+      UNITY_VERSION: "2017.4.40f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+        upload:
+          - test/mobile/features/fixtures/unity.log
+          - project_2017.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2017.tgz  test/mobile/features/fixtures/maze_runner/mazerunner_xcode
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  - label: ':ios: Build iOS test fixture for Unity 2017'
+    key: 'build-ios-fixture-2017'
+    depends_on: 'generate-fixture-project-2017'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-10.15
+    env:
+      UNITY_VERSION: "2017.4.40f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+          - project_2017.tgz
+        upload:
+          - test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.ipa
+          - test/mobile/features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2017.tgz test/mobile/features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+
+  - label: ':ios: Generate test fixture Xcode project for Unity 2018'
+    key: 'generate-fixture-project-2018'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-unity
+    env:
+      UNITY_VERSION: "2018.4.34f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+        upload:
+          - test/mobile/features/fixtures/unity.log
+          - project_2018.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2018.tgz  test/mobile/features/fixtures/maze_runner/mazerunner_xcode
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  - label: ':ios: Build iOS test fixture for Unity 2018'
+    key: 'build-ios-fixture-2018'
+    depends_on: 'generate-fixture-project-2018'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-10.15
+    env:
+      UNITY_VERSION: "2018.4.34f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+          - project_2018.tgz
+        upload:
+          - test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.ipa
+          - test/mobile/features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2018.tgz test/mobile/features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+
+  - label: ':ios: Generate test fixture Xcode project for Unity 2019'
+    key: 'generate-fixture-project-2019'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-unity
+    env:
+      UNITY_VERSION: "2019.4.25f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+        upload:
+          - test/mobile/features/fixtures/unity.log
+          - project_2019.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2019.tgz test/mobile/features/fixtures/maze_runner/mazerunner_xcode
+    concurrency: 2
+    concurrency_group: 'unity-license'
+
+  - label: ':ios: Build iOS test fixture for Unity 2019'
+    key: 'build-ios-fixture-2019'
+    depends_on: 'generate-fixture-project-2019'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-10.15
+    env:
+      UNITY_VERSION: "2019.4.25f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - Bugsnag.unitypackage
+          - Bugsnag-with-android-64bit.unitypackage
+          - project_2019.tgz
+        upload:
+          - test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.ipa
+          - test/mobile/features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2019.tgz test/mobile/features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+
+  #
+  # Run iOS tests
+  #
+  # TODO: PLAT-6656 - Avoid having to use --separate-sessions
+  - label: ':ios: Run iOS e2e tests for Unity 2017'
+    depends_on: 'build-ios-fixture-2017'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download:
+          - "test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.ipa"
+      docker-compose#v3.3.0:
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2017.4.40f1.ipa"
+          - "--farm=bs"
+          - "--device=IOS_14"
+          - "--fail-fast"
+          - "--separate-sessions"
+          - "features/ios"
+    concurrency: 9
+    concurrency_group: browserstack-app
+
+  - label: ':ios: Run iOS e2e tests for Unity 2018'
+    depends_on: 'build-ios-fixture-2018'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download:
+          - "test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.ipa"
+      docker-compose#v3.3.0:
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.34f1.ipa"
+          - "--farm=bs"
+          - "--device=IOS_14"
+          - "--fail-fast"
+          - "--separate-sessions"
+          - "features/ios"
+    concurrency: 9
+    concurrency_group: browserstack-app
+
+  - label: ':ios: Run iOS e2e tests for Unity 2019'
+    depends_on: 'build-ios-fixture-2019'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download:
+          - "test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.ipa"
+      docker-compose#v3.3.0:
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.25f1.ipa"
+          - "--farm=bs"
+          - "--device=IOS_14"
+          - "--fail-fast"
+          - "--separate-sessions"
+          - "features/ios"
+    concurrency: 9
+    concurrency_group: browserstack-app

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -580,7 +580,6 @@ steps:
     concurrency_group: browserstack-app
 
   - label: ':ios: Run iOS e2e tests for Unity 2019'
-    skip: "Pending PLAT-6653"
     depends_on: 'build-ios-fixture-2019'
     timeout_in_minutes: 30
     agents:
@@ -602,7 +601,6 @@ steps:
     concurrency_group: browserstack-app
 
   - label: ':ios: Run iOS e2e tests for Unity 2020'
-    skip: "Pending PLAT-6653"
     depends_on: 'build-ios-fixture-2020'
     timeout_in_minutes: 30
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,7 +117,7 @@ steps:
   #
   # Build iOS test fixtures
   #
-  - label: ':ios: Generate test fixture Xcode project for Unity 2020'
+  - label: ':ios: Generate Xcode project - Unity 2020'
     key: 'generate-fixture-project-2020'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,5 @@
 steps:
+
   #
   # Build notifier.  We run tests for all Unity versions with the 2017 artifacts, as that is what we ship.
   #
@@ -19,71 +20,8 @@ steps:
     concurrency_group: 'unity-license'
 
   #
-  # Build desktop test fixtures
+  # Build desktop test fixture
   #
-  - label: Build Unity 2017 MacOS test fixture
-    key: 'cocoa-2017-fixture'
-    depends_on: 'build-artifacts'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-unity
-    env:
-      UNITY_VERSION: "2017.4.40f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-    commands:
-      - cd test/desktop
-      - ./features/scripts/build_maze_runner.sh
-    artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
-    concurrency: 2
-    concurrency_group: 'unity-license'
-
-  - label: Build Unity 2018 MacOS test fixture
-    key: 'cocoa-2018-fixture'
-    depends_on: 'build-artifacts'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-unity
-    env:
-      UNITY_VERSION: "2018.4.34f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-    commands:
-      - cd test/desktop
-      - ./features/scripts/build_maze_runner.sh
-    artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
-    concurrency: 2
-    concurrency_group: 'unity-license'
-
-  - label: Build Unity 2019 MacOS test fixture
-    key: 'cocoa-2019-fixture'
-    depends_on: 'build-artifacts'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-unity
-    env:
-      UNITY_VERSION: "2019.4.25f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-    commands:
-      - cd test/desktop
-      - ./features/scripts/build_maze_runner.sh
-    artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2019.4.25f1.app.zip
-    concurrency: 2
-    concurrency_group: 'unity-license'
-
   - label: Build Unity 2020 MacOS test fixture
     key: 'cocoa-2020-fixture'
     depends_on: 'build-artifacts'
@@ -108,63 +46,6 @@ steps:
   #
   # Run desktop tests
   #
-  - label: Run MacOS e2e tests for Unity 2017.4.40f1
-    depends_on: 'cocoa-2017-fixture'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-cocoa-10.15
-    env:
-      UNITY_VERSION: "2017.4.40f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
-        upload:
-          - test/desktop/maze_output/*
-          - test/desktop/Mazerunner.log
-    commands:
-      - cd test/desktop
-      - bundle install
-      - bundle exec maze-runner --app=Mazerunner
-
-  - label: Run MacOS e2e tests for Unity 2018.4.34f1
-    depends_on: 'cocoa-2018-fixture'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-cocoa-10.15
-    env:
-      UNITY_VERSION: "2018.4.34f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
-        upload:
-          - test/desktop/maze_output/*
-          - test/desktop/Mazerunner.log
-    commands:
-      - cd test/desktop
-      - bundle install
-      - bundle exec maze-runner --app=Mazerunner
-
-  - label: Run MacOS e2e tests for Unity 2019.4.25f1
-    depends_on: 'cocoa-2019-fixture'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-cocoa-10.15
-    env:
-      UNITY_VERSION: "2019.4.25f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - test/desktop/features/fixtures/Mazerunner-2019.4.25f1.app.zip
-        upload:
-          - test/desktop/maze_output/*
-          - test/desktop/Mazerunner.log
-    commands:
-      - cd test/desktop
-      - bundle install
-      - bundle exec maze-runner --app=Mazerunner
-
   - label: Run MacOS e2e tests for Unity 2020.3.9f1
     depends_on: 'cocoa-2020-fixture'
     timeout_in_minutes: 30
@@ -187,69 +68,6 @@ steps:
   #
   # Build Android test fixtures
   #
-  - label: ':android: Build Android test fixture for Unity 2017'
-    key: 'build-android-fixture-2017'
-    depends_on: 'build-artifacts'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-unity
-    env:
-      UNITY_VERSION: "2017.4.40f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-        upload:
-          - test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk
-          - test/mobile/features/fixtures/unity.log
-    commands:
-      - rake test:android:build
-    concurrency: 2
-    concurrency_group: 'unity-license'
-
-  - label: ':android: Build Android test fixture for Unity 2018'
-    key: 'build-android-fixture-2018'
-    depends_on: 'build-artifacts'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-unity
-    env:
-      UNITY_VERSION: "2018.4.34f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-        upload:
-          - test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.apk
-          - test/mobile/features/fixtures/unity.log
-    commands:
-      - rake test:android:build
-    concurrency: 2
-    concurrency_group: 'unity-license'
-
-  - label: ':android: Build Android test fixture for Unity 2019'
-    key: 'build-android-fixture-2019'
-    depends_on: 'build-artifacts'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-unity
-    env:
-      UNITY_VERSION: "2019.4.25f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-        upload:
-          - test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.apk
-          - test/mobile/features/fixtures/unity.log
-    commands:
-      - rake test:android:build
-    concurrency: 2
-    concurrency_group: 'unity-license'
-
   - label: ':android: Build Android test fixture for Unity 2020'
     key: 'build-android-fixture-2020'
     depends_on: 'build-artifacts'
@@ -274,66 +92,6 @@ steps:
   #
   # Run Android tests
   #
-  - label: ':android: Run Android e2e tests for Unity 2017'
-    depends_on: 'build-android-fixture-2017'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.3.0:
-        download:
-          - "test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk"
-      docker-compose#v3.3.0:
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_9_0"
-          - "--fail-fast"
-          - "features/android"
-    concurrency: 9
-    concurrency_group: browserstack-app
-
-  - label: ':android: Run Android e2e tests for Unity 2018'
-    depends_on: 'build-android-fixture-2018'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.3.0:
-        download:
-          - "test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.apk"
-      docker-compose#v3.3.0:
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.34f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_9_0"
-          - "--fail-fast"
-          - "features/android"
-    concurrency: 9
-    concurrency_group: browserstack-app
-
-  - label: ':android: Run Android e2e tests for Unity 2019'
-    depends_on: 'build-android-fixture-2019'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.3.0:
-        download:
-          - "test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.apk"
-      docker-compose#v3.3.0:
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.25f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_9_0"
-          - "--fail-fast"
-          - "features/android"
-    concurrency: 9
-    concurrency_group: browserstack-app
-
   - label: ':android: Run Android e2e tests for Unity 2020'
     depends_on: 'build-android-fixture-2020'
     timeout_in_minutes: 30
@@ -359,136 +117,6 @@ steps:
   #
   # Build iOS test fixtures
   #
-  - label: ':ios: Generate test fixture Xcode project for Unity 2017'
-    key: 'generate-fixture-project-2017'
-    depends_on: 'build-artifacts'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-unity
-    env:
-      UNITY_VERSION: "2017.4.40f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-        upload:
-          - test/mobile/features/fixtures/unity.log
-          - project_2017.tgz
-    commands:
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2017.tgz  test/mobile/features/fixtures/maze_runner/mazerunner_xcode
-    concurrency: 2
-    concurrency_group: 'unity-license'
-
-  - label: ':ios: Build iOS test fixture for Unity 2017'
-    key: 'build-ios-fixture-2017'
-    depends_on: 'generate-fixture-project-2017'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-cocoa-10.15
-    env:
-      UNITY_VERSION: "2017.4.40f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-          - project_2017.tgz
-        upload:
-          - test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.ipa
-          - test/mobile/features/fixtures/unity.log
-    commands:
-      - tar -zxf project_2017.tgz test/mobile/features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-
-  - label: ':ios: Generate test fixture Xcode project for Unity 2018'
-    key: 'generate-fixture-project-2018'
-    depends_on: 'build-artifacts'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-unity
-    env:
-      UNITY_VERSION: "2018.4.34f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-        upload:
-          - test/mobile/features/fixtures/unity.log
-          - project_2018.tgz
-    commands:
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2018.tgz  test/mobile/features/fixtures/maze_runner/mazerunner_xcode
-    concurrency: 2
-    concurrency_group: 'unity-license'
-
-  - label: ':ios: Build iOS test fixture for Unity 2018'
-    key: 'build-ios-fixture-2018'
-    depends_on: 'generate-fixture-project-2018'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-cocoa-10.15
-    env:
-      UNITY_VERSION: "2018.4.34f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-          - project_2018.tgz
-        upload:
-          - test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.ipa
-          - test/mobile/features/fixtures/unity.log
-    commands:
-      - tar -zxf project_2018.tgz test/mobile/features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-
-  - label: ':ios: Generate test fixture Xcode project for Unity 2019'
-    key: 'generate-fixture-project-2019'
-    depends_on: 'build-artifacts'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-unity
-    env:
-      UNITY_VERSION: "2019.4.25f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-        upload:
-          - test/mobile/features/fixtures/unity.log
-          - project_2019.tgz
-    commands:
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2019.tgz test/mobile/features/fixtures/maze_runner/mazerunner_xcode
-    concurrency: 2
-    concurrency_group: 'unity-license'
-
-  - label: ':ios: Build iOS test fixture for Unity 2019'
-    key: 'build-ios-fixture-2019'
-    depends_on: 'generate-fixture-project-2019'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource-mac-cocoa-10.15
-    env:
-      UNITY_VERSION: "2019.4.25f1"
-    plugins:
-      artifacts#v1.2.0:
-        download:
-          - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
-          - project_2019.tgz
-        upload:
-          - test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.ipa
-          - test/mobile/features/fixtures/unity.log
-    commands:
-      - tar -zxf project_2019.tgz test/mobile/features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-
-
   - label: ':ios: Generate test fixture Xcode project for Unity 2020'
     key: 'generate-fixture-project-2020'
     depends_on: 'build-artifacts'
@@ -537,69 +165,6 @@ steps:
   # Run iOS tests
   #
   # TODO: PLAT-6656 - Avoid having to use --separate-sessions
-  - label: ':ios: Run iOS e2e tests for Unity 2017'
-    depends_on: 'build-ios-fixture-2017'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.3.0:
-        download:
-          - "test/mobile/features/fixtures/maze_runner/mazerunner_2017.4.40f1.ipa"
-      docker-compose#v3.3.0:
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2017.4.40f1.ipa"
-          - "--farm=bs"
-          - "--device=IOS_14"
-          - "--fail-fast"
-          - "--separate-sessions"
-          - "features/ios"
-    concurrency: 9
-    concurrency_group: browserstack-app
-
-  - label: ':ios: Run iOS e2e tests for Unity 2018'
-    depends_on: 'build-ios-fixture-2018'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.3.0:
-        download:
-          - "test/mobile/features/fixtures/maze_runner/mazerunner_2018.4.34f1.ipa"
-      docker-compose#v3.3.0:
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.34f1.ipa"
-          - "--farm=bs"
-          - "--device=IOS_14"
-          - "--fail-fast"
-          - "--separate-sessions"
-          - "features/ios"
-    concurrency: 9
-    concurrency_group: browserstack-app
-
-  - label: ':ios: Run iOS e2e tests for Unity 2019'
-    depends_on: 'build-ios-fixture-2019'
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.3.0:
-        download:
-          - "test/mobile/features/fixtures/maze_runner/mazerunner_2019.4.25f1.ipa"
-      docker-compose#v3.3.0:
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.25f1.ipa"
-          - "--farm=bs"
-          - "--device=IOS_14"
-          - "--fail-fast"
-          - "--separate-sessions"
-          - "features/ios"
-    concurrency: 9
-    concurrency_group: browserstack-app
-
   - label: ':ios: Run iOS e2e tests for Unity 2020'
     depends_on: 'build-ios-fixture-2020'
     timeout_in_minutes: 30
@@ -620,3 +185,9 @@ steps:
           - "features/ios"
     concurrency: 9
     concurrency_group: browserstack-app
+
+  #
+  # Conditionally trigger full pipeline
+  #
+  - label: 'Conditionally trigger full set of tests'
+    command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/pipeline_trigger.sh
+++ b/.buildkite/pipeline_trigger.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+if [[ "$BUILDKITE_MESSAGE" == *"[full ci]"* ||
+  "$BUILDKITE_BRANCH" == "next" ||
+  "$BUILDKITE_BRANCH" == "master" ||
+  "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" == "master" ]]; then
+  echo "Running full build"
+  buildkite-agent pipeline upload .buildkite/pipeline.full.yml
+fi


### PR DESCRIPTION
## Goal

Introduce two-stage quality gates.  

## Design

For the `next` and `master` branches, or PRs directly into `master`, a full run will be performed.  Otherwise a basic run (Unity 2020 tests only) will be performed.

## Changeset

`pipeline.yml` refactored to contain only the Unity 2020 tests and execution of a conditional trigger step for the full run.

## Testing

I've verified that a basic run was performed for a simple push of the branch and that it is cancelled in preference to a full build when a PR into `master` is created.  I've also changed the Github/Buildkite settings to report status checks for each build step (instead of just the whole pipeline), to ensure that all steps from a full build have been run for PRs into the `master` branch.

Once this PR is merged, a scheduled job will be set up on `next` to perform a full build every night.