### PR TITLE
task(breadcrumbs): add bugsnag loaded breadcrumb when using fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@
 * Fixed an issue where Breadcrumbs were reported in the wrong order on Windows and in the Unity Editor
   [#322](https://github.com/bugsnag/bugsnag-unity/pull/322)
 
+* Fixed an issue where platforms using the fallback implementation were not leaving a Bugsnag loaded breadcrumb 
+  [#327](https://github.com/bugsnag/bugsnag-unity/pull/327)
 
 
 ## 5.1.1 (2021-06-24)

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -95,6 +95,31 @@ namespace BugsnagUnity
             {
                 // Async behavior is not available in a test environment
             }
+            AddBugsnagLoadedBreadcrumb();
+        }
+
+        private void AddBugsnagLoadedBreadcrumb()
+        {
+            if (IsUsingFallback() && Configuration.IsBreadcrumbTypeEnabled(BreadcrumbType.State))
+            {
+                Breadcrumbs.Leave("Bugsnag loaded", BreadcrumbType.State, null);
+            }
+        }
+
+        private bool IsUsingFallback()
+        {
+            switch (Application.platform)
+            {
+                case RuntimePlatform.OSXEditor:
+                case RuntimePlatform.OSXPlayer:
+                case RuntimePlatform.WindowsPlayer:
+                case RuntimePlatform.WindowsEditor:
+                case RuntimePlatform.LinuxPlayer:
+                case RuntimePlatform.LinuxEditor:
+                case RuntimePlatform.WebGLPlayer:
+                    return true;
+            }
+            return false;
         }
 
         private void SetupSceneLoadedBreadcrumbTracking()

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -111,7 +111,6 @@ namespace BugsnagUnity
             switch (Application.platform)
             {
                 case RuntimePlatform.OSXEditor:
-                case RuntimePlatform.OSXPlayer:
                 case RuntimePlatform.WindowsPlayer:
                 case RuntimePlatform.WindowsEditor:
                 case RuntimePlatform.LinuxPlayer:


### PR DESCRIPTION
## Goal

The fallback was not leaving a bugsnag loaded breadcrumb on init

## Changeset

added a check for when the fallback is in use and left a crumb

## Testing

Tested manually and this is covered in existing tests