### PR TITLE
task(config): new configuration option AppHangThresholdMillis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+* Add `AppHangThresholdMillis` to set the [native Cocoa option](https://docs.bugsnag.com/platforms/ios/configuration-options/#apphangthresholdmillis) [#347](https://github.com/bugsnag/bugsnag-unity/pull/347)
+
 * Add `EnabledErrorTypes` configuration option to enable/disable different types of errors [#341](https://github.com/bugsnag/bugsnag-unity/pull/341)
 
 * [Android] Automatic [App Not Responding](https://developer.android.com/topic/performance/vitals/anr) (ANR) detection is now enabled by default  

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -55,6 +55,9 @@ extern "C" {
 
   void bugsnag_setEnabledErrorTypes(const void *configuration, const char *types[], int count);
 
+  void bugsnag_setAppHangThresholdMillis(const void *configuration, int appHangThresholdMillis);
+
+
 }
 
 void *bugsnag_createConfiguration(char *apiKey) {
@@ -85,6 +88,10 @@ void bugsnag_setNotifyReleaseStages(const void *configuration, const char *relea
 void bugsnag_setAppVersion(const void *configuration, char *appVersion) {
   NSString *ns_appVersion = appVersion == NULL ? nil : [NSString stringWithUTF8String: appVersion];
   ((__bridge BugsnagConfiguration *)configuration).appVersion = ns_appVersion;
+}
+
+void bugsnag_setAppHangThresholdMillis(const void *configuration, int appHangThresholdMillis) {
+  ((__bridge BugsnagConfiguration *)configuration).appHangThresholdMillis = appHangThresholdMillis;
 }
 
 void bugsnag_setContext(const void *configuration, char *context) {

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -55,7 +55,7 @@ extern "C" {
 
   void bugsnag_setEnabledErrorTypes(const void *configuration, const char *types[], int count);
 
-  void bugsnag_setAppHangThresholdMillis(const void *configuration, int appHangThresholdMillis);
+  void bugsnag_setAppHangThresholdMillis(const void *configuration, NSUInteger appHangThresholdMillis);
 
 
 }
@@ -90,7 +90,7 @@ void bugsnag_setAppVersion(const void *configuration, char *appVersion) {
   ((__bridge BugsnagConfiguration *)configuration).appVersion = ns_appVersion;
 }
 
-void bugsnag_setAppHangThresholdMillis(const void *configuration, int appHangThresholdMillis) {
+void bugsnag_setAppHangThresholdMillis(const void *configuration, NSUInteger appHangThresholdMillis) {
   ((__bridge BugsnagConfiguration *)configuration).appHangThresholdMillis = appHangThresholdMillis;
 }
 

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -112,6 +112,8 @@ namespace BugsnagUnity
 
         public ErrorTypes[] EnabledErrorTypes { get; set; }
 
+        public int AppHangThresholdMillis { get; set; } = 5000;
+
         public virtual bool IsErrorTypeEnabled(ErrorTypes errorType)
         {
             return EnabledErrorTypes == null || EnabledErrorTypes.Contains(errorType);

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -66,9 +66,10 @@ namespace BugsnagUnity
             {
                 if (value < 0 || value > 100)
                 {
-#if UNITY_EDITOR
-                    UnityEngine.Debug.LogError("Invalid configuration value detected. Option maxBreadcrumbs should be an integer between 0-100. Supplied value is " + value);
-#endif
+                    if (IsRunningInEditor())
+                    {
+                        Debug.LogError("Invalid configuration value detected. Option maxBreadcrumbs should be an integer between 0-100. Supplied value is " + value);
+                    }
                     return;
                 }
                 else
@@ -138,7 +139,28 @@ namespace BugsnagUnity
 
         public ErrorTypes[] EnabledErrorTypes { get; set; }
 
-        public int AppHangThresholdMillis { get; set; } = -1;
+
+        private ulong _appHangThresholdMillis = 0;
+
+        public ulong AppHangThresholdMillis
+        {
+            get { return _appHangThresholdMillis; }
+            set
+            {
+                if (value < 250)
+                {
+                    if (IsRunningInEditor())
+                    {
+                        Debug.LogError("Invalid configuration value detected. Option AppHangThresholdMillis should be a ulong higher than 249. Supplied value is " + value);
+                    }
+                    return;
+                }
+                else
+                {
+                    _appHangThresholdMillis = value;
+                }
+            }
+        }
 
         public virtual bool IsErrorTypeEnabled(ErrorTypes errorType)
         {
@@ -166,6 +188,13 @@ namespace BugsnagUnity
                 default:
                     return false;
             }
+        }
+
+        private bool IsRunningInEditor()
+        {
+            return Application.platform == RuntimePlatform.OSXEditor
+                || Application.platform == RuntimePlatform.WindowsEditor
+                || Application.platform == RuntimePlatform.LinuxEditor;
         }
     }
 }

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -112,7 +112,7 @@ namespace BugsnagUnity
 
         public ErrorTypes[] EnabledErrorTypes { get; set; }
 
-        public int AppHangThresholdMillis { get; set; } = 5000;
+        public int AppHangThresholdMillis { get; set; } = -1;
 
         public virtual bool IsErrorTypeEnabled(ErrorTypes errorType)
         {

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -64,6 +64,6 @@ namespace BugsnagUnity
 
         string DotnetApiCompatibility { get; set; }
 
-        int AppHangThresholdMillis { get; set; }
+        ulong AppHangThresholdMillis { get; set; }
     }
 }

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -63,5 +63,7 @@ namespace BugsnagUnity
         string DotnetScriptingRuntime { get; set; }
 
         string DotnetApiCompatibility { get; set; }
+
+        int AppHangThresholdMillis { get; set; }
     }
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -34,7 +34,7 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);
             NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
-            if (config.AppHangThresholdMillis > -1)
+            if (config.AppHangThresholdMillis > 0)
             {
                 NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);
             }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -34,7 +34,10 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);
             NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
-            NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);
+            if (config.AppHangThresholdMillis > -1)
+            {
+                NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);
+            }
             SetEnabledBreadcrumbTypes(obj,config);
             SetEnabledErrorTypes(obj, config);
             if (config.Context != null)

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -34,6 +34,7 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);
             NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
