### PR TITLE
Add e2e tests for WebGL

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -118,7 +118,8 @@ steps:
   # Run WebGL tests
   #
   - label: Run WebGL e2e tests for Unity 2017
-    depends_on: 'cocoa-wegl-2017-fixtures'
+    skip: WebGL test fixture fails to start with Unity 2017 (apparent Unity bug)
+    depends_on: 'cocoa-webgl-2017-fixtures'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa-11
@@ -129,13 +130,12 @@ steps:
         download:
           - features/fixtures/maze_runner/build/WebGL-2017.4.40f1.zip
         upload:
-          - maze_output/*
-          - Mazerunner.log
+          - maze_output/failed/**/*
     commands:
       - scripts/ci-run-webgl-tests.sh
 
   - label: Run WebGL e2e tests for Unity 2018
-    depends_on: 'cocoa-wegl-2018-fixtures'
+    depends_on: 'cocoa-webgl-2018-fixtures'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa-11
@@ -146,13 +146,12 @@ steps:
         download:
           - features/fixtures/maze_runner/build/WebGL-2018.4.34f1.zip
         upload:
-          - maze_output/*
-          - Mazerunner.log
+          - maze_output/failed/**/*
     commands:
       - scripts/ci-run-webgl-tests.sh
 
   - label: Run WebGL e2e tests for Unity 2019
-    depends_on: 'cocoa-wegl-2019-fixtures'
+    depends_on: 'cocoa-webgl-2019-fixtures'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa-11
@@ -163,8 +162,7 @@ steps:
         download:
           - features/fixtures/maze_runner/build/WebGL-2019.4.25f1.zip
         upload:
-          - maze_output/*
-          - Mazerunner.log
+          - maze_output/failed/**/*
     commands:
       - scripts/ci-run-webgl-tests.sh
 

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -4,7 +4,7 @@ steps:
   # Build MacOS and WebGL test fixtures
   #
   - label: Build Unity 2017 MacOS and WebGL test fixtures
-    key: 'cocoa-2017-fixture'
+    key: 'cocoa-webgl-2017-fixtures'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
@@ -23,7 +23,7 @@ steps:
       - features/fixtures/maze_runner/build/WebGL-2017.4.40f1.zip
 
   - label: Build Unity 2018 MacOS and WebGL test fixtures
-    key: 'cocoa-2018-fixture'
+    key: 'cocoa-webgl-2018-fixtures'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
@@ -42,7 +42,7 @@ steps:
       - features/fixtures/maze_runner/build/WebGL-2018.4.34f1.zip
 
   - label: Build Unity 2019 MacOS and WebGL test fixtures
-    key: 'cocoa-2019-fixture'
+    key: 'cocoa-webgl-2019-fixtures'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
@@ -63,8 +63,8 @@ steps:
   #
   # Run macOS desktop tests
   #
-  - label: Run MacOS e2e tests for Unity 2017.4.40f1
-    depends_on: 'cocoa-2017-fixture'
+  - label: Run MacOS e2e tests for Unity 2017
+    depends_on: 'cocoa-webgl-2017-fixtures'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa-10.15
@@ -80,8 +80,8 @@ steps:
     commands:
       - scripts/ci-run-macos-tests.sh
 
-  - label: Run MacOS e2e tests for Unity 2018.4.34f1
-    depends_on: 'cocoa-2018-fixture'
+  - label: Run MacOS e2e tests for Unity 2018
+    depends_on: 'cocoa-webgl-2018-fixtures'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa-10.15
@@ -97,8 +97,8 @@ steps:
     commands:
       - scripts/ci-run-macos-tests.sh
 
-  - label: Run MacOS e2e tests for Unity 2019.4.25f1
-    depends_on: 'cocoa-2019-fixture'
+  - label: Run MacOS e2e tests for Unity 2019
+    depends_on: 'cocoa-webgl-2019-fixtures'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa-10.15
@@ -113,6 +113,60 @@ steps:
           - Mazerunner.log
     commands:
       - scripts/ci-run-macos-tests.sh
