### PR TITLE
Resolve Windows e2e test failures

### DIFF
--- a/scripts/ci-build-windows-package.bat
+++ b/scripts/ci-build-windows-package.bat
@@ -3,4 +3,4 @@ buildkite-agent artifact download "Bugsnag.unitypackage" .
 cd test\desktop\features\scripts
 C:\Progra~1\Git\bin\bash.exe build_maze_runner.sh
 cd ..\fixtures\maze_runner
-7z a -r WindowsBuild-%UNITY_VERSION%.zip WindowsBuild
+7z a -mx9 -r WindowsBuild-%UNITY_VERSION%.zip WindowsBuild

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -21,6 +21,7 @@ namespace BugsnagUnity
 
         public void PopulateApp(App app)
         {
+            app.AddToPayload("type", "Windows");
         }
 
         public void PopulateDevice(Device device)

--- a/test/desktop/Gemfile
+++ b/test/desktop/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.5.1"
+gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.5.2"

--- a/test/desktop/features/breadcrumbs.feature
+++ b/test/desktop/features/breadcrumbs.feature
@@ -3,7 +3,7 @@ Feature: Leaving breadcrumbs to attach to reports
     Scenario: Attaching a message breadcrumb directly
         When I run the game in the "MessageBreadcrumbNotify" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "Collective failure"
         And the event has a "manual" breadcrumb named "Initialize bumpers"
@@ -11,14 +11,14 @@ Feature: Leaving breadcrumbs to attach to reports
     Scenario: Checking for the bugsnag loaded state breadcrumb
         When I run the game in the "MessageBreadcrumbNotify" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the event has a "state" breadcrumb named "Bugsnag loaded"
 
     Scenario: Attaching a low-level log message as a breadcrumb
         When I run the game in the "DebugLogBreadcrumbNotify" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "ExecutionEngineException"
         And the exception "message" equals "Invalid runtime"
         And the event has a "log" breadcrumb named "Warning"
@@ -28,7 +28,7 @@ Feature: Leaving breadcrumbs to attach to reports
     Scenario: Attaching a complex breadcrumb to a report
         When I run the game in the "ComplexBreadcrumbNotify" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "Collective failure"
         And the event has a "navigation" breadcrumb named "Reload"
@@ -37,11 +37,11 @@ Feature: Leaving breadcrumbs to attach to reports
     Scenario: Attaching an error report breadcrumb
         When I run the game in the "DoubleNotify" state
         And I wait to receive 2 errors
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "Rollback failed"
         And I discard the oldest error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "ExecutionEngineException"
         And the exception "message" equals "Invalid runtime"
         And the event "breadcrumbs.1.type" equals "error"
@@ -51,19 +51,19 @@ Feature: Leaving breadcrumbs to attach to reports
     Scenario: Disabling Breadcrumbs
         When I run the game in the "DisableBreadcrumbs" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the event "breadcrumbs.0" is null
 
     Scenario: Only enable Log Breadcrumbs
         When I run the game in the "OnlyLogBreadcrumbs" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the event "breadcrumbs.0.type" equals "log"
 
     Scenario: Setting max breadcrumbs
         When I run the game in the "MaxBreadcrumbs" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the error payload field "events.0.breadcrumbs" is an array with 5 elements
         And the event "breadcrumbs.0.name" equals "Crumb 2"
         And the event "breadcrumbs.1.name" equals "Crumb 3"

--- a/test/desktop/features/context.feature
+++ b/test/desktop/features/context.feature
@@ -4,5 +4,5 @@ Feature: Checking the context of requests
  Scenario: Manually setting the context and then loading a scene
         When I run the game in the "CheckForManualContextAfterSceneLoad" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the event "context" equals "Manually-Set"

