### PR TITLE
Provide ability to run desktop e2e tests on Windows

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -17,8 +17,7 @@ steps:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
     commands:
-      - cd test/desktop
-      - ./features/scripts/build_maze_runner.sh
+      - scripts/ci-build-macos-package.sh
     artifact_paths:
       - test/desktop/features/fixtures/maze_runner/Mazerunner-2017.4.40f1.app.zip
 
@@ -36,8 +35,7 @@ steps:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
     commands:
-      - cd test/desktop
-      - ./features/scripts/build_maze_runner.sh
+      - scripts/ci-build-macos-package.sh
     artifact_paths:
       - test/desktop/features/fixtures/maze_runner/Mazerunner-2018.4.34f1.app.zip
 
@@ -55,13 +53,12 @@ steps:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
     commands:
-      - cd test/desktop
-      - ./features/scripts/build_maze_runner.sh
+      - scripts/ci-build-macos-package.sh
     artifact_paths:
       - test/desktop/features/fixtures/maze_runner/Mazerunner-2019.4.25f1.app.zip
 
   #
-  # Run desktop tests
+  # Run macOS desktop tests
   #
   - label: Run MacOS e2e tests for Unity 2017.4.40f1
     depends_on: 'cocoa-2017-fixture'
@@ -73,16 +70,12 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
+          - test/desktop/features/fixtures/maze_runner/Mazerunner-2017.4.40f1.app.zip
         upload:
           - test/desktop/maze_output/*
           - test/desktop/Mazerunner.log
     commands:
-      - cd test/desktop/features/fixtures/maze_runner
-      - unzip Mazerunner-2017.4.40f1.app.zip
-      - cd ../../..
-      - bundle install
-      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
+      - scripts/ci-run-macos-tests.sh
 
   - label: Run MacOS e2e tests for Unity 2018.4.34f1
     depends_on: 'cocoa-2018-fixture'
@@ -94,16 +87,12 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
+          - test/desktop/features/fixtures/maze_runner/Mazerunner-2018.4.34f1.app.zip
         upload:
           - test/desktop/maze_output/*
           - test/desktop/Mazerunner.log
     commands:
-      - cd test/desktop/features/fixtures/maze_runner
-      - unzip Mazerunner-2018.4.34f1.app.zip
-      - cd ../../..
-      - bundle install
-      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
+      - scripts/ci-run-macos-tests.sh
 
   - label: Run MacOS e2e tests for Unity 2019.4.25f1
     depends_on: 'cocoa-2019-fixture'
@@ -115,16 +104,12 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - test/desktop/features/fixtures/Mazerunner-2019.4.25f1.app.zip
+          - test/desktop/features/fixtures/maze_runner/Mazerunner-2019.4.25f1.app.zip
         upload:
           - test/desktop/maze_output/*
           - test/desktop/Mazerunner.log
     commands:
-      - cd test/desktop/features/fixtures/maze_runner
-      - unzip Mazerunner-2019.4.25f1.app.zip
-      - cd ../../..
-      - bundle install
-      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
+      - scripts/ci-run-macos-tests.sh
 
   #
   # Build Android test fixtures

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -20,7 +20,7 @@ steps:
       - cd test/desktop
       - ./features/scripts/build_maze_runner.sh
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.app.zip
+      - test/desktop/features/fixtures/maze_runner/Mazerunner-2017.4.40f1.app.zip
 
   - label: Build Unity 2018 MacOS test fixture
     key: 'cocoa-2018-fixture'
@@ -39,7 +39,7 @@ steps:
       - cd test/desktop
       - ./features/scripts/build_maze_runner.sh
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2018.4.34f1.app.zip
+      - test/desktop/features/fixtures/maze_runner/Mazerunner-2018.4.34f1.app.zip
 
   - label: Build Unity 2019 MacOS test fixture
     key: 'cocoa-2019-fixture'
@@ -58,7 +58,7 @@ steps:
       - cd test/desktop
       - ./features/scripts/build_maze_runner.sh
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2019.4.25f1.app.zip
+      - test/desktop/features/fixtures/maze_runner/Mazerunner-2019.4.25f1.app.zip
 
   #
   # Run desktop tests
@@ -78,9 +78,11 @@ steps:
           - test/desktop/maze_output/*
           - test/desktop/Mazerunner.log
     commands:
-      - cd test/desktop
+      - cd test/desktop/features/fixtures/maze_runner
+      - unzip Mazerunner-2017.4.40f1.app.zip
+      - cd ../../..
       - bundle install
-      - bundle exec maze-runner --app=Mazerunner
+      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
 
   - label: Run MacOS e2e tests for Unity 2018.4.34f1
     depends_on: 'cocoa-2018-fixture'
@@ -97,9 +99,11 @@ steps:
           - test/desktop/maze_output/*
           - test/desktop/Mazerunner.log
     commands:
-      - cd test/desktop
+      - cd test/desktop/features/fixtures/maze_runner
+      - unzip Mazerunner-2018.4.34f1.app.zip
+      - cd ../../..
       - bundle install
-      - bundle exec maze-runner --app=Mazerunner
+      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
 
   - label: Run MacOS e2e tests for Unity 2019.4.25f1
     depends_on: 'cocoa-2019-fixture'
@@ -116,9 +120,11 @@ steps:
           - test/desktop/maze_output/*
           - test/desktop/Mazerunner.log
     commands:
-      - cd test/desktop
+      - cd test/desktop/features/fixtures/maze_runner
+      - unzip Mazerunner-2019.4.25f1.app.zip
+      - cd ../../..
       - bundle install
-      - bundle exec maze-runner --app=Mazerunner
+      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
 
   #
   # Build Android test fixtures

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -198,12 +198,7 @@ steps:
     env:
       UNITY_VERSION: "2017.4.40f1"
     command:
-      # Using the artifacts plugin v1.3 on Windows seem to break the whole step
-      - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
-      - 'cd test/desktop/features/scripts'
-      - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
-      - 'cd ../fixtures/maze_runner'
-      - '7z a -r WindowsBuild-2017.4.40f1.zip WindowsBuild'
+      - scripts/ci-build-windows-package.bat
     artifact_paths:
       - test/desktop/features/fixtures/maze_runner/WindowsBuild-2017.4.40f1.zip
 
@@ -216,12 +211,7 @@ steps:
     env:
       UNITY_VERSION: "2018.4.36f1"
     command:
-      # Using the artifacts plugin v1.3 on Windows seem to break the whole step
-      - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
-      - 'cd test/desktop/features/scripts'
-      - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
-      - 'cd ../fixtures/maze_runner'
-      - '7z a -r WindowsBuild-2018.4.36f1.zip WindowsBuild'
+      - scripts/ci-build-windows-package.bat
     artifact_paths:
       - test/desktop/features/fixtures/maze_runner/WindowsBuild-2018.4.36f1.zip
 
@@ -234,12 +224,7 @@ steps:
     env:
       UNITY_VERSION: "2019.4.28f1"
     command:
-      # Using the artifacts plugin v1.3 on Windows seem to break the whole step
-      - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
-      - 'cd test/desktop/features/scripts'
-      - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
-      - 'cd ../fixtures/maze_runner'
-      - '7z a -r WindowsBuild-2019.4.28f1.zip WindowsBuild'
+      - scripts/ci-build-windows-package.bat
     artifact_paths:
       - test/desktop/features/fixtures/maze_runner/WindowsBuild-2019.4.28f1.zip
 
@@ -252,11 +237,6 @@ steps:
     env:
       UNITY_VERSION: "2020.3.12f1"
     commands:
-      # Using the artifacts plugin v1.3 on Windows seem to break the whole step
-      - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
-      - 'cd test/desktop/features/scripts'
-      - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
-      - 'cd ../fixtures/maze_runner'
-      - '7z a -r WindowsBuild-2020.3.12f1.zip WindowsBuild'
+      - scripts/ci-build-windows-package.bat
     artifact_paths:
       - test/desktop/features/fixtures/maze_runner/WindowsBuild-2020.3.12f1.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,7 +63,7 @@ steps:
       - unzip Mazerunner-2020.3.9f1.app.zip
       - cd ../../..
       - bundle install
-      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app
+      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
 
   #
   # Build Android test fixtures

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,8 +36,10 @@ steps:
     commands:
       - cd test/desktop
       - ./features/scripts/build_maze_runner.sh
+      - cd features/fixtures/maze_runner
+      - zip -r Mazerunner-2020.3.9f1.app.zip Mazerunner.app
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2020.3.9f1.app.zip
+      - test/desktop/features/fixtures/maze_runner/Mazerunner-2020.3.9f1.app.zip
 
   #
   # Run desktop tests
@@ -52,14 +54,16 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - test/desktop/features/fixtures/Mazerunner-2020.3.9f1.app.zip
+          - test/desktop/features/fixtures/maze_runner/Mazerunner-2020.3.9f1.app.zip
         upload:
           - test/desktop/maze_output/*
           - test/desktop/Mazerunner.log
     commands:
-      - cd test/desktop
+      - cd test/desktop/features/fixtures/maze_runner
+      - unzip Mazerunner-2020.3.9f1.app.zip
+      - cd ../../..
       - bundle install
-      - bundle exec maze-runner --app=Mazerunner
+      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app
 
   #
   # Build Android test fixtures

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -197,7 +197,7 @@ steps:
   #
   - label: Build Unity 2017 Windows test fixture
     key: 'windows-2017-fixture'
-    depends_on: 'block-windows'
+    depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
@@ -208,12 +208,14 @@ steps:
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
+      - 'cd ../fixtures/maze_runner'
+      - '7z a -r WindowsBuild-2017.4.40f1.zip WindowsBuild'
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2017.4.40f1.zip
+      - test/desktop/features/fixtures/WindowsBuild-2017.4.40f1.zip
 
   - label: Build Unity 2018 Windows test fixture
     key: 'windows-2018-fixture'
-    depends_on: 'block-windows'
+    depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
@@ -224,12 +226,14 @@ steps:
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
+      - 'cd ../fixtures/maze_runner'
+      - '7z a -r WindowsBuild-2018.4.36f1.zip WindowsBuild'
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2018.4.36f1.zip
+      - test/desktop/features/fixtures/WindowsBuild-2018.4.36f1.zip
 
   - label: Build Unity 2019 Windows test fixture
     key: 'windows-2019-fixture'
-    depends_on: 'block-windows'
+    depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
@@ -240,12 +244,14 @@ steps:
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
+      - 'cd ../fixtures/maze_runner'
+      - '7z a -r WindowsBuild-2019.4.28f1.zip WindowsBuild'
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2019.4.28f1.zip
+      - test/desktop/features/fixtures/WindowsBuild-2019.4.28f1.zip
 
   - label: Build Unity 2020 Windows test fixture
     key: 'windows-2020-fixture'
-    depends_on: 'block-windows'
+    depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
@@ -256,5 +262,7 @@ steps:
       - 'buildkite-agent artifact download "Bugsnag.unitypackage" .'
       - 'cd test/desktop/features/scripts'
       - 'c:/Progra~1/Git/bin/bash.exe build_maze_runner.sh'
+      - 'cd ../fixtures/maze_runner'
+      - '7z a -r WindowsBuild-2020.3.12f1.zip WindowsBuild'
     artifact_paths:
-      - test/desktop/features/fixtures/Mazerunner-2020.3.12f1.zip
+      - test/desktop/features/fixtures/WindowsBuild-2020.3.12f1.zip

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -189,6 +189,7 @@ steps:
     command: sh -c .buildkite/pipeline_trigger.sh
 
   - block: "Build Windows fixtures"
+    depends_on: 'build-artifacts'
     key: 'block-windows'
     prompt: "Build Windows fixtures - Is a suitable agent running?"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,10 +34,7 @@ steps:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
     commands:
-      - cd test/desktop
-      - ./features/scripts/build_maze_runner.sh
-      - cd features/fixtures/maze_runner
-      - zip -r Mazerunner-2020.3.9f1.app.zip Mazerunner.app
+      - scripts/ci-build-macos-package.sh
     artifact_paths:
       - test/desktop/features/fixtures/maze_runner/Mazerunner-2020.3.9f1.app.zip
 
@@ -59,11 +56,7 @@ steps:
           - test/desktop/maze_output/*
           - test/desktop/Mazerunner.log
     commands:
-      - cd test/desktop/features/fixtures/maze_runner
-      - unzip Mazerunner-2020.3.9f1.app.zip
-      - cd ../../..
-      - bundle install
-      - bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
+      - scripts/ci-run-macos-tests.sh
 
   #
   # Build Android test fixtures

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -197,7 +197,7 @@ steps:
   #
   - label: Build Unity 2017 Windows test fixture
     key: 'windows-2017-fixture'
-    depends_on: 'build-artifacts'
+    depends_on: 'block-windows'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
@@ -211,11 +211,11 @@ steps:
       - 'cd ../fixtures/maze_runner'
       - '7z a -r WindowsBuild-2017.4.40f1.zip WindowsBuild'
     artifact_paths:
-      - test/desktop/features/fixtures/WindowsBuild-2017.4.40f1.zip
+      - test/desktop/features/fixtures/maze_runner/WindowsBuild-2017.4.40f1.zip
 
   - label: Build Unity 2018 Windows test fixture
     key: 'windows-2018-fixture'
-    depends_on: 'build-artifacts'
+    depends_on: 'block-windows'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
@@ -229,11 +229,11 @@ steps:
       - 'cd ../fixtures/maze_runner'
       - '7z a -r WindowsBuild-2018.4.36f1.zip WindowsBuild'
     artifact_paths:
-      - test/desktop/features/fixtures/WindowsBuild-2018.4.36f1.zip
+      - test/desktop/features/fixtures/maze_runner/WindowsBuild-2018.4.36f1.zip
 
   - label: Build Unity 2019 Windows test fixture
     key: 'windows-2019-fixture'
-    depends_on: 'build-artifacts'
+    depends_on: 'block-windows'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
@@ -247,11 +247,11 @@ steps:
       - 'cd ../fixtures/maze_runner'
       - '7z a -r WindowsBuild-2019.4.28f1.zip WindowsBuild'
     artifact_paths:
-      - test/desktop/features/fixtures/WindowsBuild-2019.4.28f1.zip
+      - test/desktop/features/fixtures/maze_runner/WindowsBuild-2019.4.28f1.zip
 
   - label: Build Unity 2020 Windows test fixture
     key: 'windows-2020-fixture'
-    depends_on: 'build-artifacts'
+    depends_on: 'block-windows'
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity
@@ -265,4 +265,4 @@ steps:
       - 'cd ../fixtures/maze_runner'
       - '7z a -r WindowsBuild-2020.3.12f1.zip WindowsBuild'
     artifact_paths:
-      - test/desktop/features/fixtures/WindowsBuild-2020.3.12f1.zip
+      - test/desktop/features/fixtures/maze_runner/WindowsBuild-2020.3.12f1.zip

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ bugsnag-android-unity/.cxx
 test/**/*.app.zip
 *.ipa
 **/maze_runner/output/