+
+  #
+  # Run WebGL tests
+  #
+  - label: Run WebGL e2e tests for Unity 2017
+    depends_on: 'cocoa-wegl-2017-fixtures'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-11
+    env:
+      UNITY_VERSION: "2017.4.40f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2017.4.40f1.zip
+        upload:
+          - maze_output/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-webgl-tests.sh
+
+  - label: Run WebGL e2e tests for Unity 2018
+    depends_on: 'cocoa-wegl-2018-fixtures'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-11
+    env:
+      UNITY_VERSION: "2018.4.34f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2018.4.34f1.zip
+        upload:
+          - maze_output/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-webgl-tests.sh
+
+  - label: Run WebGL e2e tests for Unity 2019
+    depends_on: 'cocoa-wegl-2019-fixtures'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-11
+    env:
+      UNITY_VERSION: "2019.4.25f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2019.4.25f1.zip
+        upload:
+          - maze_output/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-webgl-tests.sh
 
   #
   # Build Android test fixtures

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,7 +63,7 @@ steps:
   # Run WebGL tests
   #
   - label: Run WebGL e2e tests for Unity 2020
-    depends_on: 'cocoa-wegl-2020-fixtures'
+    depends_on: 'cocoa-webgl-2020-fixtures'
     timeout_in_minutes: 30
     agents:
       queue: opensource-mac-cocoa-11
@@ -74,8 +74,7 @@ steps:
         download:
           - features/fixtures/maze_runner/build/WebGL-2020.3.13f1.zip
         upload:
-          - maze_output/*
-          - Mazerunner.log
+          - maze_output/failed/**/*
     commands:
       - scripts/ci-run-webgl-tests.sh
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,7 @@ steps:
   # Build MacOS and WebGL test fixtures
   #
   - label: Build Unity 2020 MacOS and WebGL test fixtures
-    key: 'cocoa-2020-fixture'
+    key: 'cocoa-webgl-2020-fixtures'
     depends_on: 'build-artifacts'
     timeout_in_minutes: 30
     agents:
@@ -42,11 +42,11 @@ steps:
   #
   # Run desktop tests
   #
-  - label: Run MacOS e2e tests for Unity 2020.3.13f1
-    depends_on: 'cocoa-2020-fixture'
+  - label: Run MacOS e2e tests for Unity 2020
+    depends_on: 'cocoa-webgl-2020-fixtures'
     timeout_in_minutes: 30
     agents:
-      queue: opensource-mac-cocoa-10.15
+      queue: opensource-mac-cocoa-11
     env:
       UNITY_VERSION: "2020.3.13f1"
     plugins:
@@ -58,6 +58,26 @@ steps:
           - Mazerunner.log
     commands:
       - scripts/ci-run-macos-tests.sh
+
+  #
+  # Run WebGL tests
+  #
+  - label: Run WebGL e2e tests for Unity 2020
+    depends_on: 'cocoa-wegl-2020-fixtures'
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-mac-cocoa-11
+    env:
+      UNITY_VERSION: "2020.3.13f1"
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2020.3.13f1.zip
+        upload:
+          - maze_output/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-webgl-tests.sh
 
   #
   # Build Android test fixtures

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,11 @@ gem "rake"
 gem "xcpretty"
 gem "xcodeproj"
 
-gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.7.0"
+# Use official Maze Runner release
+#gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.7.0"
 
 # Use a specific Maze Runner branch
-#gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", branch: "tms/local-browser"
+gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", branch: "tms/local-browser"
 
 # Use a local copy of Maze Runner for development purposes
 #gem "bugsnag-maze-runner", path: "../maze-runner"

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ gem "xcpretty"
 gem "xcodeproj"
 
 # Use official Maze Runner release
-#gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.7.0"
+gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v5.8.0"
 
 # Use a specific Maze Runner branch
-gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", branch: "tms/local-browser"
+#gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", branch: "any-branch"
 
 # Use a local copy of Maze Runner for development purposes
 #gem "bugsnag-maze-runner", path: "../maze-runner"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 9be7cc7b5e358a034c439d989088b07fc227b9a2