--- a/test/desktop/features/handled_errors.feature
+++ b/test/desktop/features/handled_errors.feature
@@ -26,11 +26,8 @@ Feature: Handled Errors and Exceptions
         And the event "device.runtimeVersions.dotnetScriptingRuntime" is not null
         And the event "device.runtimeVersions.dotnetApiCompatibility" is not null
         And the event "app.type" equals the platform-dependent string:
-        | macos | "Mac OS" |
-        | windows | "Windows" |
-
-
-
+        | macos | Mac OS |
+        | windows | Windows |
         And the first significant stack frame methods and files should match:
             | Main.DoNotify()           | 
 

--- a/test/desktop/features/handled_errors.feature
+++ b/test/desktop/features/handled_errors.feature
@@ -25,7 +25,12 @@ Feature: Handled Errors and Exceptions
         And the event "device.runtimeVersions.unityScriptingBackend" is not null
         And the event "device.runtimeVersions.dotnetScriptingRuntime" is not null
         And the event "device.runtimeVersions.dotnetApiCompatibility" is not null
-        And the event "app.type" equals "Mac OS"
+        And the event "app.type" equals the platform-dependent string:
+        | macos | "Mac OS" |
+        | windows | "Windows" |
+
+
+
         And the first significant stack frame methods and files should match:
             | Main.DoNotify()           | 
 

--- a/test/desktop/features/handled_errors.feature
+++ b/test/desktop/features/handled_errors.feature
@@ -3,7 +3,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Reporting a handled exception
         When I run the game in the "Notify" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "blorb"
         And the event "unhandled" is false
@@ -16,7 +16,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Reporting a handled exception from a background thread
         When I run the game in the "NotifyBackground" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "blorb"
         And the event "unhandled" is false
@@ -26,15 +26,15 @@ Feature: Handled Errors and Exceptions
         And the event "device.runtimeVersions.dotnetScriptingRuntime" is not null
         And the event "device.runtimeVersions.dotnetApiCompatibility" is not null
         And the event "app.type" equals the platform-dependent string:
-        | macos | Mac OS |
-        | windows | Windows |
+            | macos | Mac OS |
+            | windows | Windows |
         And the first significant stack frame methods and files should match:
-            | Main.DoNotify()           | 
+            | Main.DoNotify()           |
 
     Scenario: Reporting a handled exception with a callback
         When I run the game in the "NotifyCallback" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "FunnyBusiness"
         And the exception "message" equals "cake"
         And the event "unhandled" is false
@@ -48,7 +48,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Reporting a handled exception with a custom severity
         When I run the game in the "NotifySeverity" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "blorb"
         And the event "severity" equals "info"
@@ -63,7 +63,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Logging an unthrown exception
         When I run the game in the "LogUnthrown" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "auth failed!"
         And the event "unhandled" is false
@@ -76,7 +76,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Logging an unthrown exception as unhandled
         When I run the game in the "LogUnthrownAsUnhandled" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "WAT"
         And the event "unhandled" is true
@@ -89,7 +89,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Logging a warning from a background thread to Bugsnag
         When I run the game in the "ReportLoggedWarningThreaded" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "UnityLogWarning"
         And the exception "message" equals "Something went terribly awry"
         And the event "unhandled" is false
@@ -100,7 +100,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Logging a warning to Bugsnag
         When I run the game in the "ReportLoggedWarning" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "UnityLogWarning"
         And the exception "message" equals "Something went terribly awry"
         And the event "unhandled" is false
@@ -113,7 +113,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Logging an error to Bugsnag
         When I run the game in the "ReportLoggedError" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "UnityLogError"
         And the exception "message" equals "Bad bad things"
         And the event "unhandled" is false
@@ -126,7 +126,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Logging a warning to Bugsnag with 'ReportAsHandled = false'
         When I run the game in the "ReportLoggedWarningWithHandledConfig" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "UnityLogWarning"
         And the exception "message" equals "Something went terribly awry"
         And the event "unhandled" is false
