### PR TITLE
task(config): add new BundleVersion configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TBD
 
+### Enhancements
+
+* Add `BundleVersion` to set the [native Cocoa option](https://docs.bugsnag.com/platforms/ios/configuration-options/#bundleversion) [#359](https://github.com/bugsnag/bugsnag-unity/pull/359)
+
 * Update bugsnag-android to v5.11.0:
   * Add Bugsnag listeners for StrictMode violation detection
     [#1331](https://github.com/bugsnag/bugsnag-android/pull/1331)

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -50,6 +50,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         config.SessionEndpoint = new Uri("http://bs-local.com:9339/sessions");
         config.Context = "My context";
         config.AppVersion = "1.2.3";
+        config.BundleVersion = "1.2.3";
         return config;
     }
 

--- a/features/ios/ios_csharp_errors.feature
+++ b/features/ios/ios_csharp_errors.feature
@@ -29,7 +29,7 @@ Feature: iOS smoke tests for C# errors
         And the event "app.releaseStage" equals "production"
         And the event "app.type" equals "iOS"
         And the event "app.version" equals "1.2.3"
-#        And the event "app.bundleVersion" equals "???"
+        And the event "app.bundleVersion" equals "1.2.3"
 #        And the event "app.versionCode" equals "1"
 #        And the error payload field "events.0.app.durationInForeground" is greater than 0
 #        And the event "app.inForeground" equals "true"

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -353,7 +353,6 @@ void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *i
 
   callback(appData, "id", [sysInfo[@BSG_KSSystemField_BundleID] UTF8String]);
   callback(appData, "type", [sysInfo[@BSG_KSSystemField_SystemName] UTF8String]);
-
   NSString *version = [Bugsnag configuration].appVersion ?: sysInfo[@BSG_KSSystemField_BundleShortVersion];
   callback(appData, "version", [version UTF8String]);
 }

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -121,13 +121,13 @@ void bugsnag_setEnabledBreadcrumbTypes(const void *configuration, const char *ty
         ((__bridge BugsnagConfiguration *)configuration).enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeAll;
         return;
     }
-    
+
     ((__bridge BugsnagConfiguration *)configuration).enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeNone;
