### PR TITLE
Avoid Appium session restarts between iOS e2e scenarios

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -553,7 +553,6 @@ steps:
   #
   # Run iOS tests
   #
-  # TODO: PLAT-6656 - Avoid having to use --separate-sessions
   - label: ':ios: Run iOS e2e tests for Unity 2017'
     depends_on: 'build-ios-fixture-2017'
     timeout_in_minutes: 30
@@ -570,7 +569,6 @@ steps:
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
-          - "--separate-sessions"
           - "features/ios"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -591,7 +589,6 @@ steps:
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
-          - "--separate-sessions"
           - "features/ios"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -612,7 +609,6 @@ steps:
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
-          - "--separate-sessions"
           - "features/ios"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -633,7 +629,6 @@ steps:
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
-          - "--separate-sessions"
           - "features/ios"
     concurrency: 9
     concurrency_group: browserstack-app

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -173,7 +173,6 @@ steps:
   #
   # Run iOS tests
   #
-  # TODO: PLAT-6656 - Avoid having to use --separate-sessions
   - label: ':ios: Run iOS e2e tests for Unity 2020'
     depends_on: 'build-ios-fixture-2020'
     timeout_in_minutes: 30
@@ -190,7 +189,6 @@ steps:
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
-          - "--separate-sessions"
           - "features/ios"
     concurrency: 9
     concurrency_group: browserstack-app

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -180,7 +180,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Run
+  m_Text: Run Scenario
 --- !u!222 &102434082
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -222,7 +222,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &170849449
 MonoBehaviour:
@@ -309,6 +309,80 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 170849447}
+--- !u!1 &218429011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 218429012}
+  - component: {fileID: 218429014}
+  - component: {fileID: 218429013}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &218429012
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 218429011}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 848443690}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &218429013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 218429011}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 50
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 5
+    m_MaxSize: 50
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Run Command
+--- !u!222 &218429014
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 218429011}
 --- !u!1 &250812625
 GameObject:
   m_ObjectHideFlags: 0
@@ -344,7 +418,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &250812627
 MonoBehaviour:
@@ -769,7 +843,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &541681184
 MonoBehaviour:
@@ -891,7 +965,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &615950138
 MonoBehaviour:
@@ -1015,6 +1089,7 @@ RectTransform:
   - {fileID: 615950137}
   - {fileID: 1289527222}
   - {fileID: 1013696506}
+  - {fileID: 848443690}
   - {fileID: 1254105928}
   - {fileID: 1291648681}
   m_Father: {fileID: 1778880103}
@@ -1047,6 +1122,128 @@ MonoBehaviour:
   m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0
   m_ChildControlHeight: 0
+--- !u!1 &848443689
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 848443690}
+  - component: {fileID: 848443693}
+  - component: {fileID: 848443692}
+  - component: {fileID: 848443691}
+  m_Layer: 5
+  m_Name: RunCommandButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &848443690
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 848443689}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 218429012}
+  m_Father: {fileID: 626947306}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 600, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &848443691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 848443689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 848443692}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1789907207}
+        m_MethodName: RunCommand
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &848443692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 848443689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &848443693
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 848443689}
 --- !u!1 &893676384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1082,7 +1279,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &893676386
 MonoBehaviour:
@@ -1317,7 +1514,7 @@ GameObject:
   - component: {fileID: 1013696508}
   - component: {fileID: 1013696507}
   m_Layer: 5
-  m_Name: RunButton
+  m_Name: RunScenarioButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1340,7 +1537,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1013696507
 MonoBehaviour:
@@ -1456,12 +1653,12 @@ RectTransform:
   m_Children:
   - {fileID: 914044370}
   m_Father: {fileID: 626947306}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1254105929
 MonoBehaviour:
@@ -1531,7 +1728,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1289527223
 MonoBehaviour:
@@ -1647,12 +1844,12 @@ RectTransform:
   m_Children:
   - {fileID: 1786821009}
   m_Father: {fileID: 626947306}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1291648682
 MonoBehaviour:
