### PR TITLE
task(config): add new config option AppType and pass through to android and ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+* Add `AppType` configuration option to enable setting a custom value for the app.type field in an event [#363](https://github.com/bugsnag/bugsnag-unity/pull/363)
+
 * Add `BundleVersion` to set the [native Cocoa option](https://docs.bugsnag.com/platforms/ios/configuration-options/#bundleversion) [#359](https://github.com/bugsnag/bugsnag-unity/pull/359)
 
 * Update bugsnag-cocoa to v6.10.4

--- a/features/android/android_csharp_errors.feature
+++ b/features/android/android_csharp_errors.feature
@@ -163,3 +163,8 @@ Feature: Android smoke tests for C# errors
         And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null
         And the error payload field "events.0.device.runtimeVersions.osBuild" is not null
         And the error payload field "events.0.device.runtimeVersions.unity" is not null
+
+     Scenario: Custom App Type
+        When I run the "Custom App Type" mobile scenario
+        Then I wait to receive an error
+        And the event "app.type" equals "test"

--- a/features/desktop/handled_errors.feature
+++ b/features/desktop/handled_errors.feature
@@ -32,6 +32,14 @@ Feature: Handled Errors and Exceptions
         And the first significant stack frame methods and files should match:
             | Main.DoNotify()           |
 
+    Scenario: Custom App Type
+        When I run the game in the "CustomAppType" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the event "app.type" equals "test"
+        And the first significant stack frame methods and files should match:
+            | Main.DoNotify()           |
+
     Scenario: Reporting a handled exception with a callback
         When I run the game in the "NotifyCallback" state
         And I wait to receive an error

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -135,6 +135,9 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "CustomAppType":
+                config.AppType = "test";
+                break;
             case "DiscardErrorClass":
                 config.DiscardClasses = new string[] { "ExecutionEngineException" };
                 break;
@@ -248,6 +251,9 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "CustomAppType":
+                DoNotify();
+                break;
             case "DiscardErrorClass":
                 DoUnhandledException(0);
                 break;

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -29,6 +29,8 @@ public class MobileScenarioRunner : MonoBehaviour {
         {"13", "throw Exception with breadcrumbs" },
         {"14", "Start SDK no errors" },
         {"15", "Discard Error Class" },
+        {"16", "Custom App Type" },
+
 
         // Commands
         {"90", "Clear iOS Data" },
@@ -126,6 +128,9 @@ public class MobileScenarioRunner : MonoBehaviour {
             case "Max Breadcrumbs":
                 config.MaximumBreadcrumbs = 5;
                 break;
+            case "Custom App Type":
+                config.AppType = "test";
+                break;
             case "Discard Error Class":
 #if UNITY_IOS
                 config.DiscardClasses = new string[] { "St13runtime_error" };
@@ -147,6 +152,9 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         switch (scenarioName)
         {
+            case "Custom App Type":
+                ThrowException();
+                break;
             case "Start SDK":
             case "Start SDK no errors":
                 break;

--- a/features/ios/ios_csharp_errors.feature
+++ b/features/ios/ios_csharp_errors.feature
@@ -71,3 +71,8 @@ Feature: iOS smoke tests for C# errors
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.osBuild" is not null
         And the error payload field "events.0.device.runtimeVersions.unity" is not null
+    
+    Scenario: Custom App Type
+        When I run the "Custom App Type" mobile scenario
+        Then I wait to receive an error
+        And the event "app.type" equals "test"

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -38,6 +38,8 @@ def dial_number_for(name)
       "throw Exception with breadcrumbs" => 13,
       "Start SDK no errors" => 14,
       "Discard Error Class" => 15,
+      "Custom App Type" => 16,
+
 
       # Commands
       "Clear iOS Data" => 90

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -31,6 +31,8 @@ extern "C" {
 
   void bugsnag_setBundleVersion(const void *configuration, char *bundleVersion);
 
+  void bugsnag_setAppType(const void *configuration, char *appType);
+
   void bugsnag_setContext(const void *configuration, char *context);
   void bugsnag_setContextConfig(const void *configuration, char *context);
 
@@ -102,6 +104,11 @@ void bugsnag_setAppHangThresholdMillis(const void *configuration, NSUInteger app
 void bugsnag_setBundleVersion(const void *configuration, char *bundleVersion) {
   NSString *ns_bundleVersion = bundleVersion == NULL ? nil : [NSString stringWithUTF8String: bundleVersion];
   ((__bridge BugsnagConfiguration *)configuration).bundleVersion = ns_bundleVersion;
+}
+
+void bugsnag_setAppType(const void *configuration, char *appType) {
+  NSString *ns_appType = appType == NULL ? nil : [NSString stringWithUTF8String: appType];
+  ((__bridge BugsnagConfiguration *)configuration).appType = ns_appType;
 }
 
 void bugsnag_setContext(const void *configuration, char *context) {
@@ -367,7 +374,10 @@ void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *i
   callback(appData, "bundleVersion", [bundleVersion UTF8String]);
 
   callback(appData, "id", [sysInfo[@BSG_KSSystemField_BundleID] UTF8String]);
-  callback(appData, "type", [sysInfo[@BSG_KSSystemField_SystemName] UTF8String]);
+
+  NSString *appType = [Bugsnag configuration].appType ?: sysInfo[@BSG_KSSystemField_SystemName];
+  callback(appData, "type", [appType UTF8String]);
+
   NSString *version = [Bugsnag configuration].appVersion ?: sysInfo[@BSG_KSSystemField_BundleShortVersion];
   callback(appData, "version", [version UTF8String]);
 }

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -14,6 +14,8 @@ namespace BugsnagUnity
 
         public string BundleVersion { get; set; }
 
+        public string AppType { get; set; }
+
         public Configuration(string apiKey)
         {
             ApiKey = apiKey;

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -71,5 +71,7 @@ namespace BugsnagUnity
         ulong AppHangThresholdMillis { get; set; }
 
         string BundleVersion { get; set; }
+
+        string AppType { get; set; }
     }
 }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -215,7 +215,12 @@ namespace BugsnagUnity
             obj.Call("setAppVersion", config.AppVersion);
             obj.Call("setContext", config.Context);
             obj.Call("setMaxBreadcrumbs", config.MaximumBreadcrumbs);
-            obj.Call("setAppType",config.AppType);
+
+            //Null or empty check necessary because android will set the app.type to empty if that or null is passed as default
+            if (!string.IsNullOrEmpty(config.AppType))
+            {
+                obj.Call("setAppType", config.AppType);
+            }
 
             // set EnabledBreadcrumbTypes
             if (config.EnabledBreadcrumbTypes != null)

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -211,10 +211,11 @@ namespace BugsnagUnity
                 }
             }
 
-            // set version/context/maxbreadcrumbs
+            // set version/context/maxbreadcrumbs/AppType
             obj.Call("setAppVersion", config.AppVersion);
             obj.Call("setContext", config.Context);
             obj.Call("setMaxBreadcrumbs", config.MaximumBreadcrumbs);
+            obj.Call("setAppType",config.AppType);
 
             // set EnabledBreadcrumbTypes
             if (config.EnabledBreadcrumbTypes != null)

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -35,6 +35,7 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
             NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
+            NativeCode.bugsnag_setAppType(obj, config.AppType);
             if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
             {
                 NativeCode.bugsnag_setDiscardClasses(obj, config.DiscardClasses, config.DiscardClasses.Length);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -73,6 +73,9 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setBundleVersion(IntPtr configuration, string bundleVersion);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_setAppType(IntPtr configuration, string appType);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_setNotifyUrl(IntPtr configuration, string endpoint);
 
         internal delegate void NotifyReleaseStageCallback(IntPtr instance, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] string[] releaseStages, long count);

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -71,6 +71,10 @@ namespace BugsnagUnity
 
         private string GetAppType()
         {
+            if (!string.IsNullOrEmpty(Configuration.AppType))
+            {
+                return Configuration.AppType;
+            }
             switch (Application.platform)
             {
                 case RuntimePlatform.OSXEditor:

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -21,7 +21,7 @@ namespace BugsnagUnity
 
         public void PopulateApp(App app)
         {
-            app.AddToPayload("type", "Windows");
+            app.AddToPayload("type", string.IsNullOrEmpty(Configuration.AppType) ? "Windows" : Configuration.AppType);
         }
 
         public void PopulateDevice(Device device)


### PR DESCRIPTION
## Goal

add new config option AppType and pass through to android and ios

## Changeset

- Added AppType to C# Config class
- Passed the value to android and iOS
- Added windows native implementation to PopulateApp method
- Updated Fallback PopulateApp method

## Testing

Manually tested and added Desktop, Android and iOS CI tests