-  tag: v5.7.0
+  revision: 320e1f5ddccf7dd6205d1814f8d1d960372f9d19
+  branch: tms/local-browser
   specs:
     bugsnag-maze-runner (5.7.0)
       appium_lib (~> 11.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 320e1f5ddccf7dd6205d1814f8d1d960372f9d19
-  branch: tms/local-browser
+  revision: 9a07b6cd836b4156128ba0318c8d973adf113f95
+  tag: v5.8.0
   specs:
-    bugsnag-maze-runner (5.7.0)
+    bugsnag-maze-runner (5.8.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)

--- a/TESTING.md
+++ b/TESTING.md
@@ -103,7 +103,7 @@ This will generate the following files:
 
 #### MacOS
 
-1. `UNITY_VERSION=2018.4.34f1 ./features/scripts/build_maze_runner.sh`
+1. `UNITY_VERSION=2018.4.34f1 ./features/scripts/build_maze_runner.sh macos`
 
 Where `UNITY_VERSION` corresponds to the Unity installation path, e.g:
 ```
@@ -120,7 +120,7 @@ This will generate the test fixture app:
 Building the test fixture on Windows requires a Git bash terminal.
 
 In a Git bash terminal:
-1. `UNITY_VERSION=2018.4.36f1 ./features/scripts/build_maze_runner.sh`
+1. `UNITY_VERSION=2018.4.36f1 ./features/scripts/build_maze_runner.sh windows`
 
 Where `UNITY_VERSION` corresponds to the Unity installation path, e.g:
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -165,5 +165,5 @@ In the Ubuntu terminal:
 1. Run `bundle install` if you haven't run end-to-end tests before
 1. To run the tests:
     ```shell script
-    bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows
+    bundle exec maze-runner --farm=local --browser=chrome
     ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -141,12 +141,24 @@ dependencies:
 1. Run `bundle install` if you haven't run end-to-end tests before
 1. To run the tests:
     ```shell script
-    bundle exec maze-runner --app=features/fixtures/maze_runner/Mazerunner.app --os=macos
+    bundle exec maze-runner --app=features/fixtures/maze_runner/build/MacOS/Mazerunner.app --os=macos
     ```
 
 #### Windows
 
 Running the Maze Runner tests on Windows requires the Ubuntu app (using WSL).
+
+In the Ubuntu terminal:
+1. Check the contents of `Gemfile` to select the version of `maze-runner` to use
+1. Run `bundle install` if you haven't run end-to-end tests before
+1. To run the tests:
+    ```shell script
+    bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows
+    ```
+
+#### WebGL
+
+The WebGL e2e tests depend on Chrome and `chromedriver` (available from Homebrew).
 
 In the Ubuntu terminal:
 1. Check the contents of `Gemfile` to select the version of `maze-runner` to use

--- a/features/desktop/handled_errors.feature
+++ b/features/desktop/handled_errors.feature
@@ -13,6 +13,7 @@ Feature: Handled Errors and Exceptions
             | Main.RunScenario(string scenario)  |
             | Main.Start()        |
 
+    @skip_webgl
     Scenario: Reporting a handled exception from a background thread
         When I run the game in the "NotifyBackground" state
         And I wait to receive an error
@@ -86,6 +87,7 @@ Feature: Handled Errors and Exceptions
             | Main:RunScenario(String) |
             | Main:Start() |
 
+    @skip_webgl
     Scenario: Logging a warning from a background thread to Bugsnag
         When I run the game in the "ReportLoggedWarningThreaded" state
         And I wait to receive an error

--- a/features/desktop/handled_errors.feature
+++ b/features/desktop/handled_errors.feature
@@ -99,45 +99,6 @@ Feature: Handled Errors and Exceptions
         And the first significant stack frame methods and files should match:
             | Main.DoLogWarning()       |
 
-    Scenario: Logging a warning to Bugsnag
-        When I run the game in the "ReportLoggedWarning" state
-        And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the Unity notifier
-        And the exception "errorClass" equals "UnityLogWarning"
-        And the exception "message" equals "Something went terribly awry"
-        And the event "unhandled" is false
-        And custom metadata is included in the event
-        And the first significant stack frame methods and files should match:
-            | Main.DoLogWarning()  |
-            | Main.RunScenario(string scenario)  |
-            | Main.Start()        |
-
-    Scenario: Logging an error to Bugsnag
-        When I run the game in the "ReportLoggedError" state
-        And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the Unity notifier
-        And the exception "errorClass" equals "UnityLogError"
-        And the exception "message" equals "Bad bad things"
-        And the event "unhandled" is false
-        And custom metadata is included in the event
-        And the first significant stack frame methods and files should match:
-            | Main.DoLogError()  |
-            | Main.RunScenario(string scenario)  |
-            | Main.Start()        |
-
-    Scenario: Logging a warning to Bugsnag with 'ReportAsHandled = false'
-        When I run the game in the "ReportLoggedWarningWithHandledConfig" state
-        And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the Unity notifier
-        And the exception "errorClass" equals "UnityLogWarning"
-        And the exception "message" equals "Something went terribly awry"
-        And the event "unhandled" is false
-        And custom metadata is included in the event
-        And the first significant stack frame methods and files should match:
-            | Main.DoLogWarningWithHandledConfig()  |
-            | Main.RunScenario(string scenario)  |
-            | Main.Start()        |
-
     Scenario: Notifying when the current release stage is not in "notify release stages"
         When I run the game in the "NotifyOutsideNotifyReleaseStages" state
         And I wait for 5 seconds
@@ -165,3 +126,90 @@ Feature: Handled Errors and Exceptions
         When I run the game in the "LoggedExceptionWithoutAutoNotify" state
         And I wait for 5 seconds
         Then I should receive no errors
+
+    #
+    # TODO The scenarios below are currently duplicated due to slight differences in stack frames for WebGL.
+    #
+    @skip_webgl
+    Scenario: Logging a warning to Bugsnag
+        When I run the game in the "ReportLoggedWarning" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "UnityLogWarning"
+        And the exception "message" equals "Something went terribly awry"
+        And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main.DoLogWarning()  |
+            | Main.RunScenario(string scenario)  |
+            | Main.Start()        |
+
+    @webgl_only
+    Scenario: Logging a warning to Bugsnag
+        When I run the game in the "ReportLoggedWarning" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "UnityLogWarning"
+        And the exception "message" equals "Something went terribly awry"
+        And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main:DoLogWarning()  |
+            | Main:RunScenario(String)  |
+            | Main:Start()        |
+
+    @skip_webgl
+    Scenario: Logging an error to Bugsnag
+        When I run the game in the "ReportLoggedError" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "UnityLogError"
+        And the exception "message" equals "Bad bad things"
+        And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main.DoLogError()  |
+            | Main.RunScenario(string scenario)  |
+            | Main.Start()        |
+
+    @webgl_only
+    Scenario: Logging an error to Bugsnag
+        When I run the game in the "ReportLoggedError" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "UnityLogError"
+        And the exception "message" equals "Bad bad things"
+        And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main:DoLogError()  |
+            | Main:RunScenario(String)  |
+            | Main:Start()        |
+
+    @skip_webgl
+    Scenario: Logging a warning to Bugsnag with 'ReportAsHandled = false'
+        When I run the game in the "ReportLoggedWarningWithHandledConfig" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "UnityLogWarning"
+        And the exception "message" equals "Something went terribly awry"
+        And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main.DoLogWarningWithHandledConfig()  |
+            | Main.RunScenario(string scenario)  |
+            | Main.Start()        |
+
+    @webgl_only
+    Scenario: Logging a warning to Bugsnag with 'ReportAsHandled = false'
+        When I run the game in the "ReportLoggedWarningWithHandledConfig" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "UnityLogWarning"
+        And the exception "message" equals "Something went terribly awry"
+        And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main:DoLogWarningWithHandledConfig()  |
+            | Main:RunScenario(String)  |
+            | Main:Start()        |

--- a/features/desktop/sessions.feature
+++ b/features/desktop/sessions.feature
@@ -1,5 +1,6 @@
 Feature: Session Tracking
 
+    @skip_webgl
     Scenario Outline: Automatically receiving a session
         When I run the game in the "<scenario>" state
         And I wait to receive a session
@@ -27,6 +28,28 @@ Feature: Session Tracking
             | AutoSession                      |
             | AutoSessionInNotifyReleaseStages |
 
+    @webgl_only
+    Scenario Outline: Automatically receiving a session
+        When I run the game in the "<scenario>" state
+        And I wait to receive a session
+        Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
+        And the session payload field "app.version" is not null
+        And the session payload field "app.releaseStage" equals "production"
+        And the session payload field "app.type" equals "WebGL"
+        And the session payload field "device.osVersion" is not null
+        And the session payload field "device.osName" equals "Unix"
+        And the session payload field "device.model" is null
+        And the session payload field "device.manufacturer" is null
+        And the session "id" is not null
+        And the session "startedAt" is not null
+        And the session "user.id" is not null
+        And the session "user.email" is null
+        And the session "user.name" is null
+        Examples:
+            | scenario                         |
+            | AutoSession                      |
+            | AutoSessionInNotifyReleaseStages |
+
     @macos_only
     Scenario: Automatically receiving a session before a native crash
         When I run the game in the "AutoSessionNativeCrash" state
@@ -40,6 +63,7 @@ Feature: Session Tracking
         And the error payload field "events.0.session.id" is stored as the value "session_id"
         And the session payload field "sessions.0.id" equals the stored value "session_id"
 
+    @skip_webgl
     Scenario Outline: Manually logging a session
         When I run the game in the "<scenario>" state
         And I wait to receive a session
@@ -58,6 +82,29 @@ Feature: Session Tracking
             | macos | Apple |
             | windows | PC |
 
+        And the session "id" is not null
+        And the session "startedAt" is not null
+        And the session "user.id" is not null
+        And the session "user.email" is null
+        And the session "user.name" is null
+
+        Examples:
+            | scenario                           |
+            | ManualSession                      |
+            | ManualSessionInNotifyReleaseStages |
+
+    @webgl_only
+    Scenario Outline: Manually logging a session
+        When I run the game in the "<scenario>" state
+        And I wait to receive a session
+        Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
+        And the session payload field "app.version" is not null
+        And the session payload field "app.releaseStage" equals "production"
+        And the session payload field "app.type" equals "WebGL"
+        And the session payload field "device.osVersion" is not null
+        And the session payload field "device.osName" equals "Unix"
+        And the session payload field "device.model" is null
+        And the session payload field "device.manufacturer" is null
         And the session "id" is not null
         And the session "startedAt" is not null
         And the session "user.id" is not null

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -13,6 +13,7 @@ Feature: Reporting unhandled events
             | Main.RunScenario(System.String scenario)         | |
             | Main.Start()               | |
 
+    @skip_webgl
     Scenario: Forcing uncaught exceptions to be unhandled
         When I run the game in the "UncaughtExceptionAsUnhandled" state
         And I wait to receive an error
@@ -23,6 +24,20 @@ Feature: Reporting unhandled events
         And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
             | Main.RunScenario(System.String scenario)         |
+            | Main.Start()               |
+
+    @webgl_only
+    Scenario: Forcing uncaught exceptions to be unhandled
+        When I run the game in the "UncaughtExceptionAsUnhandled" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "ExecutionEngineException"
+        And the exception "message" equals "Invariant state failure"
+        And the event "unhandled" is true
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main.UncaughtExceptionAsUnhandled() |
+            | Main.RunScenario(System.String scenario) |
             | Main.Start()               |
 
     Scenario: Reporting an assertion failure

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -74,25 +74,21 @@ Feature: Reporting unhandled events
 
     Scenario: Encountering a handled event when the current release stage is not in "notify release stages"
         When I run the game in the "UncaughtExceptionOutsideNotifyReleaseStages" state
-        And I wait for 5 seconds
         Then I should receive no requests
 
     Scenario: Encountering a handled event when the current release stage is not in "notify release stages"
         When I run the game in the "NativeCrashOutsideNotifyReleaseStages" state
         And I run the game in the "(noop)" state
-        And I wait for 5 seconds
         Then I should receive no requests
 
     Scenario: Reporting an uncaught exception when AutoNotify = false
         When I run the game in the "UncaughtExceptionWithoutAutoNotify" state
-        And I wait for 5 seconds
         Then I should receive no requests
 
     @macos_only
     Scenario: Reporting a native crash when AutoNotify = false
         When I run the game in the "NativeCrashWithoutAutoNotify" state
         And I run the game in the "(noop)" state
-        And I wait for 5 seconds
         Then I should receive no requests
 
     @macos_only

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -81,7 +81,7 @@ public class Main : MonoBehaviour
         {
             _webGlArguments.Add(splitParams[currentindex],splitParams[currentindex + 1]);
             currentindex += 2;
-        }    
+        }
     }
 
     private string GetWebGLEnvVar(string key)

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -162,10 +162,12 @@ Then("the first significant stack frame methods and files should match:") do |ex
   stacktrace.each_with_index do |item, index|
     next if expected_index >= expected_frame_values.length
     expected_frames = expected_frame_values[expected_index]
