### PR TITLE
task(config): add new configuration option: DiscardClasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   * Fix another rare crash in `bsg_ksmachgetThreadQueueName`.
     [#1157](https://github.com/bugsnag/bugsnag-cocoa/pull/1157)
     
+* Add `DiscardClasses` configuration option to disable sending events that contain user defined error classes. [#361](https://github.com/bugsnag/bugsnag-unity/pull/361)
+
 * Update bugsnag-android to v5.11.0:
   * Add Bugsnag listeners for StrictMode violation detection
     [#1331](https://github.com/bugsnag/bugsnag-android/pull/1331)

--- a/features/android/android_jvm_errors.feature
+++ b/features/android/android_jvm_errors.feature
@@ -3,8 +3,8 @@ Feature: Android manual smoke tests
     Background:
         Given I wait for the mobile game to start
 
- Scenario: Disgard JVM Error Class
-        When I run the "Disgard Error Class" mobile scenario
+ Scenario: Discard JVM Error Class
+        When I run the "Discard Error Class" mobile scenario
         Then I should receive no errors
 
     Scenario: Uncaught JVM exception

--- a/features/android/android_jvm_errors.feature
+++ b/features/android/android_jvm_errors.feature
@@ -3,6 +3,10 @@ Feature: Android manual smoke tests
     Background:
         Given I wait for the mobile game to start
 
+ Scenario: Disgard JVM Error Class
+        When I run the "Disgard Error Class" mobile scenario
+        Then I should receive no errors
+
     Scenario: Uncaught JVM exception
         When I run the "Native exception" mobile scenario
         Then I wait to receive 1 error

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -85,8 +85,8 @@ Feature: Reporting unhandled events
         When I run the game in the "UncaughtExceptionWithoutAutoNotify" state
         Then I should receive no requests
 
-    Scenario: Disgarding An Error Class
-        When I run the game in the "DisgardErrorClass" state
+    Scenario: Discarding An Error Class
+        When I run the game in the "DiscardErrorClass" state
         Then I should receive no errors
 
     @macos_only

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -85,6 +85,10 @@ Feature: Reporting unhandled events
         When I run the game in the "UncaughtExceptionWithoutAutoNotify" state
         Then I should receive no requests
 
+    Scenario: Disgarding An Error Class
+        When I run the game in the "DisgardErrorClass" state
+        Then I should receive no errors
+
     @macos_only
     Scenario: Reporting a native crash when AutoNotify = false
         When I run the game in the "NativeCrashWithoutAutoNotify" state

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -135,6 +135,9 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "DisgardErrorClass":
+                config.DiscardClasses = new string[] { "ExecutionEngineException" };
+                break;
             case "EnableUnhandledExceptions":
                 config.EnabledErrorTypes = new ErrorTypes[] {ErrorTypes.UnhandledExceptions };
                 config.NotifyLevel = LogType.Log;
@@ -245,6 +248,9 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "DisgardErrorClass":
+                DoUnhandledException(0);
+                break;
             case "EnableUnhandledExceptions":
                 CheckEnabledErrorTypes();
                 break;

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -135,7 +135,7 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
-            case "DisgardErrorClass":
+            case "DiscardErrorClass":
                 config.DiscardClasses = new string[] { "ExecutionEngineException" };
                 break;
             case "EnableUnhandledExceptions":
@@ -248,7 +248,7 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
-            case "DisgardErrorClass":
+            case "DiscardErrorClass":
                 DoUnhandledException(0);
                 break;
             case "EnableUnhandledExceptions":

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -28,6 +28,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         {"12", "Disable Native Errors" },
         {"13", "throw Exception with breadcrumbs" },
         {"14", "Start SDK no errors" },
+        {"15", "Disgard Error Class" },
 
         // Commands
         {"90", "Clear iOS Data" },
@@ -114,6 +115,7 @@ public class MobileScenarioRunner : MonoBehaviour {
             case "Start SDK no errors":
             case "Disable Native Errors":
                 config.EnabledErrorTypes = new ErrorTypes[0];
+                config.DiscardClasses = new string[] { "St13runtime_error" };
                 break;
             case "Log error":
                 config.NotifyLevel = LogType.Error;
@@ -123,6 +125,14 @@ public class MobileScenarioRunner : MonoBehaviour {
                 break;
             case "Max Breadcrumbs":
                 config.MaximumBreadcrumbs = 5;
+                break;
+            case "Disgard Error Class":
+#if UNITY_IOS
+                config.DiscardClasses = new string[] { "St13runtime_error" };
+
+#elif UNITY_ANDROID
+                config.DiscardClasses = new string[] { "java.lang.ArrayIndexOutOfBoundsException" };
+#endif
                 break;
         }
         return config;
@@ -139,6 +149,9 @@ public class MobileScenarioRunner : MonoBehaviour {
         {
             case "Start SDK":
             case "Start SDK no errors":
+                break;
+            case "Disgard Error Class":
+                NativeException();
                 break;
             case "Disable Native Errors":
                 NativeException();

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -28,7 +28,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         {"12", "Disable Native Errors" },
         {"13", "throw Exception with breadcrumbs" },
         {"14", "Start SDK no errors" },
-        {"15", "Disgard Error Class" },
+        {"15", "Discard Error Class" },
 
         // Commands
         {"90", "Clear iOS Data" },
@@ -126,7 +126,7 @@ public class MobileScenarioRunner : MonoBehaviour {
             case "Max Breadcrumbs":
                 config.MaximumBreadcrumbs = 5;
                 break;
-            case "Disgard Error Class":
+            case "Discard Error Class":
 #if UNITY_IOS
                 config.DiscardClasses = new string[] { "St13runtime_error" };
 
@@ -150,7 +150,7 @@ public class MobileScenarioRunner : MonoBehaviour {
             case "Start SDK":
             case "Start SDK no errors":
                 break;
-            case "Disgard Error Class":
+            case "Discard Error Class":
                 NativeException();
                 break;
             case "Disable Native Errors":

--- a/features/ios/ios_discarded_error_class.feature
+++ b/features/ios/ios_discarded_error_class.feature
@@ -1,11 +1,11 @@
-Feature: Disgard Native Error Class
+Feature: Discard Native Error Class
 
     Background:
         Given I wait for the mobile game to start
         And I clear all persistent data
 
     Scenario: Disable Native Errors
-        When I run the "Disgard Error Class" mobile scenario
+        When I run the "Discard Error Class" mobile scenario
         And I wait for 2 seconds
         And I relaunch the Unity mobile app
         When I run the "Start SDK no errors" mobile scenario

--- a/features/ios/ios_disgarded_error_class.feature
+++ b/features/ios/ios_disgarded_error_class.feature
@@ -1,0 +1,14 @@
+Feature: Disgard Native Error Class
+
+    Background:
+        Given I wait for the mobile game to start
+        And I clear all persistent data
+
+    Scenario: Disable Native Errors
+        When I run the "Disgard Error Class" mobile scenario
+        And I wait for 2 seconds
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK no errors" mobile scenario
+        Then I should receive no errors
+
+

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -37,6 +37,7 @@ def dial_number_for(name)
       "Disable Native Errors" => 12,
       "throw Exception with breadcrumbs" => 13,
       "Start SDK no errors" => 14,
+      "Disgard Error Class" => 15,
 
       # Commands
       "Clear iOS Data" => 90

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -37,7 +37,7 @@ def dial_number_for(name)
       "Disable Native Errors" => 12,
       "throw Exception with breadcrumbs" => 13,
       "Start SDK no errors" => 14,
-      "Disgard Error Class" => 15,
+      "Discard Error Class" => 15,
 
       # Commands
       "Clear iOS Data" => 90

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -57,6 +57,9 @@ extern "C" {
 
   void bugsnag_setEnabledErrorTypes(const void *configuration, const char *types[], int count);
 
+  void bugsnag_setDiscardClasses(const void *configuration, const char *classNames[], int count);
+
+
   void bugsnag_setAppHangThresholdMillis(const void *configuration, NSUInteger appHangThresholdMillis);
 
 
@@ -203,6 +206,18 @@ void bugsnag_setEnabledErrorTypes(const void *configuration, const char *types[]
             }
         }
       }
+}
+
+void bugsnag_setDiscardClasses(const void *configuration, const char *classNames[], int count){
+  NSMutableSet *ns_classNames = [NSMutableSet new];
+  for (int i = 0; i < count; i++) {
+    const char *className = classNames[i];
+    if (className != nil) {
+      NSString *ns_className = [NSString stringWithUTF8String: className];
+      [ns_classNames addObject: ns_className];
+    }
+  }
+  ((__bridge BugsnagConfiguration *)configuration).discardClasses = ns_classNames;
 }
 
 void bugsnag_setAutoNotifyConfig(const void *configuration, bool autoNotify) {

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -260,10 +260,11 @@ namespace BugsnagUnity
 
         void Notify(Exception[] exceptions, HandledState handledState, Middleware callback, LogType? logType)
         {
-            if (!ShouldSendRequests())
+            if (!ShouldSendRequests() || EventContainsDisgardedClass(exceptions))
             {
                 return; // Skip overhead of computing payload to to ultimately not be sent
             }
+
             var user = new User { Id = User.Id, Email = User.Email, Name = User.Name };
             var app = new App(Configuration)
             {
@@ -325,6 +326,18 @@ namespace BugsnagUnity
 
                 SessionTracking.AddException(report);
             }
+        }
+
+        private bool EventContainsDisgardedClass(Exception[] exceptions)
+        {
+            foreach (var exception in exceptions)
+            {
+                if (Configuration.ErrorClassIsDiscarded(exception.ErrorClass))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public void SetApplicationState(bool inFocus)

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -199,7 +199,7 @@ namespace BugsnagUnity
             }
         }
 
-      
+
 
         public void BeforeNotify(Middleware middleware)
         {
@@ -260,7 +260,7 @@ namespace BugsnagUnity
 
         void Notify(Exception[] exceptions, HandledState handledState, Middleware callback, LogType? logType)
         {
-            if (!ShouldSendRequests() || EventContainsDisgardedClass(exceptions))
+            if (!ShouldSendRequests() || EventContainsDiscardedClass(exceptions))
             {
                 return; // Skip overhead of computing payload to to ultimately not be sent
             }
@@ -328,7 +328,7 @@ namespace BugsnagUnity
             }
         }
 
-        private bool EventContainsDisgardedClass(Exception[] exceptions)
+        private bool EventContainsDiscardedClass(Exception[] exceptions)
         {
             foreach (var exception in exceptions)
             {

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -189,6 +189,13 @@ namespace BugsnagUnity
             }
         }
 
+        public string[] DiscardClasses { get; set; }
+
+        public virtual bool ErrorClassIsDiscarded(string className)
+        {
+            return DiscardClasses != null && DiscardClasses.Contains(className);
+        }
+
         public virtual bool IsErrorTypeEnabled(ErrorTypes errorType)
         {
             return EnabledErrorTypes == null || EnabledErrorTypes.Contains(errorType);

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -11,6 +11,10 @@ namespace BugsnagUnity
 
         bool ReportUncaughtExceptionsAsHandled { get; set; }
 
+        string[] DiscardClasses { get; set; }
+
+        bool ErrorClassIsDiscarded(string className);
+
         ErrorTypes[] EnabledErrorTypes { get; set; }
 
         bool IsUnityLogErrorTypeEnabled(LogType logType);

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -234,7 +234,21 @@ namespace BugsnagUnity
                     obj.Call("setEnabledBreadcrumbTypes", enabledBreadcrumbs);
                 }
             }
-            
+
+            // set DisgardedClasses
+            if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
+            {
+
+                using (AndroidJavaObject discardClasses = new AndroidJavaObject("java.util.HashSet"))
+                {
+                    foreach (var className in config.DiscardClasses)
+                    {
+                        discardClasses.Call<Boolean>("add", className);
+                    }
+                    obj.Call("setDiscardClasses", discardClasses);
+                }
+            }
+
             // add unity event callback
             var BugsnagUnity = new AndroidJavaClass("com.bugsnag.android.unity.BugsnagUnity");
             obj.Call("addOnError", BugsnagUnity.CallStatic<AndroidJavaObject>("getNativeCallback", new object[] { }));

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -235,7 +235,7 @@ namespace BugsnagUnity
                 }
             }
 
-            // set DisgardedClasses
+            // set DiscardedClasses
             if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
             {
 

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -35,6 +35,10 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
             NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
+            if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
+            {
+                NativeCode.bugsnag_setDiscardClasses(obj, config.DiscardClasses, config.DiscardClasses.Length);
+            }
             if (config.AppHangThresholdMillis > 0)
             {
                 NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -61,6 +61,9 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setEnabledErrorTypes(IntPtr configuration, string[] types, int count);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_setDiscardClasses(IntPtr configuration, string[] classNames, int count);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_setContextConfig(IntPtr configuration, string context);
 
         [DllImport(Import)]


### PR DESCRIPTION
## Goal

New configuration option to set the fallback, native Cocoa discardClasses option: https://docs.bugsnag.com/platforms/ios/configuration-options/#discardclasses and the Android discardClasses: https://docs.bugsnag.com/platforms/android/configuration-options/#discardclasses.

And to add support in the Unity fallback for discardClasses

## Design/Changeset

- Added a simple method `EventContainsDisgardedClass(Exception[] exceptions)` in the config class to check events before they are serialised for sending

- Passed the value through to Android and iOS

## Testing

Manually tested and added CI tests for fallback, iOS native and Android native events