@@ -149,7 +149,7 @@ Feature: Handled Errors and Exceptions
     Scenario: Reporting a handled exception when AutoNotify = false
         When I run the game in the "NotifyWithoutAutoNotify" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "Exception"
         And the exception "message" equals "blorb"
         And the event "unhandled" is false

--- a/test/desktop/features/runtime_versions.feature
+++ b/test/desktop/features/runtime_versions.feature
@@ -3,7 +3,7 @@ Feature: Runtime versions are included in reports
     Scenario: Handled error includes runtime versions
         When I run the game in the "Notify" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the event "device.runtimeVersions.unity" is not null
         And the event "device.runtimeVersions.unityScriptingBackend" is not null
         And the event "device.runtimeVersions.dotnetScriptingRuntime" is not null
@@ -12,7 +12,7 @@ Feature: Runtime versions are included in reports
     Scenario: Unhandled error includes runtime versions
         When I run the game in the "UncaughtException" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the event "device.runtimeVersions.unity" is not null
         And the event "device.runtimeVersions.unityScriptingBackend" is not null
         And the event "device.runtimeVersions.dotnetScriptingRuntime" is not null

--- a/test/desktop/features/sessions.feature
+++ b/test/desktop/features/sessions.feature
@@ -7,8 +7,8 @@ Feature: Session Tracking
         And the session payload field "app.version" is not null
         And the session payload field "app.releaseStage" equals "production"
         And the session payload field "app.type" equals the platform-dependent string:
-        | macos | Mac OS |
-        | windows | Windows |
+            | macos | Mac OS |
+            | windows | Windows |
         And the session payload field "device.osVersion" is not null
         And the session payload field "device.osName" equals "Mac OS"
         And the session payload field "device.model" is not null
@@ -29,11 +29,7 @@ Feature: Session Tracking
         And I wait to receive a session
         And I wait to receive an error
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
-        And the error is valid for the error reporting API sent by the platform-dependent string:
-        | macos | OSX Bugsnag Notifier |
-        | windows | Unity Bugsnag Notifier |
-
-
+        And the error is valid for the error reporting API sent by the Unity notifier
         And the event "session.events.handled" equals 0
         And the event "session.events.unhandled" equals 1
         And the error payload field "events.0.session.id" is stored as the value "session_id"
@@ -46,8 +42,8 @@ Feature: Session Tracking
         And the session payload field "app.version" is not null
         And the session payload field "app.releaseStage" equals "production"
         And the session payload field "app.type" equals the platform-dependent string:
-        | macos | Mac OS |
-        | windows | Windows |
+            | macos | Mac OS |
+            | windows | Windows |
         And the session payload field "device.osVersion" is not null
         And the session payload field "device.osName" equals "Mac OS"
         And the session payload field "device.model" is not null
@@ -69,7 +65,7 @@ Feature: Session Tracking
         And I wait to receive a session
         And I wait to receive an error
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
-        And the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        And the error is valid for the error reporting API sent by the Unity notifier
         And the event "session.events.handled" equals 0
         And the event "session.events.unhandled" equals 1
         And the error payload field "events.0.session.id" is stored as the value "session_id"
@@ -80,7 +76,7 @@ Feature: Session Tracking
         And I wait to receive a session
         And I wait to receive an error
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
-        And the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        And the error is valid for the error reporting API sent by the Unity notifier
         And the event "session.events.handled" equals 1
         And the event "session.events.unhandled" equals 0
         And the error payload field "events.0.session.id" is stored as the value "session_id"

--- a/test/desktop/features/sessions.feature
+++ b/test/desktop/features/sessions.feature
@@ -96,12 +96,16 @@ Feature: Session Tracking
         And I wait to receive a session
         And I wait to receive 3 errors
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
-        And the errors are valid for the error reporting API sent by the "Unity Bugsnag Notifier"
         And the current error request events match one of:
             | message                      | handled | unhandled |
             | blorb                        | 1       | 0         |
             | Something went terribly awry | 2       | 0         |
             | Invariant state failure      | 2       | 1         |