+            NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);
             SetEnabledBreadcrumbTypes(obj,config);
             SetEnabledErrorTypes(obj, config);
             if (config.Context != null)

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -52,7 +52,7 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setMaxBreadcrumbs(IntPtr configuration, int maxBreadcrumbs);
 
         [DllImport(Import)]
-        internal static extern void bugsnag_setAppHangThresholdMillis(IntPtr configuration, int appHangThresholdMillis);
+        internal static extern void bugsnag_setAppHangThresholdMillis(IntPtr configuration, ulong appHangThresholdMillis);
 
         [DllImport(Import)]
         internal static extern void bugsnag_setEnabledBreadcrumbTypes(IntPtr configuration, string[] types, int count);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -52,6 +52,9 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setMaxBreadcrumbs(IntPtr configuration, int maxBreadcrumbs);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_setAppHangThresholdMillis(IntPtr configuration, int appHangThresholdMillis);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_setEnabledBreadcrumbTypes(IntPtr configuration, string[] types, int count);
 
         [DllImport(Import)]

--- a/tests/UnityEngine/Debug.cs
+++ b/tests/UnityEngine/Debug.cs
@@ -8,5 +8,7 @@ namespace UnityEngine
     public class Debug
     {
         public static bool isDebugBuild { get; }
+        public static void LogError(object message) { }
+
     }
 }


### PR DESCRIPTION
## Goal

New configuration option AppHangThresholdMillis to set the native Cocoa option: https://docs.bugsnag.com/platforms/ios/configuration-options/#apphangthresholdmillis

Cocoa-only.

## Testing

Manually tested, no ci tests planned due to difficulty automating the apphang