### PR TITLE
chore(test) add test for automatic bugsnag loaded breadcrumb

### DIFF
--- a/test/desktop/features/breadcrumbs.feature
+++ b/test/desktop/features/breadcrumbs.feature
@@ -8,6 +8,13 @@ Feature: Leaving breadcrumbs to attach to reports
         And the exception "message" equals "Collective failure"
         And the event has a "manual" breadcrumb named "Initialize bumpers"
 
+    Scenario: Checking for the bugsnag loaded state breadcrumb
+        When I run the game in the "MessageBreadcrumbNotify" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        And the exception "errorClass" equals "Exception"
+        And the event has a "state" breadcrumb named "Bugsnag loaded"
+
     Scenario: Attaching a low-level log message as a breadcrumb
         When I run the game in the "DebugLogBreadcrumbNotify" state
         And I wait to receive an error

--- a/test/mobile/features/android/android_breadcrumbs.feature
+++ b/test/mobile/features/android/android_breadcrumbs.feature
@@ -6,12 +6,16 @@ Feature: android breadcrumbs
     Scenario: Disable Breadcrumbs
         When I tap the "Disable Breadcrumbs" button
         Then I wait to receive an error
-
         And the error payload field "events.0.breadcrumbs.0" is null       
 
 
     Scenario: Max Breadcrumbs
         When I tap the "Max Breadcrumbs" button
         Then I wait to receive an error
-
         And the error payload field "events.0.breadcrumbs" is an array with 5 elements
+
+
+    Scenario: Bugsnag Loaded Breadcrumb
+        When I tap the "throw Exception" button
+        Then I wait to receive an error
+        And the event has a "state" breadcrumb named "Bugsnag loaded"

--- a/test/mobile/features/ios/ios_breadcrumbs.feature
+++ b/test/mobile/features/ios/ios_breadcrumbs.feature
@@ -6,12 +6,15 @@ Feature: ios breadcrumbs
     Scenario: Disable Breadcrumbs
         When I tap the "Disable Breadcrumbs" button
         Then I wait to receive an error
-
         And the error payload field "events.0.breadcrumbs.0" is null       
 
 
     Scenario: Max Breadcrumbs
         When I tap the "Max Breadcrumbs" button
         Then I wait to receive an error
-
         And the error payload field "events.0.breadcrumbs" is an array with 5 elements
+
+    Scenario: Bugsnag Loaded Breadcrumb
+        When I tap the "throw Exception" button
+        Then I wait to receive an error
+        And the event has a "state" breadcrumb named "Bugsnag loaded"


### PR DESCRIPTION
## Goal

Add tests for the native breadcrumb 'Bugsnag loaded'

## Changeset

Added desktop, android and iOS tests to check for the existence on the specific breadcrumb

## Testing

Tested manually and against browserstack