+        And the error is valid for the error reporting API sent by the Unity notifier
+        And I discard the oldest error
+        And the error is valid for the error reporting API sent by the Unity notifier
+        And I discard the oldest error
+        And the error is valid for the error reporting API sent by the Unity notifier
 
     Scenario Outline: Launching the app but the current release stage is not in "notify release stages"
         When I run the game in the "<scenario>" state

--- a/test/desktop/features/sessions.feature
+++ b/test/desktop/features/sessions.feature
@@ -6,18 +6,18 @@ Feature: Session Tracking
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
         And the session payload field "app.version" is not null
         And the session payload field "app.releaseStage" equals "production"
-        And the session payload field "app.type" equals "Mac OS"
+        And the session payload field "app.type" equals the platform-dependent string:
+        | macos | Mac OS |
+        | windows | Windows |
         And the session payload field "device.osVersion" is not null
         And the session payload field "device.osName" equals "Mac OS"
         And the session payload field "device.model" is not null
         And the session payload field "device.manufacturer" equals "Apple"
-
         And the session "id" is not null
         And the session "startedAt" is not null
         And the session "user.id" is not null
         And the session "user.email" is null
         And the session "user.name" is null
-
         Examples:
             | scenario                         |
             | AutoSession                      |
@@ -29,7 +29,11 @@ Feature: Session Tracking
         And I wait to receive a session
         And I wait to receive an error
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
-        And the error is valid for the error reporting API sent by the "OSX Bugsnag Notifier"
+        And the error is valid for the error reporting API sent by the platform-dependent string:
+        | macos | OSX Bugsnag Notifier |
+        | windows | Unity Bugsnag Notifier |
+
+
         And the event "session.events.handled" equals 0
         And the event "session.events.unhandled" equals 1
         And the error payload field "events.0.session.id" is stored as the value "session_id"
@@ -41,7 +45,9 @@ Feature: Session Tracking
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
         And the session payload field "app.version" is not null
         And the session payload field "app.releaseStage" equals "production"
-        And the session payload field "app.type" equals "Mac OS"
+        And the session payload field "app.type" equals the platform-dependent string:
+        | macos | Mac OS |
+        | windows | Windows |
         And the session payload field "device.osVersion" is not null
         And the session payload field "device.osName" equals "Mac OS"
         And the session payload field "device.model" is not null

--- a/test/desktop/features/sessions.feature
+++ b/test/desktop/features/sessions.feature
@@ -10,9 +10,13 @@ Feature: Session Tracking
             | macos | Mac OS |
             | windows | Windows |
         And the session payload field "device.osVersion" is not null
-        And the session payload field "device.osName" equals "Mac OS"
+        And the session payload field "device.osName" equals the platform-dependent string:
+            | macos | Mac OS |
+            | windows | Microsoft Windows NT |
         And the session payload field "device.model" is not null
-        And the session payload field "device.manufacturer" equals "Apple"
+        And the session payload field "device.manufacturer" equals the platform-dependent string:
+            | macos | Apple |
+            | windows | PC |
         And the session "id" is not null
         And the session "startedAt" is not null
         And the session "user.id" is not null
@@ -23,6 +27,7 @@ Feature: Session Tracking
             | AutoSession                      |
             | AutoSessionInNotifyReleaseStages |
 
+    @macos_only
     Scenario: Automatically receiving a session before a native crash
         When I run the game in the "AutoSessionNativeCrash" state
         And I run the game in the "(noop)" state
@@ -45,9 +50,13 @@ Feature: Session Tracking
             | macos | Mac OS |
             | windows | Windows |
         And the session payload field "device.osVersion" is not null
-        And the session payload field "device.osName" equals "Mac OS"
+        And the session payload field "device.osName" equals the platform-dependent string:
+            | macos | Mac OS |
+            | windows | Microsoft Windows NT |
         And the session payload field "device.model" is not null
