### PR TITLE
fix(breadcrumbs): make sure breadcrumbs retain correct order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,6 @@
   * Prevent some potential false positive detection of app hangs.
     [#1122](https://github.com/bugsnag/bugsnag-cocoa/pull/1122)
     
-### Bug fixes
-
-* Fixed an issue where WebGL web requests that initially fail were not respecting the 10 second delay before retrying 
-  [#321](https://github.com/bugsnag/bugsnag-unity/pull/321)
-
 * Update bugsnag-android to v5.9.5:
 
   * Properly handle ANRs after multiple calls to autoNotify and autoDetectAnrs
@@ -71,7 +66,17 @@
     [#1293](https://github.com/bugsnag/bugsnag-android/pull/1293)
 
   * Optimize capture of thread traces
-    [#1300](https://github.com/bugsnag/bugsnag-android/pull/1300)
+    [#1300](https://github.com/bugsnag/bugsnag-android/pull/1300)    
+    
+### Bug fixes
+
+* Fixed an issue where WebGL web requests that initially fail were not respecting the 10 second delay before retrying 
+  [#321](https://github.com/bugsnag/bugsnag-unity/pull/321)
+  
+* Fixed an issue where Breadcrumbs were reported in the wrong order on Windows and in the Unity Editor
+  [#322](https://github.com/bugsnag/bugsnag-unity/pull/322)
+
+
 
 ## 5.1.1 (2021-06-24)
 

--- a/src/BugsnagUnity/Native/Fallback/Breadcrumbs.cs
+++ b/src/BugsnagUnity/Native/Fallback/Breadcrumbs.cs
@@ -45,13 +45,17 @@ namespace BugsnagUnity
         /// <param name="breadcrumb"></param>
         public void Leave(Breadcrumb breadcrumb)
         {
+            if (Configuration.MaximumBreadcrumbs == 0)
+            {
+                return;
+            }
+
             if (breadcrumb != null)
             {
                 lock (_lock)
                 {
-                    var maximumBreadcrumbs = Configuration.MaximumBreadcrumbs;
-
-                    if (_breadcrumbs.Count == maximumBreadcrumbs)
+                   
+                    if (_breadcrumbs.Count == Configuration.MaximumBreadcrumbs)
                     {
                         _breadcrumbs.RemoveAt(0);
                     }

--- a/src/BugsnagUnity/Native/Fallback/Breadcrumbs.cs
+++ b/src/BugsnagUnity/Native/Fallback/Breadcrumbs.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using BugsnagUnity.Payload;
 
 namespace BugsnagUnity
@@ -8,8 +7,7 @@ namespace BugsnagUnity
     {
         readonly object _lock = new object();
         IConfiguration Configuration { get; }
-        Breadcrumb[] _breadcrumbs;
-        int _current;
+        List<Breadcrumb> _breadcrumbs;
 
         /// <summary>
         /// Constructs a collection of breadcrumbs
@@ -18,8 +16,7 @@ namespace BugsnagUnity
         internal Breadcrumbs(IConfiguration configuration)
         {
             Configuration = configuration;
-            _current = 0;
-            _breadcrumbs = new Breadcrumb[Configuration.MaximumBreadcrumbs];
+            _breadcrumbs = new List<Breadcrumb>();
         }
 
         /// <summary>
@@ -53,16 +50,13 @@ namespace BugsnagUnity
                 lock (_lock)
                 {
                     var maximumBreadcrumbs = Configuration.MaximumBreadcrumbs;
-                    if (_breadcrumbs.Length != maximumBreadcrumbs)
+
+                    if (_breadcrumbs.Count == maximumBreadcrumbs)
                     {
-                        Array.Resize(ref _breadcrumbs, maximumBreadcrumbs);
-                        if (_current >= maximumBreadcrumbs)
-                        {
-                            _current = 0;
-                        }
+                        _breadcrumbs.RemoveAt(0);
                     }
-                    _breadcrumbs[_current] = breadcrumb;
-                    _current = (_current + 1) % maximumBreadcrumbs;
+
+                    _breadcrumbs.Add(breadcrumb);
                 }
             }
         }
@@ -77,18 +71,7 @@ namespace BugsnagUnity
         {
             lock (_lock)
             {
-                var numberOfBreadcrumbs = Array.IndexOf(_breadcrumbs, null);
-
-                if (numberOfBreadcrumbs < 0) numberOfBreadcrumbs = _breadcrumbs.Length;
-
-                var breadcrumbs = new Breadcrumb[numberOfBreadcrumbs];
-
-                for (var i = 0; i < numberOfBreadcrumbs; i++)
-                {
-                    breadcrumbs[i] = _breadcrumbs[i];
-                }
-
-                return breadcrumbs;
+                return _breadcrumbs.ToArray();
             }
         }
     }

--- a/test/desktop/features/breadcrumbs.feature
+++ b/test/desktop/features/breadcrumbs.feature
@@ -65,3 +65,10 @@ Feature: Leaving breadcrumbs to attach to reports
         And I wait to receive an error
         Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
         And the error payload field "events.0.breadcrumbs" is an array with 5 elements
+        And the event "breadcrumbs.0.name" equals "Crumb 2"
+        And the event "breadcrumbs.1.name" equals "Crumb 3"
+        And the event "breadcrumbs.2.name" equals "Crumb 4"
+        And the event "breadcrumbs.3.name" equals "Crumb 5"
+        And the event "breadcrumbs.4.name" equals "Log"
+
+

--- a/test/desktop/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/test/desktop/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -390,7 +390,7 @@ public class Main : MonoBehaviour
 
     private void LeaveBreadcrumbs()
     {
-        for (int i = 0; i < 10; i++)
+        for (int i = 0; i < 6; i++)
         {
             Bugsnag.LeaveBreadcrumb("Crumb " + i);
         }


### PR DESCRIPTION
## Goal

The fallback implementation was messing up the order of breadcrumbs when the breadcrumb limit was reached

## Design

I found the original implementation a little over engineered and hard to read, so i used a simple list instead of an array, which can do the same thing with 10% of the code and minimal memory impact.

## Changeset

Changed the fallback breadcrumbs to use a list and simpler apis

## Testing

Tested manually