+**/maze_output

--- a/TESTING.md
+++ b/TESTING.md
@@ -120,8 +120,9 @@ This will generate the test fixture app:
 
 Building the test fixture on Windows requires a Git bash terminal.
 
+In a Git bash terminal:
 1. `cd test/desktop`
-1. `UNITY_VERSION=2018.4.34f1 ./features/scripts/build_maze_runner.sh`
+1. `UNITY_VERSION=2018.4.36f1 ./features/scripts/build_maze_runner.sh`
 
 Where `UNITY_VERSION` corresponds to the Unity installation path, e.g:
 ```
@@ -143,5 +144,18 @@ dependencies:
 1. Run `bundle install` if you haven't run end-to-end tests before
 1. To run the tests:
     ```shell script
-    UNITY_VERSION=2018.4.34f1 bundle exec maze-runner --app=Mazerunner
+    bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
+    ```
+
+#### Windows
+
+Running the Maze Runner tests on Windows requires the Ubuntu app (using WSL).
+
+In the Ubuntu terminal:
+1. `cd test/desktop`
+1. Check the contents of `Gemfile` to select the version of `maze-runner` to use
+1. Run `bundle install` if you haven't run end-to-end tests before
+1. To run the tests:
+    ```shell script
+    bundle exec maze-runner --app=features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe --os=windows
     ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -93,8 +93,7 @@ the following environment variables:
 
 ### Building the test fixture
 
