### PR TITLE
Build Windows test fixtures

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -21,8 +21,6 @@ steps:
       - ./features/scripts/build_maze_runner.sh
     artifact_paths:
       - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   - label: Build Unity 2018 MacOS test fixture
     key: 'cocoa-2018-fixture'
@@ -42,8 +40,6 @@ steps:
       - ./features/scripts/build_maze_runner.sh
     artifact_paths:
       - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   - label: Build Unity 2019 MacOS test fixture
     key: 'cocoa-2019-fixture'
@@ -63,8 +59,6 @@ steps:
       - ./features/scripts/build_maze_runner.sh
     artifact_paths:
       - test/desktop/features/fixtures/Mazerunner-2019.4.25f1.app.zip
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   #
   # Run desktop tests
@@ -147,8 +141,6 @@ steps:
           - test/mobile/features/fixtures/unity.log
     commands:
       - rake test:android:build
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   - label: ':android: Build Android test fixture for Unity 2018'
     key: 'build-android-fixture-2018'
@@ -168,8 +160,6 @@ steps:
           - test/mobile/features/fixtures/unity.log
     commands:
       - rake test:android:build
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   - label: ':android: Build Android test fixture for Unity 2019'
     key: 'build-android-fixture-2019'
@@ -189,8 +179,6 @@ steps:
           - test/mobile/features/fixtures/unity.log
     commands:
       - rake test:android:build
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   #
   # Run Android tests
@@ -277,8 +265,6 @@ steps:
     commands:
       - rake test:ios:generate_xcode
       - tar -zvcf project_2017.tgz  test/mobile/features/fixtures/maze_runner/mazerunner_xcode
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   - label: ':ios: Build iOS test fixture for Unity 2017'
     key: 'build-ios-fixture-2017'
@@ -320,8 +306,6 @@ steps:
     commands:
       - rake test:ios:generate_xcode
       - tar -zvcf project_2018.tgz  test/mobile/features/fixtures/maze_runner/mazerunner_xcode
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   - label: ':ios: Build iOS test fixture for Unity 2018'
     key: 'build-ios-fixture-2018'
@@ -363,8 +347,6 @@ steps:
     commands:
       - rake test:ios:generate_xcode
       - tar -zvcf project_2019.tgz test/mobile/features/fixtures/maze_runner/mazerunner_xcode
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   - label: ':ios: Build iOS test fixture for Unity 2019'
     key: 'build-ios-fixture-2019'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -185,7 +185,6 @@ steps:
     command: sh -c .buildkite/pipeline_trigger.sh
 
   - block: "Build Windows fixtures"
-    key: block-windows
     prompt: "Build Windows fixtures - Is a suitable agent running?"
 
   #
@@ -238,7 +237,7 @@ steps:
 
   - label: Build Unity 2020 Windows test fixture
     key: 'windows-2020-fixture'
-#    depends_on: 'build-artifacts'
+    depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -218,10 +218,10 @@ steps:
     command:
       # Using the artifacts plugin v1.3 on Windows seem to break the whole step
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
-      - 'cd test\\desktop'
-      - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
+      - 'cd test/desktop/features/scripts'
+      - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test\\desktop\\features\\fixtures\\maze_runner\\WindowsBuild/Mazerunner.exe
+      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe
 
   - label: Build Unity 2019 Windows test fixture
     key: 'windows-2019-fixture'
@@ -234,10 +234,10 @@ steps:
     command:
       # Using the artifacts plugin v1.3 on Windows seem to break the whole step
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
-      - 'cd test\\desktop'
-      - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
+      - 'cd test/desktop/features/scripts'
+      - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test\\desktop\\features\\fixtures\\maze_runner\\WindowsBuild/Mazerunner.exe
+      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe
 
   - label: Build Unity 2020 Windows test fixture
     key: 'windows-2020-fixture'
@@ -250,7 +250,7 @@ steps:
     commands:
       # Using the artifacts plugin v1.3 on Windows seem to break the whole step
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
-      - 'cd test\\desktop'
-      - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
+      - 'cd test/desktop/features/scripts'
+      - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test\\desktop\\features\\fixtures\\maze_runner\\WindowsBuild/Mazerunner.exe
+      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
     commands:
       - cd test/desktop
       - ./features/scripts/build_maze_runner.sh
-    artifact_paths:
+    artifact_paths: 
       - test/desktop/features/fixtures/Mazerunner-2020.3.9f1.app.zip
     concurrency: 2
     concurrency_group: 'unity-license'
