### PR TITLE
fix(webgl): fix delayed sending of failed requests on webgl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
   * Prevent some potential false positive detection of app hangs.
     [#1122](https://github.com/bugsnag/bugsnag-cocoa/pull/1122)
+    
+### Bug fixes
+
+* Fixed an issue where WebGL web requests that initially fail were not respecting the 10 second delay before retrying 
+  [#321](https://github.com/bugsnag/bugsnag-unity/pull/321)
 
 ## 5.1.1 (2021-06-24)
 

--- a/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
+++ b/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
@@ -70,6 +70,17 @@ namespace BugsnagUnity
             yield return null;
         }
 
+        public void EnqueueWithDelayCoroutine(Action action, float delay)
+        {
+            StartCoroutine(DelayAction(action,delay));
+        }
+
+        private IEnumerator DelayAction(Action action, float delay)
+        {
+            yield return new WaitForSeconds(delay);
+            action.Invoke();
+        }
+
 
         private static MainThreadDispatchBehaviour _instance = null;
 
@@ -82,7 +93,7 @@ namespace BugsnagUnity
         {
             if (!Exists())
             {
-                throw new Exception("MainThreadDispatchBehaviour could not find the MainThreadDispatchBehaviour object. Please ensure you have added the MainThreadExecutor Prefab to your scene.");
+                throw new Exception("MainThreadDispatchBehaviour could not find the MainThreadDispatchBehaviour object.");
             }
             return _instance;
         }


### PR DESCRIPTION
## Goal

Because of WebGL not supporting background threads, the delay beforte retrying requests was not working

## Design

I added a simple coroutine to handle any webgl web request with a 500 type status code

## Changeset

Added coroutine and stopped requests with errors from being retried

## Testing

Tested manually