### PR TITLE
Soft fail on Android for Unity 2017

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -248,6 +248,9 @@ steps:
           - "features/android"
     concurrency: 9
     concurrency_group: browserstack-app
+    # TODO Soft fail pending PLAT-7058
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Run Android e2e tests for Unity 2018'
     depends_on: 'build-android-fixture-2018'


### PR DESCRIPTION
## Goal

Soft fail on Android for Unity 2017 pending further investigation of missing field `metaData.device.osLanguage` after a recent change to the test fixture (it is present when tested manually in other apps).