-    
+
     for (int i = 0; i < count; i++) {
         const char *enabledType = types[i];
         if (enabledType != nil) {
-				
+
 			NSString *typeString = [[NSString alloc] initWithUTF8String:enabledType];
 
             if([typeString isEqualToString:@"Navigation"])
@@ -174,7 +174,7 @@ void bugsnag_setEnabledErrorTypes(const void *configuration, const char *types[]
     for (int i = 0; i < count; i++) {
         const char *enabledType = types[i];
         if (enabledType != nil) {
-				
+
 			NSString *typeString = [[NSString alloc] initWithUTF8String:enabledType];
 
             if([typeString isEqualToString:@"AppHangs"])
@@ -246,7 +246,7 @@ void bugsnag_setMetadata(const void *configuration, const char *tab, const char 
 }
 
 void bugsnag_retrieveMetaData(const void *metadata, void (*callback)(const void *instance, const char *tab,const char *keys[], int keys_size, const char *values[], int values_size)) {
-    
+
     for (NSString* sectionKey in [Bugsnag.client metadata].dictionary.allKeys) {
                  NSDictionary* sectionDictionary = [[Bugsnag.client metadata].dictionary valueForKey:sectionKey];
                  NSArray *keys = [sectionDictionary allKeys];
@@ -265,7 +265,7 @@ void bugsnag_retrieveMetaData(const void *metadata, void (*callback)(const void 
                 free(c_keys);
                 free(c_values);
            }
-    
+
 }
 
 void bugsnag_removeMetadata(const void *configuration, const char *tab) {
@@ -352,12 +352,9 @@ void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *i
   callback(appData, "bundleVersion", [bundleVersion UTF8String]);
 
   callback(appData, "id", [sysInfo[@BSG_KSSystemField_BundleID] UTF8String]);
+  callback(appData, "type", [sysInfo[@BSG_KSSystemField_SystemName] UTF8String]);
 
-  NSString *appType = [Bugsnag configuration].appType ?: sysInfo[@BSG_KSSystemField_SystemName];
-  callback(appData, "type", [appType UTF8String]);
-  
   NSString *version = [Bugsnag configuration].appVersion ?: sysInfo[@BSG_KSSystemField_BundleShortVersion];
-
   callback(appData, "version", [version UTF8String]);
 }
 

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -98,10 +98,7 @@ void bugsnag_setAppHangThresholdMillis(const void *configuration, NSUInteger app
 
 void bugsnag_setBundleVersion(const void *configuration, char *bundleVersion) {
   NSString *ns_bundleVersion = bundleVersion == NULL ? nil : [NSString stringWithUTF8String: bundleVersion];
-  NSLog(@"Setting Bundle Version: %@" , ns_bundleVersion );
   ((__bridge BugsnagConfiguration *)configuration).bundleVersion = ns_bundleVersion;
-  NSLog(@"Is Bundle Version set: %@" , ((__bridge BugsnagConfiguration *)configuration).bundleVersion );
-
 }
 
 void bugsnag_setContext(const void *configuration, char *context) {
@@ -359,15 +356,7 @@ void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *i
   NSString *appType = [Bugsnag configuration].appType ?: sysInfo[@BSG_KSSystemField_SystemName];
   callback(appData, "type", [appType UTF8String]);
   
-
   NSString *version = [Bugsnag configuration].appVersion ?: sysInfo[@BSG_KSSystemField_BundleShortVersion];
-
-  NSLog(@"Config Version: %@" , [Bugsnag configuration].appVersion );
-
-  NSLog(@"Sysinfo Version: %@" , sysInfo[@BSG_KSSystemField_BundleShortVersion] );
-
-
-  NSLog(@"Returning Bundle Version: %@" , version );
 
   callback(appData, "version", [version UTF8String]);
 }

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -98,7 +98,10 @@ void bugsnag_setAppHangThresholdMillis(const void *configuration, NSUInteger app
 
 void bugsnag_setBundleVersion(const void *configuration, char *bundleVersion) {
   NSString *ns_bundleVersion = bundleVersion == NULL ? nil : [NSString stringWithUTF8String: bundleVersion];
+  NSLog(@"Setting Bundle Version: %@" , ns_bundleVersion );
   ((__bridge BugsnagConfiguration *)configuration).bundleVersion = ns_bundleVersion;
+  NSLog(@"Is Bundle Version set: %@" , ((__bridge BugsnagConfiguration *)configuration).bundleVersion );
+
 }
 
 void bugsnag_setContext(const void *configuration, char *context) {
@@ -358,6 +361,14 @@ void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *i
   
 
   NSString *version = [Bugsnag configuration].appVersion ?: sysInfo[@BSG_KSSystemField_BundleShortVersion];
+
+  NSLog(@"Config Version: %@" , [Bugsnag configuration].appVersion );
+
+  NSLog(@"Sysinfo Version: %@" , sysInfo[@BSG_KSSystemField_BundleShortVersion] );
+
+
+  NSLog(@"Returning Bundle Version: %@" , version );
+
   callback(appData, "version", [version UTF8String]);
 }
 

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -29,6 +29,8 @@ extern "C" {
 
   void bugsnag_setAutoNotify(bool autoNotify);
 
+  void bugsnag_setBundleVersion(const void *configuration, char *bundleVersion);
+
   void bugsnag_setContext(const void *configuration, char *context);
   void bugsnag_setContextConfig(const void *configuration, char *context);
 
@@ -92,6 +94,11 @@ void bugsnag_setAppVersion(const void *configuration, char *appVersion) {
 
 void bugsnag_setAppHangThresholdMillis(const void *configuration, NSUInteger appHangThresholdMillis) {
   ((__bridge BugsnagConfiguration *)configuration).appHangThresholdMillis = appHangThresholdMillis;
+}
+
+void bugsnag_setBundleVersion(const void *configuration, char *bundleVersion) {
+  NSString *ns_bundleVersion = bundleVersion == NULL ? nil : [NSString stringWithUTF8String: bundleVersion];
+  ((__bridge BugsnagConfiguration *)configuration).bundleVersion = ns_bundleVersion;
 }
 
 void bugsnag_setContext(const void *configuration, char *context) {
@@ -341,9 +348,15 @@ void bugsnag_retrieveBreadcrumbs(const void *managedBreadcrumbs, void (*breadcru
 void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *instance, const char *key, const char *value)) {
   NSDictionary *sysInfo = [BSG_KSSystemInfo systemInfo];
 
-  callback(appData, "bundleVersion", [sysInfo[@BSG_KSSystemField_BundleVersion] UTF8String]);
+  NSString *bundleVersion = [Bugsnag configuration].bundleVersion ?: sysInfo[@BSG_KSSystemField_BundleVersion];
+  callback(appData, "bundleVersion", [bundleVersion UTF8String]);
+
   callback(appData, "id", [sysInfo[@BSG_KSSystemField_BundleID] UTF8String]);
-  callback(appData, "type", [sysInfo[@BSG_KSSystemField_SystemName] UTF8String]);
+
+  NSString *appType = [Bugsnag configuration].appType ?: sysInfo[@BSG_KSSystemField_SystemName];
+  callback(appData, "type", [appType UTF8String]);
+  
+
   NSString *version = [Bugsnag configuration].appVersion ?: sysInfo[@BSG_KSSystemField_BundleShortVersion];
   callback(appData, "version", [version UTF8String]);
 }

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -124,7 +124,7 @@ namespace BugsnagUnity
             }
         }
 
-        private bool _autoDetectErrors = true; 
+        private bool _autoDetectErrors = true;
 
         [Obsolete("AutoNotify is deprecated, please use AutoDetectErrors instead.", false)]
         public virtual bool AutoNotify
@@ -189,7 +189,6 @@ namespace BugsnagUnity
             }
         }
 
-
         public virtual bool IsErrorTypeEnabled(ErrorTypes errorType)
         {
             return EnabledErrorTypes == null || EnabledErrorTypes.Contains(errorType);
@@ -224,8 +223,6 @@ namespace BugsnagUnity
                 || Application.platform == RuntimePlatform.WindowsEditor
                 || Application.platform == RuntimePlatform.LinuxEditor;
         }
-
-       
     }
 }
 

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -12,6 +12,8 @@ namespace BugsnagUnity
 
         public const string DefaultSessionEndpoint = "https://sessions.bugsnag.com";
 
+        public string BundleVersion { get; set; }
+
         public Configuration(string apiKey)
         {
             ApiKey = apiKey;
@@ -187,6 +189,7 @@ namespace BugsnagUnity
             }
         }
 
+
         public virtual bool IsErrorTypeEnabled(ErrorTypes errorType)
         {
             return EnabledErrorTypes == null || EnabledErrorTypes.Contains(errorType);
@@ -221,6 +224,8 @@ namespace BugsnagUnity
                 || Application.platform == RuntimePlatform.WindowsEditor
                 || Application.platform == RuntimePlatform.LinuxEditor;
         }
+
+       
     }
 }
 

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -65,5 +65,7 @@ namespace BugsnagUnity
         string DotnetApiCompatibility { get; set; }
 
         ulong AppHangThresholdMillis { get; set; }
+
+        string BundleVersion { get; set; }
     }
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -34,6 +34,10 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);
             NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
+            if (!string.IsNullOrEmpty(config.BundleVersion))
+            {
+                NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
+            }
             if (config.AppHangThresholdMillis > 0)
             {
                 NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -34,10 +34,7 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);
             NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
-            if (!string.IsNullOrEmpty(config.BundleVersion))
-            {
-                NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
-            }
+            NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
             if (config.AppHangThresholdMillis > 0)
             {
                 NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -67,6 +67,9 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setAppVersion(IntPtr configuration, string appVersion);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_setBundleVersion(IntPtr configuration, string bundleVersion);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_setNotifyUrl(IntPtr configuration, string endpoint);
 
         internal delegate void NotifyReleaseStageCallback(IntPtr instance, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] string[] releaseStages, long count);


### PR DESCRIPTION
## Goal

New configuration option BundleVersion to set the native Cocoa bundleVersion option

## Design

The config value is null by default and only passed through to cocoa if set by the user

## Changeset

- Added BundleVersion to IConfiguration and Configuration classes
- Added native method bugsnag_setBundleVersion in NativeCode and Bugsnag.mm classes

## Testing

Added check for the value in the iOS test ios_csharp_errors.feature:8