@@ -191,3 +191,71 @@ steps:
   #
   - label: 'Conditionally trigger full set of tests'
     command: sh -c .buildkite/pipeline_trigger.sh
+
+  - block: "Build Windows fixtures"
+    key: block-windows
+    depends_on: build-artifacts
+    prompt: "Build Windows fixtures - Is a suitable agent running?"
+
+  #
+  # TODO Once Windows infrastructure is fully in place, refactor the following steps into the basic and full pipelines.
+  #
+  - label: Build Unity 2017 Windows test fixture
+    key: 'windows-2017-fixture'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-windows-unity
+    env:
+      UNITY_VERSION: "2017.4.40f1"
+    command:
+      - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
+      - 'cd test\\desktop'
+      - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
+    artifact_paths:
+      - test\\desktop\\features\\fixtures\\maze_runner\\WindowsBuild/Mazerunner.exe
+
+  - label: Build Unity 2018 Windows test fixture
+    key: 'windows-2018-fixture'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-windows-unity
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+    command:
+      - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
+      - 'cd test\\desktop'
+      - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
+    artifact_paths:
+      - test\\desktop\\features\\fixtures\\maze_runner\\WindowsBuild/Mazerunner.exe
+
+  - label: Build Unity 2019 Windows test fixture
+    key: 'windows-2019-fixture'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-windows-unity
+    env:
+      UNITY_VERSION: "2019.4.28f1"
+    command:
+      - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
+      - 'cd test\\desktop'
+      - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
+    artifact_paths:
+      - test\\desktop\\features\\fixtures\\maze_runner\\WindowsBuild/Mazerunner.exe
+
+  - label: Build Unity 2020 Windows test fixture
+    key: 'windows-2020-fixture'
+    depends_on: 'build-artifacts'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-windows-unity
+    env:
+      UNITY_VERSION: "2020.3.12f1"
+    command:
+      - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
+      - 'cd test\\desktop'
+      - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
+    artifact_paths:
+      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -205,7 +205,7 @@ steps:
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test\\desktop\\features\\fixtures\\Mazerunner-2017.4.40f1.zip
+      - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.zip
 
   - label: Build Unity 2018 Windows test fixture
     key: 'windows-2018-fixture'
@@ -221,7 +221,7 @@ steps:
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test\\desktop\\features\\fixtures\\Mazerunner-2018.4.36f1.zip
+      - test/desktop/features/fixtures/Mazerunner-2018.4.36f1.zip
 
   - label: Build Unity 2019 Windows test fixture
     key: 'windows-2019-fixture'
@@ -237,7 +237,7 @@ steps:
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test\\desktop\\features\\fixtures\\Mazerunner-2019.4.28f1.zip
+      - test/desktop/features/fixtures/Mazerunner-2019.4.28f1.zip
 
   - label: Build Unity 2020 Windows test fixture
     key: 'windows-2020-fixture'
@@ -253,4 +253,4 @@ steps:
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test\\desktop\\features\\fixtures\\Mazerunner-2020.3.12f1.zip
+      - test/desktop/features/fixtures/Mazerunner-2020.3.12f1.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -185,6 +185,7 @@ steps:
     command: sh -c .buildkite/pipeline_trigger.sh
 
   - block: "Build Windows fixtures"
+    key: 'block-windows'
     prompt: "Build Windows fixtures - Is a suitable agent running?"
 
   #
@@ -192,13 +193,14 @@ steps:
   #
   - label: Build Unity 2017 Windows test fixture
     key: 'windows-2017-fixture'
-    depends_on: 'build-artifacts'
+    depends_on: 'block-windows'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
     env:
       UNITY_VERSION: "2017.4.40f1"
     command:
+      # Using the artifacts plugin v1.3 on Windows seem to break the whole step
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
       - 'cd test\\desktop'
       - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
@@ -207,13 +209,14 @@ steps:
 
   - label: Build Unity 2018 Windows test fixture
     key: 'windows-2018-fixture'
-    depends_on: 'build-artifacts'
+    depends_on: 'block-windows'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
     env:
       UNITY_VERSION: "2018.4.36f1"
     command:
+      # Using the artifacts plugin v1.3 on Windows seem to break the whole step
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
       - 'cd test\\desktop'
       - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
@@ -222,13 +225,14 @@ steps:
 
   - label: Build Unity 2019 Windows test fixture
     key: 'windows-2019-fixture'
-    depends_on: 'build-artifacts'
+    depends_on: 'block-windows'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
     env:
       UNITY_VERSION: "2019.4.28f1"
     command:
+      # Using the artifacts plugin v1.3 on Windows seem to break the whole step
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
       - 'cd test\\desktop'
       - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