-Building the mobile test fixtures currently assumes a macOS based Unity installation.  To build any test fixture, 
-from the root of the repository, first build the notifier:
+To build any test fixture, from the root of the repository, first build the notifier:
 ```
 rake plugin:export
 ```
@@ -112,12 +111,28 @@ Where `UNITY_VERSION` corresponds to the Unity installation path, e.g:
 /Applications/Unity/Hub/Editor/2018.4.34f1/Unity.app/Contents/MacOS/Unity
 ```
 
-This will generate a zip file containing the test fixture named according to the `UNITY_VERSION`, e.g:
+This will generate the test fixture app:
 ```
-./test/desktop/features/fixtures/Mazerunner_2018.4.34f1.app.zip
+./test/desktop/features/fixtures/maze_runner/Mazerunner.app
 ```
 
-This file will automatically be unzipped when running the tests, so no further action is required.
+#### Windows
+
+Building the test fixture on Windows requires a Git bash terminal.
+
+1. `cd test/desktop`
+1. `UNITY_VERSION=2018.4.34f1 ./features/scripts/build_maze_runner.sh`
+
+Where `UNITY_VERSION` corresponds to the Unity installation path, e.g:
+```
+/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe
+```
+
+This will generate a build folder containing the test fixture executable, together with the UnityPlayer.dll and other
+dependencies:
+```
+./test/desktop/features/fixtures/maze_runner/WindowsBuild
+```
 
 ### Running an end-to-end test
 
@@ -130,5 +145,3 @@ This file will automatically be unzipped when running the tests, so no further a
     ```shell script
     UNITY_VERSION=2018.4.34f1 bundle exec maze-runner --app=Mazerunner
     ```
-
-Where `UNITY_VERSION` corresponds to the Unity version used to build the test fixture initially.

--- a/scripts/ci-build-macos-package.sh
+++ b/scripts/ci-build-macos-package.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+pushd test/desktop
+  ./features/scripts/build_maze_runner.sh
+  if [[ $? != 0 ]]; then
+    popd
+    exit $1
+  fi
+
+  pushd features/fixtures/maze_runner
+    zip -r Mazerunner-$UNITY_VERSION.app.zip Mazerunner.app
+  popd
+popd

--- a/scripts/ci-build-windows-package.bat
+++ b/scripts/ci-build-windows-package.bat
@@ -1,0 +1,6 @@
+REM Using the artifacts plugin v1.3 on Windows seems to break the whole step
+buildkite-agent artifact download "Bugsnag.unitypackage" .
+cd test\desktop\features\scripts
+C:\Progra~1\Git\bin\bash.exe build_maze_runner.sh
+cd ..\fixtures\maze_runner
+7z a -r WindowsBuild-%UNITY_VERSION%.zip WindowsBuild

--- a/scripts/ci-run-macos-tests.sh
+++ b/scripts/ci-run-macos-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+pushd test/desktop/features/fixtures/maze_runner
+  unzip Mazerunner-$UNITY_VERSION.app.zip
+  pushd ../../..
+    bundle install
+    bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
+  popd
+popd

--- a/test/desktop/Gemfile
+++ b/test/desktop/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.1.0"
+gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.5.0"

--- a/test/desktop/Gemfile
+++ b/test/desktop/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.5.0"
+gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.5.1"

--- a/test/desktop/Gemfile.lock
+++ b/test/desktop/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: eea928bc06926bbe8e647c6981959c3c86807bd5
-  tag: v5.5.0
+  revision: 8fc4686ab165613071f504408a41f73e1c9cd874
+  tag: v5.5.1
   specs:
-    bugsnag-maze-runner (5.5.0)
+    bugsnag-maze-runner (5.5.1)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/test/desktop/Gemfile.lock
+++ b/test/desktop/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: f7536f3128462c5e56963b6c75372b3e96243823
-  tag: v5.1.0
+  revision: eea928bc06926bbe8e647c6981959c3c86807bd5
+  tag: v5.5.0
   specs:
-    bugsnag-maze-runner (5.1.0)
+    bugsnag-maze-runner (5.5.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -23,7 +23,7 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.5.0)
+    appium_lib_core (4.6.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.21.0)
@@ -48,32 +48,32 @@ GEM
     curb (0.9.11)
     diff-lcs (1.4.4)
     eventmachine (1.2.7)
-    faye-websocket (0.11.0)
+    faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)
-    mini_portile2 (2.5.1)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.3)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.3-x86_64-darwin)
+    nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
     power_assert (2.0.0)
     racc (1.5.2)
     rake (12.3.3)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     test-unit (3.3.9)
       power_assert
     tomlrb (1.3.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
 

--- a/test/desktop/features/fixtures/.gitignore
+++ b/test/desktop/features/fixtures/.gitignore
@@ -1,1 +1,2 @@
 Mazerunner.app
+WindowsBuild

--- a/test/desktop/features/scripts/build_maze_runner.sh
+++ b/test/desktop/features/scripts/build_maze_runner.sh
@@ -8,18 +8,14 @@ fi
 #!/usr/bin/env bash
 
 if [ "$(uname)" == "Darwin" ]; then
-
   PLATFORM="MacOS"
   echo "MacOS Detected"
   UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
-
 elif [ $OS == "Windows_NT" ]; then
-
     PLATFORM="Win64"
     set -m
     echo "Windows64 Detected"
     UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
-
 fi
 
 # Set project_path to the repo root
@@ -65,16 +61,5 @@ pushd $SCRIPT_DIR
       -executeMethod "Builder.$PLATFORM"
     RESULT=$?
     if [ $RESULT -ne 0 ]; then exit $RESULT; fi
-
-
-    if [ "$PLATFORM" == "MacOS" ]; then
-      zip -r "Mazerunner-$UNITY_VERSION.app.zip" "maze_runner/Mazerunner.app"
-      RESULT=$?
-      if [ $RESULT -ne 0 ]; then exit $RESULT; fi
-    else
-      7z a -r "Mazerunner-$UNITY_VERSION.zip" "maze_runner/WindowsBuild"
-      RESULT=$?
-      if [ $RESULT -ne 0 ]; then exit $RESULT; fi
-    fi
   popd
 popd

--- a/test/desktop/features/steps/unity_steps.rb
+++ b/test/desktop/features/steps/unity_steps.rb
@@ -5,10 +5,16 @@ When("I run the game in the {string} state") do |state|
 
   if Maze.config.os == 'macos'
     command = "open -W #{Maze.config.app} --args -batchmode -nographics"
+    Maze::Runner.run_command(command)
   else
     command = "#{Maze.config.app} -batchmode -nographics"
+    env = {
+        'BUGSNAG_SCENARIO' => state,
+        'BUGSNAG_APIKEY' => $api_key,
+        'MAZE_ENDPOINT' => 'http://localhost:9339'
+    }
+    system(env, command)
   end
-  Maze::Runner.run_command(command)
 end
 
 Then("the error is valid for the error reporting API sent by the {string}") do |notifier_name|

--- a/test/desktop/features/steps/unity_steps.rb
+++ b/test/desktop/features/steps/unity_steps.rb
@@ -3,8 +3,7 @@ When("I run the game in the {string} state") do |state|
   Maze::Runner.environment['BUGSNAG_APIKEY'] = $api_key
   Maze::Runner.environment['MAZE_ENDPOINT'] = 'http://localhost:9339'
   command = %(
-    cd features/fixtures/maze_runner &&
-    #{Maze.config.app}.app/Contents/MacOS/#{Maze.config.app} -batchmode -nographics
+    open #{Maze.config.app} --args -batchmode -nographics
   )
   Maze::Runner.run_command(command)
 end

--- a/test/desktop/features/steps/unity_steps.rb
+++ b/test/desktop/features/steps/unity_steps.rb
@@ -3,7 +3,7 @@ When("I run the game in the {string} state") do |state|
   Maze::Runner.environment['BUGSNAG_APIKEY'] = $api_key
   Maze::Runner.environment['MAZE_ENDPOINT'] = 'http://localhost:9339'
   command = %(
-    open #{Maze.config.app} --args -batchmode -nographics
+    open -W #{Maze.config.app} --args -batchmode -nographics
   )
   Maze::Runner.run_command(command)
 end

--- a/test/desktop/features/steps/unity_steps.rb
+++ b/test/desktop/features/steps/unity_steps.rb
@@ -2,9 +2,12 @@ When("I run the game in the {string} state") do |state|
   Maze::Runner.environment['BUGSNAG_SCENARIO'] = state
   Maze::Runner.environment['BUGSNAG_APIKEY'] = $api_key
   Maze::Runner.environment['MAZE_ENDPOINT'] = 'http://localhost:9339'
-  command = %(
-    open -W #{Maze.config.app} --args -batchmode -nographics
-  )
+
+  if Maze.config.os == 'macos'
+    command = "open -W #{Maze.config.app} --args -batchmode -nographics"
+  else
+    command = "#{Maze.config.app} -batchmode -nographics"
+  end
   Maze::Runner.run_command(command)
 end
 

--- a/test/desktop/features/steps/unity_steps.rb
+++ b/test/desktop/features/steps/unity_steps.rb
@@ -2,7 +2,6 @@ When("I run the game in the {string} state") do |state|
   Maze::Runner.environment['BUGSNAG_SCENARIO'] = state
   Maze::Runner.environment['BUGSNAG_APIKEY'] = $api_key
   Maze::Runner.environment['MAZE_ENDPOINT'] = 'http://localhost:9339'
-  Maze::Runner.environment['UNITY_PROJECT_NAME'] = "#{Maze.config.app}.app"
   command = %(
     cd features/fixtures/maze_runner &&
     #{Maze.config.app}.app/Contents/MacOS/#{Maze.config.app} -batchmode -nographics
@@ -32,7 +31,7 @@ Then("the error is valid for the error reporting API sent by the {string}") do |
 end
 
 Then("the errors are valid for the error reporting API sent by the {string}") do |notifier_name|
-  
+
 end
 
 Then("the first significant stack frame methods and files should match:") do |expected_values|

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -21,6 +21,7 @@ end
 
 at_exit do
   if Maze.config.os == 'macos'
-    Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze.start_time}' > #{Maze.config.app}.log")
+    app_name = Maze.config.app.gsub /\.app$/, ''
+    Maze::Runner.run_command("log show --predicate '(process == \"#{app_name}\")' --style syslog --start '#{Maze.start_time}' > #{app_name}.log")
   end
 end

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -2,21 +2,23 @@ require 'fileutils'
 
 $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
 
+raise '--os option must be set (to "macos" or "windows"' if Maze.config.os.nil?
+
+AfterConfiguration do |_config|
+  Maze.config.enforce_bugsnag_integrity = false
+
+  if Maze.config.os.downcase == 'macos'
+    # The default macOS Crash Reporter "#{app_name} quit unexpectedly" alert grabs focus which can cause tests to flake.
+    # This option, which appears to have been introduced in macOS 10.11, displays a notification instead of the alert.
+    Maze::Runner.run_command('defaults write com.apple.CrashReporter UseUNC 1')
+  end
+end
+
 Maze.hooks.before do
   if Maze.config.os == 'macos'
     support_dir = File.expand_path '~/Library/Application Support/com.bugsnag.Bugsnag'
     $logger.info 'Clearing #{support_dir}'
     FileUtils.rm_rf(support_dir)
-  end
-end
-
-AfterConfiguration do |_config|
-  Maze.config.enforce_bugsnag_integrity = false
-
-  if Maze.config.os == 'macos'
-    # The default macOS Crash Reporter "#{app_name} quit unexpectedly" alert grabs focus which can cause tests to flake.
-    # This option, which appears to have been introduced in macOS 10.11, displays a notification instead of the alert.
-    Maze::Runner.run_command('defaults write com.apple.CrashReporter UseUNC 1')
   end
 end
 

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -12,6 +12,9 @@ AfterConfiguration do |_config|
     # The default macOS Crash Reporter "#{app_name} quit unexpectedly" alert grabs focus which can cause tests to flake.
     # This option, which appears to have been introduced in macOS 10.11, displays a notification instead of the alert.
     Maze::Runner.run_command('defaults write com.apple.CrashReporter UseUNC 1')
+  elsif Maze.config.os.downcase == 'windows'
+    # Allow the necessary environment variables to be passed from Ubuntu (under WSL) to the Windows test fixture
+    ENV['WSLENV'] = 'BUGSNAG_SCENARIO:BUGSNAG_APIKEY:MAZE_ENDPOINT'
   end
 end
 

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -2,9 +2,10 @@ require 'fileutils'
 
 $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
 
-raise '--os option must be set (to "macos" or "windows"' if Maze.config.os.nil?
 
 AfterConfiguration do |_config|
+  raise '--os option must be set (to "macos" or "windows"' if Maze.config.os.nil?
+
   Maze.config.enforce_bugsnag_integrity = false
 
   if Maze.config.os.downcase == 'macos'

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -2,37 +2,25 @@ require 'fileutils'
 
 $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
 
-AfterConfiguration do |_config|
-  # The default macOS Crash Reporter "#{app_name} quit unexpectedly" alert grabs focus which can cause tests to flake.
-  # This option, which appears to have been introduced in macOS 10.11, displays a notification instead of the alert.
-  Maze::Runner.run_command('defaults write com.apple.CrashReporter UseUNC 1')
-
-  Maze.hooks.before do
+Maze.hooks.before do
+  if Maze.config.os == 'macos'
+    $logger.info 'Clearing '
     FileUtils.rm_rf('~/Library/Application Support/com.bugsnag.Bugsnag')
   end
+end
 
+AfterConfiguration do |_config|
   Maze.config.enforce_bugsnag_integrity = false
 
-  project_name = Maze.config.app
-  fixture_dir = 'features/fixtures'
-  project_dir = "#{fixture_dir}/maze_runner"
-  app_file = "#{project_name}.app"
-  zip_file = "#{project_name}-#{ENV['UNITY_VERSION']}.app.zip"
-
-  unless File.exist?("#{fixture_dir}/#{zip_file}")
-    raise StandardError, "Test fixture build archive not found at #{fixture_dir}/#{zip_file}"
+  if Maze.config.os == 'macos'
+    # The default macOS Crash Reporter "#{app_name} quit unexpectedly" alert grabs focus which can cause tests to flake.
+    # This option, which appears to have been introduced in macOS 10.11, displays a notification instead of the alert.
+    Maze::Runner.run_command('defaults write com.apple.CrashReporter UseUNC 1')
   end
+end
 
-  `cd #{fixture_dir} && unzip #{zip_file}`
-
-  unless File.exist?("#{project_dir}/#{app_file}")
-    raise StandardError, "Test fixture wasn't successfully extracted to #{project_dir}/#{app_file}"
-  end
-
-  Maze::Runner.environment['UNITY_PROJECT_NAME'] = project_name
-
-  at_exit do
-    FileUtils.rm_rf(project_dir + app_file)
+at_exit do
+  if Maze.config.os == 'macos'
     Maze::Runner.run_command("log show --predicate '(process == \"#{Maze.config.app}\")' --style syslog --start '#{Maze.start_time}' > #{Maze.config.app}.log")
   end
 end

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -18,7 +18,7 @@ end
 Maze.hooks.before do
   if Maze.config.os == 'macos'
     support_dir = File.expand_path '~/Library/Application Support/com.bugsnag.Bugsnag'
