### PR TITLE
task(config): add configuration option Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+* Add `Configuration.Endpoints` to enable setting custom endpoints for events and sessions [#366](https://github.com/bugsnag/bugsnag-unity/pull/366)
+
 * Add `BundleVersion` to set the [native Cocoa option](https://docs.bugsnag.com/platforms/ios/configuration-options/#bundleversion) [#359](https://github.com/bugsnag/bugsnag-unity/pull/359)
 
 * Update bugsnag-cocoa to v6.10.4
@@ -22,6 +24,12 @@
 
   * Address pre-existing StrictMode violations
     [#1328](https://github.com/bugsnag/bugsnag-android/pull/1328)
+    
+### Deprecated
+
+* `Configuration.Endpoint` has been deprecated in favour of the new `Configuration.Endpoints` class and will be removed in the next major release.
+
+* `Configuration.SessionEndpoint` has been deprecated in favour of the new `Configuration.Endpoints` class and will be removed in the next major release.    
 
 ## 5.2.0 (2021-08-04)
 

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -260,7 +260,7 @@ namespace BugsnagUnity
 
         void Notify(Exception[] exceptions, HandledState handledState, Middleware callback, LogType? logType)
         {
-            if (!ShouldSendRequests() || EventContainsDiscardedClass(exceptions))
+            if (!ShouldSendRequests() || EventContainsDiscardedClass(exceptions) || !Configuration.Endpoints.IsValid)
             {
                 return; // Skip overhead of computing payload to to ultimately not be sent
             }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -95,7 +95,25 @@ namespace BugsnagUnity
             {
                 // Async behavior is not available in a test environment
             }
+            if (!Configuration.Endpoints.IsValid)
+            {
+                CheckForMisconfiguredEndpointsWarning();
+            }
             AddBugsnagLoadedBreadcrumb();
+        }
+
+        private void CheckForMisconfiguredEndpointsWarning()
+        {
+            var endpoints = Configuration.Endpoints;
+            if (endpoints.NotifyIsCustom && !endpoints.SessionIsCustom)
+            {
+                UnityEngine.Debug.LogWarning("Invalid configuration. endpoints.Notify cannot be set without also setting endpoints.Session. Events will not be sent to Bugsnag.");
+            }
+            if (!endpoints.NotifyIsCustom && endpoints.SessionIsCustom)
+            {
+                UnityEngine.Debug.LogWarning("Invalid configuration. endpoints.Session cannot be set without also setting endpoints.Notify. Sessions will not be sent to Bugsnag.");
+            }
+
         }
 
         private void AddBugsnagLoadedBreadcrumb()

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -8,9 +8,6 @@ namespace BugsnagUnity
 {
     public class Configuration : IConfiguration
     {
-        public const string DefaultEndpoint = "https://notify.bugsnag.com";
-
-        public const string DefaultSessionEndpoint = "https://sessions.bugsnag.com";
 
         public string BundleVersion { get; set; }
 
@@ -22,8 +19,6 @@ namespace BugsnagUnity
             AutoDetectErrors = true;
             AutoDetectAnrs = true;
             ReleaseStage = "production";
-            Endpoint = new Uri(DefaultEndpoint);
-            SessionEndpoint = new Uri(DefaultSessionEndpoint);
         }
 
         public virtual bool ReportUncaughtExceptionsAsHandled { get; set; } = true;
@@ -87,11 +82,35 @@ namespace BugsnagUnity
 
         public virtual string AppVersion { get; set; }
 
-        public virtual Uri Endpoint { get; set; } = new Uri(DefaultEndpoint);
+        [Obsolete("Endpoint is deprecated, please use Configuration.Endpoints instead.", false)]
+        public virtual Uri Endpoint
+        {
+            get
+            {
+                return Endpoints.Notify;
+            }
+            set
+            {
+                Endpoints.Notify = value;
+            }
+        }
+
+        [Obsolete("SessionEndpoint is deprecated, please use Configuration.Endpoints instead.", false)]
+        public virtual Uri SessionEndpoint
+        {
+            get
+            {
+                return Endpoints.Session;
+            }
+            set
+            {
+                Endpoints.Session = value;
+            }
+        }
+
+        public EndpointConfiguration Endpoints { get; set; } = new EndpointConfiguration();
 
         public virtual string PayloadVersion { get; } = "4.0";
-
-        public virtual Uri SessionEndpoint { get; set; } = new Uri(DefaultSessionEndpoint);
 
         public virtual string SessionPayloadVersion { get; } = "1.0";
 
@@ -101,7 +120,8 @@ namespace BugsnagUnity
         private LogType _notifyLogLevel = LogType.Exception;
 
         [Obsolete("NotifyLevel is deprecated, please use NotifyLogLevel instead.", false)]
-        public virtual LogType NotifyLevel {
+        public virtual LogType NotifyLevel
+        {
             get
             {
                 return _notifyLogLevel;

--- a/src/BugsnagUnity/EndpointConfiguration.cs
+++ b/src/BugsnagUnity/EndpointConfiguration.cs
@@ -12,13 +12,17 @@ namespace BugsnagUnity
 
         internal Uri Session;
 
+        internal bool NotifyIsCustom => Notify != null && Notify.ToString() != new Uri( DefaultNotifyEndpoint ).ToString();
+
+        internal bool SessionIsCustom => Session != null && Session.ToString() != new Uri ( DefaultSessionEndpoint ).ToString();
+
         internal bool IsValid
         {
             get
             {
-                return Notify != null && Session != null;
+                return Notify != null && Session != null && (NotifyIsCustom && SessionIsCustom || !NotifyIsCustom && !SessionIsCustom);
             }
-        }
+        }        
 
         internal EndpointConfiguration()
         {

--- a/src/BugsnagUnity/EndpointConfiguration.cs
+++ b/src/BugsnagUnity/EndpointConfiguration.cs
@@ -1,0 +1,51 @@
+﻿using System;
+namespace BugsnagUnity
+{
+    public class EndpointConfiguration
+    {
+
+        private const string DefaultNotifyEndpoint = "https://notify.bugsnag.com";
+
+        private const string DefaultSessionEndpoint = "https://sessions.bugsnag.com";
+
+        internal Uri Notify;
+
+        internal Uri Session;
+
+        internal bool IsValid
+        {
+            get
+            {
+                return Notify != null && Session != null;
+            }
+        }
+
+        internal EndpointConfiguration()
+        {
+            Notify = new Uri(DefaultNotifyEndpoint);
+            Session = new Uri(DefaultSessionEndpoint);
+        }
+
+        public EndpointConfiguration(string notifyEndpoint, string sessionEndpoint)
+        {
+            try
+            {
+                Notify = new Uri(notifyEndpoint);
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning( string.Format("Invalid configuration. Endpoints.Notify should be a valid URI. Error message: {0}. Events will not be sent to Bugsnag. " , e.Message));
+            }
+            try
+            {
+                Session = new Uri(sessionEndpoint);
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning(string.Format("Invalid configuration. Endpoints.Session should be a valid URI. Error message:  {0}. Sessions will not be sent to Bugsnag. ", e.Message));
+
+            }
+        }
+       
+    }
+}

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -43,11 +43,9 @@ namespace BugsnagUnity
 
         string AppVersion { get; set; }
 
-        Uri Endpoint { get; set; }
+        EndpointConfiguration Endpoints { get; set; }
 
         string PayloadVersion { get; }
-
-        Uri SessionEndpoint { get; set; }
 
         string SessionPayloadVersion { get; }
 

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -186,8 +186,8 @@ namespace BugsnagUnity
             obj.Call("setAutoDetectErrors", config.AutoDetectErrors);
 
             // set endpoints
-            var notify = config.Endpoint.ToString();
-            var sessions = config.SessionEndpoint.ToString();
+            var notify = config.Endpoints.Notify.ToString();
+            var sessions = config.Endpoints.Session.ToString();
             using (AndroidJavaObject endpointConfig = new AndroidJavaObject("com.bugsnag.android.EndpointConfiguration", notify, sessions))
             {
                 obj.Call("setEndpoints", endpointConfig);

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -32,7 +32,7 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setAutoNotifyConfig(obj, config.AutoDetectErrors);
             NativeCode.bugsnag_setReleaseStage(obj, config.ReleaseStage);
             NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);
-            NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoint.ToString());
+            NativeCode.bugsnag_setNotifyUrl(obj, config.Endpoints.Notify.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
             NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
             if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)

--- a/src/BugsnagUnity/Payload/Report.cs
+++ b/src/BugsnagUnity/Payload/Report.cs
@@ -16,7 +16,7 @@ namespace BugsnagUnity.Payload
         /// Gets the endpoint that will be used to send the report to.
         /// </summary>
         /// <value>The endpoint.</value>
-        public Uri Endpoint => Configuration.Endpoint;
+        public Uri Endpoint => Configuration.Endpoints.Notify;
 
         /// <summary>
         /// Gets the headers that will be attached to the http request used to send

--- a/src/BugsnagUnity/Payload/SessionReport.cs
+++ b/src/BugsnagUnity/Payload/SessionReport.cs
@@ -7,7 +7,7 @@ namespace BugsnagUnity.Payload
     {
         IConfiguration Configuration { get; }
 
-        public Uri Endpoint => Configuration.SessionEndpoint;
+        public Uri Endpoint => Configuration.Endpoints.Session;
 
         public KeyValuePair<string, string>[] Headers { get; }
 

--- a/src/BugsnagUnity/SessionTracker.cs
+++ b/src/BugsnagUnity/SessionTracker.cs
@@ -57,9 +57,15 @@ namespace BugsnagUnity
             Client.NativeClient.PopulateDevice(device);
             device.AddRuntimeVersions(Client.Configuration);
 
-            var payload = new SessionReport(Client.Configuration, app, device, Client.User, session);
-
-            Client.Send(payload);
+            if (Client.Configuration.Endpoints.IsValid)
+            {
+                var payload = new SessionReport(Client.Configuration, app, device, Client.User, session);
+                Client.Send(payload);
+            }
+            else
+            {
+                UnityEngine.Debug.LogWarning("Invalid configuration. Configuration.Endpoints is not correctly configured, no sessions will be sent.");
+            }
         }
 
         public void StopSession()

--- a/tests/BugsnagUnity.Tests/ConfigurationTests.cs
+++ b/tests/BugsnagUnity.Tests/ConfigurationTests.cs
@@ -33,5 +33,25 @@ namespace BugsnagUnity.Payload.Tests
             config.MaximumBreadcrumbs = 20;
             Assert.AreEqual(config.MaximumBreadcrumbs, 20);
         }
+
+        [Test]
+        public void EndpointValidation()
+        {
+            var config = new Configuration("foo");
+
+            Assert.IsTrue(config.Endpoints.IsValid);
+
+            config.Endpoint = new System.Uri("https://www.richIsCool.com/");
+
+            Assert.IsFalse(config.Endpoints.IsValid);
+
+            config.SessionEndpoint = new System.Uri("https://www.richIsSuperCool.com/");
+
+            Assert.IsTrue(config.Endpoints.IsValid);
+
+            config.Endpoint = null;
+
+            Assert.IsFalse(config.Endpoints.IsValid);
+        }
     }
 }

--- a/tests/BugsnagUnity.Tests/ConfigurationTests.cs
+++ b/tests/BugsnagUnity.Tests/ConfigurationTests.cs
@@ -16,8 +16,8 @@ namespace BugsnagUnity.Payload.Tests
             Assert.IsTrue(config.AutoDetectErrors);
             Assert.IsTrue(config.AutoTrackSessions);
             Assert.AreEqual("production", config.ReleaseStage);
-            Assert.AreEqual("https://notify.bugsnag.com/", config.Endpoint.ToString());
-            Assert.AreEqual("https://sessions.bugsnag.com/", config.SessionEndpoint.ToString());
+            Assert.AreEqual("https://notify.bugsnag.com/", config.Endpoints.Notify.ToString());
+            Assert.AreEqual("https://sessions.bugsnag.com/", config.Endpoints.Session.ToString());
             Assert.AreEqual("foo", config.ApiKey);
         }
 

--- a/tests/UnityEngine/Debug.cs
+++ b/tests/UnityEngine/Debug.cs
@@ -9,6 +9,7 @@ namespace UnityEngine
     {
         public static bool isDebugBuild { get; }
         public static void LogError(object message) { }
+        public static void LogWarning(object message) { }
 
     }
 }


### PR DESCRIPTION
## Goal

-New configuration option Endpoints to set the endpoints (via a new class EndpointConfiguration)

-The existing Endpoint and SessionEndpoint configuration options should be marked as deprecated and alias the new option.

## Changeset

- Created new EndpointConfiguration.cs class and added the new field Endpoints to the config class
- Used the build in System.Uri class to validate the input of the constructor.
- Added a check to session tracking to not send sessions if the config is not valid and log a warning.
- Added a check to the client class to not send error events if the config is not valid, did not add a warning as this could lead to a loop if the notify level is configured to send warning logs as events.
- Added deprecation warnings for config.Endpoint and config.SessionEndpoint
- Made config.Endpoint and config.SessionEndpoint alias the new Endpoints class fields

## Testing

Added unit tests to check for config validation