### PR TITLE
Add Windows MazeRunner steps to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -253,3 +253,33 @@ steps:
       UNITY_VERSION: "2017.4.40f1"
     command:
       - scripts/ci-run-windows-tests.bat
+
+  - label: Run Windows e2e tests for Unity 2018
+    depends_on: 'windows-2018-fixture'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-windows-unity
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+    command:
+      - scripts/ci-run-windows-tests.bat
+
+  - label: Run Windows e2e tests for Unity 2019
+    depends_on: 'windows-2019-fixture'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-windows-unity
+    env:
+      UNITY_VERSION: "2019.4.28f1"
+    command:
+      - scripts/ci-run-windows-tests.bat
+
+  - label: Run Windows e2e tests for Unity 2020
+    depends_on: 'windows-2020-fixture'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-windows-unity
+    env:
+      UNITY_VERSION: "2020.3.12f1"
+    command:
+      - scripts/ci-run-windows-tests.bat

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -251,10 +251,5 @@ steps:
       queue: opensource-windows-unity
     env:
       UNITY_VERSION: "2017.4.40f1"
-    plugins:
-      artifacts#v1.2.0:
-        upload:
-          - test/desktop/maze_output/*
-          - test/desktop/Mazerunner.log
     command:
       - scripts/ci-run-windows-tests.bat

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -240,3 +240,21 @@ steps:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
       - test/desktop/features/fixtures/maze_runner/WindowsBuild-2020.3.12f1.zip
+
+  #
+  # Run Windows e2e tests
+  #
+  - label: Run Windows e2e tests for Unity 2017
+    depends_on: 'windows-2017-fixture'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-windows-unity
+    env:
+      UNITY_VERSION: "2017.4.40f1"
+    plugins:
+      artifacts#v1.2.0:
+        upload:
+          - test/desktop/maze_output/*
+          - test/desktop/Mazerunner.log
+    command:
+      - scripts/ci-run-windows-tests.bat

--- a/scripts/ci-run-windows-tests.bat
+++ b/scripts/ci-run-windows-tests.bat
@@ -1,0 +1,7 @@
+REM Using the artifacts plugin v1.3 on Windows seems to break the whole step
+buildkite-agent artifact download test/desktop/features/fixtures/maze_runner/WindowsBuild-%UNITY_VERSION%.zip
+cd test\desktop\features\fixtures\maze_runner
+7z x WindowsBuild-%UNITY_VERSION%.zip
+cd ..\..\..
+wsl -d Ubuntu bundle install
+wsl -d bundle exec maze-runner --app=features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe --os=windows

--- a/scripts/ci-run-windows-tests.bat
+++ b/scripts/ci-run-windows-tests.bat
@@ -4,4 +4,4 @@ cd test\desktop\features\fixtures\maze_runner
 7z x WindowsBuild-%UNITY_VERSION%.zip
 cd ..\..\..
 wsl -d Ubuntu bundle install
-wsl -d bundle exec maze-runner --app=features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe --os=windows
+wsl -d Ubuntu bundle exec maze-runner --app=features/fixtures/maze_runner/WindowsBuild/Mazerunner.exe --os=windows

--- a/scripts/ci-run-windows-tests.bat
+++ b/scripts/ci-run-windows-tests.bat
@@ -1,5 +1,5 @@
 REM Using the artifacts plugin v1.3 on Windows seems to break the whole step
-buildkite-agent artifact download test/desktop/features/fixtures/maze_runner/WindowsBuild-%UNITY_VERSION%.zip
+buildkite-agent artifact download "test\desktop\features\fixtures\maze_runner\WindowsBuild-%UNITY_VERSION%.zip" .
 cd test\desktop\features\fixtures\maze_runner
 7z x WindowsBuild-%UNITY_VERSION%.zip
 cd ..\..\..


### PR DESCRIPTION
## Goal

Adds steps to CI to run the e2e tests on Windows.

## Design

The new steps are currently behind a block step as we don't yet have permanent Windows build infrastructure in place.

The approach here makes use of the Windows Buildkite agent, which has a few nuances and aspects like the artifacts plugin that simply don't work.  The MazeRunner output also lacks the color highlighting that we're used to and running the Linux agent under WSL may fare better - I'll investigate that and provide a separate PR if it works out.

## Changeset

New pipeline steps and support batch script.

## Testing

With a temporary Windows build server setup running the Windows Buildkite agent, the MazeRunner steps run to completion.  There are a few failures resulting from slight differences in expected behavior on Windows that have been ported to the engineering team and will be resolved in due course.