### PR TITLE
task(app.type): add fallback implementation of getting the app type for events payload data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,8 @@
 * Fixed an issue where Breadcrumbs were reported in the wrong order on Windows and in the Unity Editor
   [#322](https://github.com/bugsnag/bugsnag-unity/pull/322)
 
-
+* Fixed an issue where the fallback was not reporting the correct app.type
+  [#325](https://github.com/bugsnag/bugsnag-unity/pull/325)
 
 ## 5.1.1 (2021-06-24)
 

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -1,5 +1,6 @@
 ﻿using BugsnagUnity.Payload;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace BugsnagUnity
 {
@@ -22,6 +23,7 @@ namespace BugsnagUnity
 
         public void PopulateApp(App app)
         {
+            app.AddToPayload("type",GetAppType());
         }
 
         public void PopulateDevice(Device device)
@@ -65,6 +67,26 @@ namespace BugsnagUnity
 
         public void SetAutoDetectAnrs(bool autoDetectAnrs)
         {
+        }
+
+        private string GetAppType()
+        {
+            switch (Application.platform)
+            {
+                case RuntimePlatform.OSXEditor:
+                case RuntimePlatform.OSXPlayer:
+                    return "MacOS";
+                case RuntimePlatform.WindowsPlayer:      
+                case RuntimePlatform.WindowsEditor:
+                    return "Windows";               
+                case RuntimePlatform.LinuxPlayer:
+                case RuntimePlatform.LinuxEditor:
+                    return "Linux";
+                case RuntimePlatform.WebGLPlayer:
+                    return "WebGL";
+                default:
+                    return string.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
## Changeset

Added a fallback for NativeClient.PopulateApp

## Testing

Manually tested and will be covered in the inprogress windows testing pr