@@ -237,13 +241,14 @@ steps:
 
   - label: Build Unity 2020 Windows test fixture
     key: 'windows-2020-fixture'
-    depends_on: 'build-artifacts'
+    depends_on: 'block-windows'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
     env:
       UNITY_VERSION: "2020.3.12f1"
     commands:
+      # Using the artifacts plugin v1.3 on Windows seem to break the whole step
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
       - 'cd test\\desktop'
       - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,8 +16,6 @@ steps:
     artifact_paths:
       - Bugsnag.unitypackage
       - Bugsnag-with-android-64bit.unitypackage
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   #
   # Build desktop test fixture
@@ -38,10 +36,8 @@ steps:
     commands:
       - cd test/desktop
       - ./features/scripts/build_maze_runner.sh
-    artifact_paths: 
+    artifact_paths:
       - test/desktop/features/fixtures/Mazerunner-2020.3.9f1.app.zip
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   #
   # Run desktop tests
@@ -86,8 +82,6 @@ steps:
           - test/mobile/features/fixtures/unity.log
     commands:
       - rake test:android:build
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   #
   # Run Android tests
@@ -137,8 +131,6 @@ steps:
     commands:
       - rake test:ios:generate_xcode
       - tar -zvcf project_2020.tgz test/mobile/features/fixtures/maze_runner/mazerunner_xcode
-    concurrency: 2
-    concurrency_group: 'unity-license'
 
   - label: ':ios: Build iOS test fixture for Unity 2020'
     key: 'build-ios-fixture-2020'
@@ -194,7 +186,6 @@ steps:
 
   - block: "Build Windows fixtures"
     key: block-windows
-    depends_on: build-artifacts
     prompt: "Build Windows fixtures - Is a suitable agent running?"
 
   #
@@ -247,15 +238,15 @@ steps:
 
   - label: Build Unity 2020 Windows test fixture
     key: 'windows-2020-fixture'
-    depends_on: 'build-artifacts'
+#    depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
     env:
       UNITY_VERSION: "2020.3.12f1"
-    command:
+    commands:
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
       - 'cd test\\desktop'
       - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
     artifact_paths:
-      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe
+      - test\\desktop\\features\\fixtures\\maze_runner\\WindowsBuild/Mazerunner.exe

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -202,10 +202,10 @@ steps:
     command:
       # Using the artifacts plugin v1.3 on Windows seem to break the whole step
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
-      - 'cd test\\desktop'
-      - 'c:\\Progra~1\\Git\\bin\\bash.exe ./features/scripts/build_maze_runner.sh'
+      - 'cd test/desktop/features/scripts'
+      - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test\\desktop\\features\\fixtures\\maze_runner\\WindowsBuild/Mazerunner.exe
+      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe
 
   - label: Build Unity 2018 Windows test fixture
     key: 'windows-2018-fixture'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -205,7 +205,7 @@ steps:
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe
+      - test\\desktop\\features\\fixtures\\Mazerunner-2017.4.40f1.zip
 
   - label: Build Unity 2018 Windows test fixture
     key: 'windows-2018-fixture'
@@ -221,7 +221,7 @@ steps:
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe
+      - test\\desktop\\features\\fixtures\\Mazerunner-2018.4.36f1.zip
 
   - label: Build Unity 2019 Windows test fixture
     key: 'windows-2019-fixture'
@@ -237,7 +237,7 @@ steps:
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe
+      - test\\desktop\\features\\fixtures\\Mazerunner-2019.4.28f1.zip
 
   - label: Build Unity 2020 Windows test fixture
     key: 'windows-2020-fixture'
@@ -253,4 +253,4 @@ steps:
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
     artifact_paths:
-      - test/desktop/features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe
+      - test\\desktop\\features\\fixtures\\Mazerunner-2020.3.12f1.zip

--- a/test/desktop/features/scripts/build_maze_runner.sh
+++ b/test/desktop/features/scripts/build_maze_runner.sh
@@ -9,21 +9,22 @@ fi
 
 if [ "$(uname)" == "Darwin" ]; then
 
-  PLATFORM="MacOS"    
+  PLATFORM="MacOS"
   echo "MacOS Detected"
   UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
 
 elif [ $OS == "Windows_NT" ]; then
 
-    PLATFORM="Win64"  
+    PLATFORM="Win64"
     set -m
     echo "Windows64 Detected"
-    UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe" 
+    UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
 
 fi
 
 # Set project_path to the repo root