-    next if item["method"].start_with? "UnityEngine"
-    next if item["method"].start_with? "BugsnagUnity"
 
-    assert(expected_frames.any? { |frame| frame == item["method"] }, "None of the given methods match the frame #{item["method"]}")
+    method = item['method']
+    next if method.start_with? 'UnityEngine' or 'method'.start_with? 'BugsnagUnity'
+
+    frame_matches = expected_frames.any? { |frame| frame == method }
+    assert(frame_matches, "None of the given methods match the frame #{method}")
     expected_index += 1
   end
 end

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -164,7 +164,7 @@ Then("the first significant stack frame methods and files should match:") do |ex
     expected_frames = expected_frame_values[expected_index]
 
     method = item['method']
-    next if method.start_with? 'UnityEngine' or 'method'.start_with? 'BugsnagUnity'
+    next if method.start_with? 'UnityEngine' or method.start_with? 'BugsnagUnity'
 
     frame_matches = expected_frames.any? { |frame| frame == method }
     assert(frame_matches, "None of the given methods match the frame #{method}")

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -26,7 +26,7 @@ AfterConfiguration do |_config|
     ENV['WSLENV'] = 'BUGSNAG_SCENARIO:BUGSNAG_APIKEY:MAZE_ENDPOINT'
   elsif Maze.config.browser != nil # WebGL
     Maze.config.document_server_root = 'features/fixtures/maze_runner/build/WebGL/Mazerunner'