@@ -2012,7 +2209,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1756777456
 MonoBehaviour:
@@ -2431,7 +2628,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1853781880
 MonoBehaviour:
@@ -2553,7 +2750,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1965148507
 MonoBehaviour:
@@ -2749,7 +2946,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 100}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2023570298
 MonoBehaviour:

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileNative.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileNative.cs
@@ -40,7 +40,7 @@ public class MobileNative : MonoBehaviour {
 #endif
     }
 
-    public static void ClearPersistantData()
+    public static void ClearIOSData()
     {
 #if UNITY_IOS
         ClearPersistentData();

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -11,8 +11,9 @@ public class MobileScenarioRunner : MonoBehaviour {
 
     public Text Dialled, ScenarioName;
 
-    private Dictionary<String, String> SCENARIOS = new Dictionary<String, String>
+    private Dictionary<String, String> LOOKUP = new Dictionary<String, String>
     {
+        // Scenarios
         {"01", "throw Exception" },
         {"02", "Log error" },
         {"03", "Native exception" },
@@ -27,11 +28,14 @@ public class MobileScenarioRunner : MonoBehaviour {
         {"12", "Disable Native Errors" },
         {"13", "throw Exception with breadcrumbs" },
         {"14", "Start SDK no errors" },
+
+        // Commands
+        {"90", "Clear iOS Data" },
     };
 
-    private string GetScenarioNameFromDialCode(string code)
+    private string GetNameFromDialCode(string code)
     {
-        var scenarioName = SCENARIOS[code];
+        var scenarioName = LOOKUP[code];
         if (string.IsNullOrEmpty(scenarioName))
         {
             throw new System.Exception("Unable to find Scenario name for code: " + code);
@@ -59,13 +63,14 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         // 1: Get the dial code
         var code = Dialled.text;
+        Debug.Log("RunCommand called, code is " + code);
         if (string.IsNullOrEmpty(code) || code.Length != 2)
         {
             throw new System.Exception("Code is empty or not correctly formatted: " + code);
         }
 
         // 2: Get the command name and clear the number
-        var scenarioName = GetScenarioNameFromDialCode(code);
+        var scenarioName = GetNameFromDialCode(code);
         ScenarioName.text = scenarioName;
         Dialled.text = string.Empty;
 
@@ -78,13 +83,14 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         // 1: Get the dial code
         var code = Dialled.text;
+        Debug.Log("RunScenario called, code is " + code);
         if (string.IsNullOrEmpty(code) || code.Length != 2)
         {
             throw new System.Exception("Code is empty or not correctly formatted: " + code);
         }
 
         // 2: Get the scenario name and clear the number
-        var scenarioName = GetScenarioNameFromDialCode(code);
+        var scenarioName = GetNameFromDialCode(code);
         ScenarioName.text = scenarioName;
         Dialled.text = string.Empty;
 

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -55,6 +55,26 @@ public class MobileScenarioRunner : MonoBehaviour {
         Dialled.text += number;
     }
 
+    // Issues a command to the test fixture
+    public void RunCommand()
+    {
+        // 1: Get the dial code
+        var code = Dialled.text;
+        if (string.IsNullOrEmpty(code) || code.Length != 2)
+        {
+            throw new System.Exception("Code is empty or not correctly formatted: " + code);
+        }
+
+        // 2: Get the command name and clear the number
+        var scenarioName = GetScenarioNameFromDialCode(code);
+        ScenarioName.text = scenarioName;
+        Dialled.text = string.Empty;
+
+        // 3: Issue the command
+        DoTestAction(scenarioName);
+    }
+
+    // Tells the test fixture to run a particular test scenario
     public void RunScenario()
     {
         // 1: Get the dial code
@@ -75,7 +95,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         // 4: Start the Bugsnag SDK
         StartTheSdk(config);
 
-        //5: Trigger the actions for the test
+        // 5: Trigger the actions for the test
         DoTestAction(scenarioName);
     }
 

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -27,7 +27,6 @@ public class MobileScenarioRunner : MonoBehaviour {
         {"12", "Disable Native Errors" },
         {"13", "throw Exception with breadcrumbs" },
         {"14", "Start SDK no errors" },
-        {"15", "Clear iOS Data" }
     };
 
     private string GetScenarioNameFromDialCode(string code)

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -12,25 +12,23 @@ public class MobileScenarioRunner : MonoBehaviour {
     public Text Dialled, ScenarioName;
 
     private Dictionary<String, String> SCENARIOS = new Dictionary<String, String>
-        {
-            {"01", "throw Exception" },
-            {"02", "Log error" },
-            {"03", "Native exception" },
-            {"04", "Log caught exception" },
-            {"05", "NDK signal" },
-            {"06", "Notify caught exception" },
-            {"07", "Notify with callback" },
-            {"08", "Change scene" },
-            {"09", "Disable Breadcrumbs" },
-            {"10", "Start SDK" },
-            {"11", "Max Breadcrumbs" },
-            {"12", "Disable Native Errors" },
-            {"13", "throw Exception with breadcrumbs" },
-            {"14", "Start SDK no errors" },
-            {"15", "Clear iOS Data" }
-
-
-        };
+    {
+        {"01", "throw Exception" },
+        {"02", "Log error" },
+        {"03", "Native exception" },
+        {"04", "Log caught exception" },
+        {"05", "NDK signal" },
+        {"06", "Notify caught exception" },
+        {"07", "Notify with callback" },
+        {"08", "Change scene" },
+        {"09", "Disable Breadcrumbs" },
+        {"10", "Start SDK" },
+        {"11", "Max Breadcrumbs" },
+        {"12", "Disable Native Errors" },
+        {"13", "throw Exception with breadcrumbs" },
+        {"14", "Start SDK no errors" },
+        {"15", "Clear iOS Data" }
+    };
 
     private string GetScenarioNameFromDialCode(string code)
     {
@@ -50,7 +48,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         config.Context = "My context";
         config.AppVersion = "1.2.3";
         return config;
-    }   
+    }
 
     public void Dial(string number)
     {
@@ -66,9 +64,10 @@ public class MobileScenarioRunner : MonoBehaviour {
             throw new System.Exception("Code is empty or not correctly formatted: " + code);
         }
 
-        // 2: Get the scenario name
+        // 2: Get the scenario name and clear the number
         var scenarioName = GetScenarioNameFromDialCode(code);
         ScenarioName.text = scenarioName;
+        Dialled.text = string.Empty;
 
         // 3: Get the config for that scenario
         var config = PreapareConfigForScenario(scenarioName);
@@ -78,7 +77,6 @@ public class MobileScenarioRunner : MonoBehaviour {
 
         //5: Trigger the actions for the test
         DoTestAction(scenarioName);
-
     }
 
     private Configuration PreapareConfigForScenario(string scenarioName)
@@ -164,11 +162,10 @@ public class MobileScenarioRunner : MonoBehaviour {
                 ThrowException();
                 break;
             case "Clear iOS Data":
-                MobileNative.ClearPersistantData();
+                MobileNative.ClearIOSData();
                 break;
             default:
                 throw new System.Exception("Unknown scenario: " + scenarioName);
-
         }
     }
 
@@ -238,7 +235,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         });
     }
 
-   
+
     public void StartSession()
     {
 

--- a/features/fixtures/maze_runner/Assets/nativeplugin/native_code.mm
+++ b/features/fixtures/maze_runner/Assets/nativeplugin/native_code.mm
@@ -8,10 +8,6 @@ extern "C" {
   void ClearPersistentData();
 }
 
-
-
-
-
 void ClearPersistentData() {
     NSLog(@"Clear persistent data");
     [NSUserDefaults.standardUserDefaults removePersistentDomainForName:NSBundle.mainBundle.bundleIdentifier];
@@ -24,8 +20,6 @@ void ClearPersistentData() {
         }
     }
 }
-
-
 
 void RaiseCocoaSignal() {
     abort();

--- a/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
+++ b/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
@@ -160,6 +160,7 @@ PlayerSettings:
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
     Android: com.bugsnag.mazerunner
+    iOS: com.bugsnag.unity.mazerunner
   buildNumber: {}
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 16
@@ -236,10 +237,10 @@ PlayerSettings:
   metalEditorSupport: 0
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 0
-  appleDeveloperTeamID: 
+  appleDeveloperTeamID: 372ZUL2ZB7
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
-  appleEnableAutomaticSigning: 0
+  appleEnableAutomaticSigning: 1
   clonedFromGUID: 00000000000000000000000000000000
   AndroidTargetArchitectures: 5
   AndroidSplashScreenScale: 0

--- a/features/ios/ios_breadcrumbs.feature
+++ b/features/ios/ios_breadcrumbs.feature
@@ -2,12 +2,12 @@ Feature: ios breadcrumbs
 
     Background:
         Given I wait for the mobile game to start
+        And I clear all persistent data
 
     Scenario: Disable Breadcrumbs
         When I run the "Disable Breadcrumbs" mobile scenario
         Then I wait to receive an error
-        And the error payload field "events.0.breadcrumbs.0" is null       
-
+        And the error payload field "events.0.breadcrumbs.0" is null
 
     Scenario: Max Breadcrumbs
         When I run the "Max Breadcrumbs" mobile scenario

--- a/features/ios/ios_breadcrumbs.feature
+++ b/features/ios/ios_breadcrumbs.feature
@@ -1,8 +1,8 @@
 Feature: ios breadcrumbs
 
     Background:
-        Given I clear all persistent data
-        And I wait for the mobile game to start
+        Given I wait for the mobile game to start
+        And I clear all persistent data
 
     Scenario: Disable Breadcrumbs
         When I run the "Disable Breadcrumbs" mobile scenario

--- a/features/ios/ios_breadcrumbs.feature
+++ b/features/ios/ios_breadcrumbs.feature
@@ -1,8 +1,8 @@
 Feature: ios breadcrumbs
 
     Background:
-        Given I wait for the mobile game to start
-        And I clear all persistent data
+        Given I clear all persistent data
+        And I wait for the mobile game to start
 
     Scenario: Disable Breadcrumbs
         When I run the "Disable Breadcrumbs" mobile scenario

--- a/features/ios/ios_csharp_errors.feature
+++ b/features/ios/ios_csharp_errors.feature
@@ -3,6 +3,7 @@ Feature: iOS smoke tests for C# errors
     # TODO: Failing steps commented out pending full implementation of PLAT-6372
     Background:
         Given I wait for the mobile game to start
+        And I clear all persistent data
 
     Scenario: Uncaught C# exception
         When I run the "throw Exception with breadcrumbs" mobile scenario

--- a/features/ios/ios_enabled_error_types.feature
+++ b/features/ios/ios_enabled_error_types.feature
@@ -2,6 +2,7 @@ Feature: Enabled Error Types
 
     Background:
         Given I wait for the mobile game to start
+        And I clear all persistent data
 
     Scenario: Disable Native Errors
         When I run the "Disable Native Errors" mobile scenario

--- a/features/ios/ios_log.feature
+++ b/features/ios/ios_log.feature
@@ -2,6 +2,7 @@ Feature: iOS smoke tests for log entries
 
     Background:
         Given I wait for the mobile game to start
+        And I clear all persistent data
 
     Scenario: Calling Bugsnag.Log() with an error
 

--- a/features/ios/ios_notify.feature
+++ b/features/ios/ios_notify.feature
@@ -3,6 +3,7 @@ Feature: iOS smoke tests for C# errors
     # TODO: Failing steps commented out pending full implementation of PLAT-6372
     Background:
         Given I wait for the mobile game to start
+        And I clear all persistent data
 
     Scenario: Calling Bugsnag.Notify() with caught C# exception
 

--- a/features/ios/ios_sessions.feature
+++ b/features/ios/ios_sessions.feature
@@ -3,6 +3,7 @@ Feature: iOS smoke tests for sessions
     # TODO: Failing steps commented out pending full implementation of PLAT-6372
     Background:
         Given I wait for the mobile game to start
+        And I clear all persistent data
 
     Scenario: Bugsnag automatically tracks sessions
         When I run the "Notify with callback" mobile scenario

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -10,6 +10,10 @@ When("I wait for the mobile game to start") do
   sleep 3
 end
 
+When('I clear all persistent data') do
+  step('I run the "Clear iOS Data" mobile scenario')
+end
+
 When('I relaunch the Unity mobile app') do
   Maze.driver.launch_app
   # Wait for a fixed time period

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -11,7 +11,7 @@ When("I wait for the mobile game to start") do
 end
 
 When('I clear all persistent data') do
-  step('I run the "Clear iOS Data" mobile scenario')
+  step('I run the "Clear iOS Data" command')
 end
 
 When('I relaunch the Unity mobile app') do

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -20,9 +20,9 @@ When('I relaunch the Unity mobile app') do
   sleep 3
 end
 
-When("I run the {string} mobile scenario") do |scenario|
-
+def dial_number_for(name)
   lookup = {
+      # Scenarios
       "throw Exception" => 1,
       "Log error" => 2,
       "Native exception" => 3,
@@ -37,36 +37,48 @@ When("I run the {string} mobile scenario") do |scenario|
       "Disable Native Errors" => 12,
       "throw Exception with breadcrumbs" => 13,
       "Start SDK no errors" => 14,
-      "Clear iOS Data" => 15
+
+      # Commands
+      "Clear iOS Data" => 90
   }
-  number = lookup[scenario]
-  $logger.debug "#{scenario}' has dial-in code #{number}"
+  number = lookup[name]
+  $logger.debug "Command/scenario '#{name}' has dial-in code #{number}"
 
   step("I dial #{number / 10}")
   sleep 1
   step("I dial #{number % 10}")
   sleep 1
-  step("I press dial")
-  sleep 1
+end
+
+When("I run the {string} command") do |command|
+  dial_number_for command
+  step("I press Run Command")
+end
+
+When("I run the {string} mobile scenario") do |scenario|
+  dial_number_for scenario
+  step("I press Run Scenario")
 end
 
 When("I dial {int}") do |number|
   $logger.debug "Dialling #{number}"
-  # Ensure we tap in the button
-  viewport = Maze.driver.session_capabilities['viewportRect']
-  center = viewport['width'] / 2
-  press_at center, 50 + (number * 100)
+  press_at 40 + (number * 80)
   sleep 1
 end
 
-When("I press dial") do
-  # Ensure we tap in the button
-  viewport = Maze.driver.session_capabilities['viewportRect']
-  center = viewport['width'] / 2
-  press_at center, 1050
+When("I press Run Scenario") do
+  press_at 840
 end
 
-def press_at(x, y)
+When("I press Run Command") do
+  press_at 920
+end
+
+def press_at(y)
+
+  # Ensure we tap in the button
+  viewport = Maze.driver.session_capabilities['viewportRect']
+  x = viewport['width'] / 2
 
   $logger.debug "Press at: #{x},#{y}"
 


### PR DESCRIPTION
## Goal

Avoid have to use the `--separate-sessions` MazeRunner option to create a new Appium session before each iOS test scenario.  This speeds up the run and also means that we just get a single video and set of logs for the run to inspect.

## Design

I've reworked the test fixture a little to hook into the existing functionality to clear all persistent data on iOS.  It was the "false OOMs" caused by the app being killed between scenarios that meant we needed to use separate sessions initially.

I've separated the running of commands from scenarios.  Although they are very similar in how they are invoked, they are separate concerns and have some important differences.  For example, command should not typically be starting Bugsnag.

## Changeset

- `--separate-sessions` removed from pipelines
- Test fixture buttons reduced in height slightly to fit a new "Run command" button on.
- Test fixture and harness changes to separate the concerns of running scenarios and commands, whilst reusing common elements.

## Testing

Covered by a full CI run.