-pushd "${0%/*}"
+SCRIPT_DIR=$(dirname "$(realpath $0)")
+pushd $SCRIPT_DIR
   pushd ../../../..
     package_path=`pwd`
     echo "Expecting to find Bugsnag package in: $package_path"
@@ -56,7 +57,7 @@ pushd "${0%/*}"
     RESULT=$?
     if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 
-    
+
     echo "Building the fixture for $PLATFORM"
 
     "$UNITY_PATH" $DEFAULT_CLI_ARGS \
@@ -77,9 +78,5 @@ pushd "${0%/*}"
         RESULT=$?
          if [ $RESULT -ne 0 ]; then exit $RESULT; fi
     fi
-
-
-
-   
   popd
 popd

--- a/test/desktop/features/scripts/build_maze_runner.sh
+++ b/test/desktop/features/scripts/build_maze_runner.sh
@@ -74,7 +74,7 @@ pushd $SCRIPT_DIR
          if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 
     else
-       zip -r "Mazerunner-$UNITY_VERSION.zip" "maze_runner/WindowsBuild/"
+       gzip -r "Mazerunner-$UNITY_VERSION.zip" "maze_runner/WindowsBuild/"
         RESULT=$?
          if [ $RESULT -ne 0 ]; then exit $RESULT; fi
     fi

--- a/test/desktop/features/scripts/build_maze_runner.sh
+++ b/test/desktop/features/scripts/build_maze_runner.sh
@@ -69,12 +69,12 @@ pushd $SCRIPT_DIR
 
     if [ "$PLATFORM" == "MacOS" ]; then
 
-       tar -czf "Mazerunner-$UNITY_VERSION.app.zip" "maze_runner/Mazerunner.app"
+       zip -r "Mazerunner-$UNITY_VERSION.app.zip" "maze_runner/Mazerunner.app"
         RESULT=$?
          if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 
     else
-       tar -czf "Mazerunner-$UNITY_VERSION.zip" "maze_runner/WindowsBuild/"
+       zip -r "Mazerunner-$UNITY_VERSION.zip" "maze_runner/WindowsBuild/"
         RESULT=$?
          if [ $RESULT -ne 0 ]; then exit $RESULT; fi
     fi

--- a/test/desktop/features/scripts/build_maze_runner.sh
+++ b/test/desktop/features/scripts/build_maze_runner.sh
@@ -68,15 +68,13 @@ pushd $SCRIPT_DIR
 
 
     if [ "$PLATFORM" == "MacOS" ]; then
-
-       zip -r "Mazerunner-$UNITY_VERSION.app.zip" "maze_runner/Mazerunner.app"
-        RESULT=$?
-         if [ $RESULT -ne 0 ]; then exit $RESULT; fi
-
+      zip -r "Mazerunner-$UNITY_VERSION.app.zip" "maze_runner/Mazerunner.app"
+      RESULT=$?
+      if [ $RESULT -ne 0 ]; then exit $RESULT; fi
     else
-       gzip -r "Mazerunner-$UNITY_VERSION.zip" "maze_runner/WindowsBuild/"
-        RESULT=$?
-         if [ $RESULT -ne 0 ]; then exit $RESULT; fi
+      7z a -r "Mazerunner-$UNITY_VERSION.zip" "maze_runner/WindowsBuild"
+      RESULT=$?
+      if [ $RESULT -ne 0 ]; then exit $RESULT; fi
     fi
   popd
 popd

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -23,7 +23,7 @@ AfterConfiguration do |_config|
     raise StandardError, "Test fixture build archive not found at #{fixture_dir}/#{zip_file}"
   end
 
-  `cd #{fixture_dir} && tar -xzf #{zip_file}`
+  `cd #{fixture_dir} && unzip #{zip_file}`
 
   unless File.exist?("#{project_dir}/#{app_file}")
     raise StandardError, "Test fixture wasn't successfully extracted to #{project_dir}/#{app_file}"


### PR DESCRIPTION
## Goal

Build e2e test fixtures for Unity 2017 to 2020 on Windows in the CI pipeline.

## Design

New steps are currently behind a block step as we don't yet have permanent Windows build servers in place.  There's also low value in only building the test fixtures - running the e2e tests will come shortly.

To run these new build steps, a Buildkite agent can be set up temporarily on a Windows development machine very easily and the block step manually released through the Buildkite UI.

## Changeset

New pipeline steps as described.  Existing concurrency group settings removed as they are unnecessary - only the number of Unity agents for the number of licenses that we have will be stood up in the first place.  If there's an agent free, it will be licensed.

## Testing

Tested with an agent running on my Windows development machine.