-  else
+  elsif Maze.config.device.nil?
     raise '--browser (WebGL), --device (for Android/iOS) or --os (for desktop) option must be set'
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,6 +6,10 @@ Before('@skip_webgl') do |_scenario|
   skip_this_scenario("Skipping scenario") unless Maze.config.browser.nil?
 end
 
+Before('@webgl_only') do |_scenario|
+  skip_this_scenario("Skipping scenario") if Maze.config.browser.nil?
+end
+
 Before('@macos_only') do |_scenario|
   skip_this_scenario("Skipping scenario") unless Maze.config.os == 'macos'
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -18,6 +18,10 @@ AfterConfiguration do |_config|
   elsif Maze.config.os&.downcase == 'windows'
     # Allow the necessary environment variables to be passed from Ubuntu (under WSL) to the Windows test fixture
     ENV['WSLENV'] = 'BUGSNAG_SCENARIO:BUGSNAG_APIKEY:MAZE_ENDPOINT'
+  elsif Maze.config.browser != nil # WebGL
+    Maze.config.document_server_root = 'features/fixtures/maze_runner/build/WebGL/Mazerunner'
+  else
+    raise 'Either an --os option must be set (to "macos" or "windows") or --browser for WebGL'
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,8 +15,6 @@ Before('@macos_only') do |_scenario|
 end
 
 AfterConfiguration do |_config|