-    $logger.info 'Clearing #{support_dir}'
+    $logger.info "Clearing #{support_dir}"
     FileUtils.rm_rf(support_dir)
   end
 end

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -4,8 +4,9 @@ $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
 
 Maze.hooks.before do
   if Maze.config.os == 'macos'
-    $logger.info 'Clearing '
-    FileUtils.rm_rf('~/Library/Application Support/com.bugsnag.Bugsnag')
+    support_dir = File.expand_path '~/Library/Application Support/com.bugsnag.Bugsnag'
+    $logger.info 'Clearing #{support_dir}'
+    FileUtils.rm_rf(support_dir)
   end
 end
 


### PR DESCRIPTION
## Goal

Provide the ability to run the desktop e2e tests on Windows locally, as detailed in `TESTING.md`.  Additional to the CI pipeline will come in a subsequent PR.

## Design

Whilst MazeRunner is written in Ruby, a number of its dependencies have native extensions, making porting it to Windows much harder.  To avoid having to take that on, the approach here uses the Windows Subsystem for Linux (WSL), which allows a full Ubuntu instance to run within Windows.  Moreover, it allows Windows executables to be invoked from an otherwise Linux terminal. 🤯 

## Changeset

I've also refactored the existing setup to push any zipping/unzipping of built artifacts into the CI pipeline.  It's not necessary for running the tests locally and unnecessarily clutters both the codebase and working tree.

## Testing

Successfully executed the whole test suite locally on a Windows 10 development machine (there are some failures to investigate).  