-        And the session payload field "device.manufacturer" equals "Apple"
+        And the session payload field "device.manufacturer" equals the platform-dependent string:
+            | macos | Apple |
+            | windows | PC |
 
         And the session "id" is not null
         And the session "startedAt" is not null

--- a/test/desktop/features/steps/unity_steps.rb
+++ b/test/desktop/features/steps/unity_steps.rb
@@ -17,7 +17,7 @@ When("I run the game in the {string} state") do |state|
   end
 end
 
-Then("the error is valid for the error reporting API sent by the Unity notifier")
+Then("the error is valid for the error reporting API sent by the Unity notifier") do
 
   if Maze.config.farm == :bs
     # Mobile - could be ios or android
@@ -55,6 +55,7 @@ Then("the error is valid for the error reporting API sent by the Unity notifier"
     And each element in error payload field "events" has "unhandled"
     And each element in error payload field "events" has "exceptions"
   )
+
 end
 
 Then("the first significant stack frame methods and files should match:") do |expected_values|

--- a/test/desktop/features/steps/unity_steps.rb
+++ b/test/desktop/features/steps/unity_steps.rb
@@ -17,7 +17,26 @@ When("I run the game in the {string} state") do |state|
   end
 end
 
-Then("the error is valid for the error reporting API sent by the {string}") do |notifier_name|
+Then("the error is valid for the error reporting API sent by the Unity notifier")
+
+  if Maze.config.farm == :bs
+    # Mobile - could be ios or android
+    os = Maze.config.capabilities['os']
+  else
+    # Could be windows or macos
+    os = Maze.config.os
+  end
+
+  if os == 'macos'
+    notifier_name = 'OSX Bugsnag Notifier'
+  elsif os == 'ios'
+    notifier_name = 'iOS Bugsnag Notifier'
+  elsif os == 'android'
+    notifier_name = 'Android Bugsnag Notifier'
+  else
+    notifier_name = 'Unity Bugsnag Notifier'
+  end
+
   steps %(
     Then the error "Bugsnag-Api-Key" header equals "#{$api_key}"
     And the error payload field "apiKey" equals "#{$api_key}"
@@ -36,10 +55,6 @@ Then("the error is valid for the error reporting API sent by the {string}") do |
     And each element in error payload field "events" has "unhandled"
     And each element in error payload field "events" has "exceptions"
   )
-end
-
-Then("the errors are valid for the error reporting API sent by the {string}") do |notifier_name|
-
 end
 
 Then("the first significant stack frame methods and files should match:") do |expected_values|

--- a/test/desktop/features/stopping_sessions.feature
+++ b/test/desktop/features/stopping_sessions.feature
@@ -5,7 +5,7 @@ Scenario: When a session is stopped the error has no session information
     And I wait to receive a session
     And I wait to receive an error
     Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
-    And the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+    And the error is valid for the error reporting API sent by the Unity notifier
     And the event "session" is null
 
 Scenario: When a session is resumed the error uses the previous session information
@@ -17,11 +17,11 @@ Scenario: When a session is resumed the error uses the previous session informat
         | message      | handled | unhandled |
         | First Error  | 1       | 0         |
         | Second Error | 2       | 0         |
-    And the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+    And the error is valid for the error reporting API sent by the Unity notifier
     And the error payload field "session.id" is stored as the value "session_id"
     And the error payload field "session.startedAt" is stored as the value "session_startedAt"
     And I discard the oldest error
-    And the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+    And the error is valid for the error reporting API sent by the Unity notifier
     And the error payload field "session.id" equals the stored value "session_id"
     And the error payload field "session.startedAt" equals the stored value "session_startedAt"
 
@@ -38,12 +38,12 @@ Scenario: When a new session is started the error uses different session informa
     And the session payload field "sessions.0.id" does not equal the stored value "session_id_1"
     And the session payload field "sessions.0.id" is stored as the value "session_id_2"
     # Error 1