-  raise '--device or --os option must be set (to "macos" or "windows"' if Maze.config.os.nil? and Maze.config.device.nil?
-
   Maze.config.enforce_bugsnag_integrity = false
 
   if Maze.config.os&.downcase == 'macos'
@@ -29,7 +27,7 @@ AfterConfiguration do |_config|
   elsif Maze.config.browser != nil # WebGL
     Maze.config.document_server_root = 'features/fixtures/maze_runner/build/WebGL/Mazerunner'
   else
-    raise 'Either an --os option must be set (to "macos" or "windows") or --browser for WebGL'
+    raise '--browser (WebGL), --device (for Android/iOS) or --os (for desktop) option must be set'
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,7 +2,11 @@ require 'fileutils'
 
 $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'
 
-Before('@macos_only') do |scenario|
+Before('@skip_webgl') do |_scenario|
+  skip_this_scenario("Skipping scenario") unless Maze.config.browser.nil?
+end
+
+Before('@macos_only') do |_scenario|
   skip_this_scenario("Skipping scenario") unless Maze.config.os == 'macos'
 end
 

--- a/scripts/ci-run-webgl-tests.sh
+++ b/scripts/ci-run-webgl-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+pushd features/fixtures/maze_runner/build
+  unzip WebGL-$UNITY_VERSION.zip
+popd
+
+bundle install
+bundle exec maze-runner --farm=local --browser=chrome

--- a/scripts/ci-run-webgl-tests.sh
+++ b/scripts/ci-run-webgl-tests.sh
@@ -4,4 +4,4 @@ pushd features/fixtures/maze_runner/build
 popd
 
 bundle install
-bundle exec maze-runner --farm=local --browser=chrome
+bundle exec maze-runner --farm=local --browser=chrome features/desktop


### PR DESCRIPTION
## Goal

Run e2e tests against the test fixture built for WebGL.

## Design

The test fixture game was far too slow to start in browsers from our usual supplier, so I've set the tests to run in local mode against Chrome on our own servers.

## Changeset

- New pipeline steps
- Plumbing to feed test scenario details in via the URL
- New convenience script for CI
- Incidental corrections

## Testing

Covered by a full CI run.

## TODO

- This PR relies on draft changes to MazeRunner, which will need to be formalised and released before this can be merged.