### PR TITLE
Fix e2e test failures for native errors on macOS

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,7 +27,7 @@ steps:
     agents:
       queue: opensource-mac-unity
     env:
-      UNITY_VERSION: "2020.3.9f1"
+      UNITY_VERSION: "2020.3.13f1"
     plugins:
       artifacts#v1.2.0:
         download:
@@ -36,22 +36,22 @@ steps:
     commands:
       - scripts/ci-build-macos-package.sh
     artifact_paths:
-      - features/fixtures/maze_runner/Mazerunner-2020.3.9f1.app.zip
+      - features/fixtures/maze_runner/Mazerunner-2020.3.13f1.app.zip
 
   #
   # Run desktop tests
   #
-  - label: Run MacOS e2e tests for Unity 2020.3.9f1
+  - label: Run MacOS e2e tests for Unity 2020.3.13f1
     depends_on: 'cocoa-2020-fixture'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa-10.15
     env:
-      UNITY_VERSION: "2020.3.9f1"
+      UNITY_VERSION: "2020.3.13f1"
     plugins:
       artifacts#v1.2.0:
         download:
-          - features/fixtures/maze_runner/Mazerunner-2020.3.9f1.app.zip
+          - features/fixtures/maze_runner/Mazerunner-2020.3.13f1.app.zip
         upload:
           - maze_output/*
           - Mazerunner.log
@@ -68,14 +68,14 @@ steps:
     agents:
       queue: opensource-mac-unity
     env:
-      UNITY_VERSION: "2020.3.9f1"
+      UNITY_VERSION: "2020.3.13f1"
     plugins:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
         upload:
-          - test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.9f1.apk
+          - test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.13f1.apk
           - test/mobile/features/fixtures/unity.log
     commands:
       - rake test:android:build
@@ -89,15 +89,15 @@ steps:
     agents:
       queue: opensource
     env:
-      UNITY_VERSION: "2020.3.9f1"
+      UNITY_VERSION: "2020.3.13f1"
     plugins:
       artifacts#v1.3.0:
         download:
-          - "test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.9f1.apk"
+          - "test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.13f1.apk"
       docker-compose#v3.3.0:
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.9f1.apk"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.13f1.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "--fail-fast"
@@ -115,14 +115,14 @@ steps:
     agents:
       queue: opensource-mac-unity
     env:
-      UNITY_VERSION: "2020.3.9f1"
+      UNITY_VERSION: "2020.3.13f1"
     plugins:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
         upload:
-          - test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.9f1.ipa
+          - test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.13f1.ipa
           - test/mobile/features/fixtures/unity.log
           - project_2020.tgz
     commands:
@@ -136,7 +136,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.15
     env:
-      UNITY_VERSION: "2020.3.9f1"
+      UNITY_VERSION: "2020.3.13f1"
     plugins:
       artifacts#v1.2.0:
         download:
@@ -144,7 +144,7 @@ steps:
           - Bugsnag-with-android-64bit.unitypackage
           - project_2020.tgz
         upload:
-          - test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.9f1.ipa
+          - test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.13f1.ipa
           - test/mobile/features/fixtures/unity.log
     commands:
       - tar -zxf project_2020.tgz test/mobile/features/fixtures/maze_runner
@@ -162,11 +162,11 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download:
-          - "test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.9f1.ipa"
+          - "test/mobile/features/fixtures/maze_runner/mazerunner_2020.3.13f1.ipa"
       docker-compose#v3.3.0:
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.9f1.ipa"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.13f1.ipa"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"

--- a/features/sessions.feature
+++ b/features/sessions.feature
@@ -34,7 +34,7 @@ Feature: Session Tracking
         And I wait to receive a session
         And I wait to receive an error
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
-        And the error is valid for the error reporting API sent by the Unity notifier
+        And the error is valid for the error reporting API sent by the native Unity notifier
         And the event "session.events.handled" equals 0
         And the event "session.events.unhandled" equals 1
         And the error payload field "events.0.session.id" is stored as the value "session_id"

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -17,26 +17,7 @@ When("I run the game in the {string} state") do |state|
   end
 end
 
-Then("the error is valid for the error reporting API sent by the Unity notifier") do
-
-  if Maze.config.farm == :bs
-    # Mobile - could be ios or android
-    os = Maze.config.capabilities['os']
-  else
-    # Could be windows or macos
-    os = Maze.config.os
-  end
-
-  if os == 'macos'
-    notifier_name = 'OSX Bugsnag Notifier'
-  elsif os == 'ios'
-    notifier_name = 'iOS Bugsnag Notifier'
-  elsif os == 'android'
-    notifier_name = 'Android Bugsnag Notifier'
-  else
-    notifier_name = 'Unity Bugsnag Notifier'
-  end
-
+def check_error_reporting_api(notifier_name)
   steps %(
     Then the error "Bugsnag-Api-Key" header equals "#{$api_key}"
     And the error payload field "apiKey" equals "#{$api_key}"
@@ -55,7 +36,32 @@ Then("the error is valid for the error reporting API sent by the Unity notifier"
     And each element in error payload field "events" has "unhandled"
     And each element in error payload field "events" has "exceptions"
   )
+end
 
+Then("the error is valid for the error reporting API sent by the native Unity notifier") do
+  # This step currently only applies to native errors on macOS macOS
+  check_error_reporting_api 'OSX Bugsnag Notifier'
+end
+
+Then("the error is valid for the error reporting API sent by the Unity notifier") do
+
+  if Maze.config.farm == :bs
+    # Mobile - could be ios or android
+    os = Maze.config.capabilities['os']
+  else
+    # Could be windows or macos
+    os = Maze.config.os
+  end
+
+  if os == 'ios'
+    notifier_name = 'iOS Bugsnag Notifier'
+  elsif os == 'android'
+    notifier_name = 'Android Bugsnag Notifier'
+  else
+    notifier_name = 'Unity Bugsnag Notifier'
+  end
+
+  check_error_reporting_api notifier_name
 end
 
 Then("the first significant stack frame methods and files should match:") do |expected_values|

--- a/features/unhandled_errors.feature
+++ b/features/unhandled_errors.feature
@@ -45,7 +45,7 @@ Feature: Reporting unhandled events
         When I run the game in the "NativeCrash" state
         And I run the game in the "(noop)" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the Unity notifier
+        Then the error is valid for the error reporting API sent by the native Unity notifier
         And the exception "errorClass" equals "SIGABRT"
         And the event "unhandled" is true
         And the first significant stack frame methods and files should match:
@@ -85,7 +85,7 @@ Feature: Reporting unhandled events
         When I run the game in the "NativeCrashReEnableAutoNotify" state
         And I run the game in the "(noop)" state
         And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the Unity notifier
+        Then the error is valid for the error reporting API sent by the native Unity notifier
         And the exception "errorClass" equals "SIGABRT"
         And the event "unhandled" is true
         And the first significant stack frame methods and files should match:

--- a/scripts/ci-run-macos-tests.sh
+++ b/scripts/ci-run-macos-tests.sh
@@ -4,5 +4,7 @@ pushd features/fixtures/maze_runner
   pushd ../../..
     bundle install
     bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
+    RESULT=$?
   popd
 popd
+exit $RESULT


### PR DESCRIPTION
## Goal

Fixes a few test failures that had gone unnoticed in the e2e tests, due to the return code not being fed back to Buildkite (also fixed).

## Design

Introduces a new Cucumber step to allow individual scenario steps to specify when the notifier name will be derived from the native notifier on macOS.

## Changeset

Also bumps the minor version on Unity 20202, after an incidental update of our build servers.

## Testing

Covered by a basic CI run.