-    And the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+    And the error is valid for the error reporting API sent by the Unity notifier
     And the event "session.events.handled" equals 1
     And the error payload field "events.0.session.id" equals the stored value "session_id_1"
     And I discard the oldest error
     # Error 2
-    And the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+    And the error is valid for the error reporting API sent by the Unity notifier
     And the event "session.events.handled" equals 1
     And the error payload field "events.0.session.id" equals the stored value "session_id_2"
     And the error payload field "events.0.session.id" does not equal the stored value "session_id_1"

--- a/test/desktop/features/support/env.rb
+++ b/test/desktop/features/support/env.rb
@@ -2,6 +2,9 @@ require 'fileutils'
 
 $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
 
+Before('@macos_only') do |scenario|
+  skip_this_scenario("Skipping scenario") unless Maze.config.os == 'macos'
+end
 
 AfterConfiguration do |_config|
   raise '--os option must be set (to "macos" or "windows"' if Maze.config.os.nil?

--- a/test/desktop/features/unhandled_errors.feature
+++ b/test/desktop/features/unhandled_errors.feature
@@ -40,6 +40,7 @@ Feature: Reporting unhandled events
             | Main.RunScenario(System.String scenario)                      | |
             | Main.Start()                            | |
 
+    @macos_only
     Scenario: Reporting a native crash
         When I run the game in the "NativeCrash" state
         And I run the game in the "(noop)" state
@@ -72,12 +73,14 @@ Feature: Reporting unhandled events
         And I wait for 5 seconds
         Then I should receive no requests
 
+    @macos_only
     Scenario: Reporting a native crash when AutoNotify = false
         When I run the game in the "NativeCrashWithoutAutoNotify" state
         And I run the game in the "(noop)" state
         And I wait for 5 seconds
         Then I should receive no requests
 
+    @macos_only
     Scenario: Reporting a native crash after toggling AutoNotify off then on again
         When I run the game in the "NativeCrashReEnableAutoNotify" state
         And I run the game in the "(noop)" state

--- a/test/desktop/features/unhandled_errors.feature
+++ b/test/desktop/features/unhandled_errors.feature
@@ -3,7 +3,7 @@ Feature: Reporting unhandled events
     Scenario: Reporting an uncaught exception
         When I run the game in the "UncaughtException" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "ExecutionEngineException"
         And the exception "message" equals "Promise Rejection"
         And the event "unhandled" is false
@@ -16,7 +16,7 @@ Feature: Reporting unhandled events
     Scenario: Forcing uncaught exceptions to be unhandled
         When I run the game in the "UncaughtExceptionAsUnhandled" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "ExecutionEngineException"
         And the exception "message" equals "Invariant state failure"
         And the event "unhandled" is true
@@ -28,7 +28,7 @@ Feature: Reporting unhandled events
     Scenario: Reporting an assertion failure
         When I run the game in the "AssertionFailure" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "Unity Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "IndexOutOfRangeException"
         And the event "exceptions.0.message" matches one of:
             | Array index is out of range. |
@@ -44,7 +44,7 @@ Feature: Reporting unhandled events
         When I run the game in the "NativeCrash" state
         And I run the game in the "(noop)" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "OSX Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "SIGABRT"
         And the event "unhandled" is true
         And the first significant stack frame methods and files should match:
@@ -82,7 +82,7 @@ Feature: Reporting unhandled events
         When I run the game in the "NativeCrashReEnableAutoNotify" state
         And I run the game in the "(noop)" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the "OSX Bugsnag Notifier"
+        Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "SIGABRT"
         And the event "unhandled" is true
         And the first significant stack frame methods and files should match:


### PR DESCRIPTION
## Goal

Resolves e2e test failures on Windows.

## Changeset

Cucumber steps adjusted to cater for differences between. macOS and Windows.  Some scenarios now run on macOS only as they don't apply to Windows.

## Testing

Now covered by CI, noting that at present we only have temporary test infrastructure for Windows, which needs to be set up manually.