### PR TITLE
fix(stacktraces): add support for windows new line characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,9 @@
     
 ### Bug fixes
 
+* Fixed an issue where Windows events would have incorrectly split stacktraces resulting in all lines being bundled into one 
+  [#350](https://github.com/bugsnag/bugsnag-unity/pull/350)
+
 * Fixed an issue where WebGL web requests that initially fail were not respecting the 10 second delay before retrying 
   [#321](https://github.com/bugsnag/bugsnag-unity/pull/321)
   

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -162,7 +162,10 @@ Then("the first significant stack frame methods and files should match:") do |ex
   stacktrace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.exceptions.0.stacktrace")
   expected_frame_values = expected_values.raw
   expected_index = 0
+  
   flunk("The stacktrace is empty") if stacktrace.length == 0
+  flunk("The stacktrace is not long enough") if stacktrace.length < 3
+
   stacktrace.each_with_index do |item, index|
     next if expected_index >= expected_frame_values.length
     expected_frames = expected_frame_values[expected_index]

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -164,7 +164,7 @@ Then("the first significant stack frame methods and files should match:") do |ex
   expected_index = 0
   
   flunk("The stacktrace is empty") if stacktrace.length == 0
-  flunk("The stacktrace is not long enough") if stacktrace.length < 3
+  flunk("The stacktrace is not long enough") if stacktrace.length < expected_frame_values.length
 
   stacktrace.each_with_index do |item, index|
     next if expected_index >= expected_frame_values.length

--- a/src/BugsnagUnity/Payload/StackTraceLine.cs
+++ b/src/BugsnagUnity/Payload/StackTraceLine.cs
@@ -31,7 +31,7 @@ namespace BugsnagUnity.Payload
 
         internal StackTrace(string stackTrace, StackTraceFormat format)
         {
-            string[] lines = stackTrace.Split(new[] { System.Environment.NewLine },
+            string[] lines = stackTrace.Split(new[] {"\r\n","\r","\n", System.Environment.NewLine },
                                               System.StringSplitOptions.RemoveEmptyEntries);
             var frames = new List<StackTraceLine>();
             for (int i = 0; i < lines.Length; i++)


### PR DESCRIPTION
## Goal

Windows stacktraces were not being split properly

## Design

Added support for more types of new line

## Testing

Manually tested and fix a test that should have caught this issue before