### PR TITLE
task(config): new configuration option RedactedKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+* Add `RedactedKeys` configuration option to enable redacting specific keys in metadata [#367](https://github.com/bugsnag/bugsnag-unity/pull/367)
+
 * Add `Configuration.Endpoints` to enable setting custom endpoints for events and sessions [#366](https://github.com/bugsnag/bugsnag-unity/pull/366)
 
 * Add `ProjectPackages` config option to set the [native Android option](https://docs.bugsnag.com/platforms/android/configuration-options/#projectpackages) [#364](https://github.com/bugsnag/bugsnag-unity/pull/364)

--- a/features/android/android_jvm_errors.feature
+++ b/features/android/android_jvm_errors.feature
@@ -119,5 +119,6 @@ Feature: Android manual smoke tests
         And the event "app.versionCode" equals 1
         And the error payload field "events.0.app.duration" is not null
         And the error payload field "events.0.app.durationInForeground" is not null
-
+        And the event "metaData.User.test" equals "[REDACTED]"
+        And the event "metaData.User.password" equals "[REDACTED]"
  

--- a/features/desktop/handled_errors.feature
+++ b/features/desktop/handled_errors.feature
@@ -40,6 +40,14 @@ Feature: Handled Errors and Exceptions
         And the first significant stack frame methods and files should match:
             | Main.DoNotify()           |
 
+    Scenario: Redacted Keys
+        When I run the game in the "RedactedKeys" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the event "metaData.User.test" equals "[REDACTED]"
+        And the event "metaData.User.password" equals "[REDACTED]"
+
+
     Scenario: Reporting a handled exception with a callback
         When I run the game in the "NotifyCallback" state
         And I wait to receive an error

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -135,6 +135,9 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "RedactedKeys":
+                config.RedactedKeys = new string[] { "test", "password" };
+                break;
             case "CustomAppType":
                 config.AppType = "test";
                 break;
@@ -283,6 +286,10 @@ public class Main : MonoBehaviour
             case "NotifyOutsideNotifyReleaseStages":
                 DoNotify();
                 break;
+            case "RedactedKeys":
+                AddKeysForRedaction();
+                DoNotify();
+                break;
             case "NativeCrashOutsideNotifyReleaseStages":
                 crashy_signal_runner(8);
                 break;
@@ -414,6 +421,14 @@ public class Main : MonoBehaviour
                 throw new ArgumentException("Unable to run unexpected scenario: " + scenario);
                 break;
         }
+    }
+
+    private void AddKeysForRedaction()
+    {
+        Bugsnag.Metadata.Add("User", new Dictionary<string, string>() {
+                    {"test","test" },
+                    { "password","password" }
+                });
     }
 
     private void CheckEnabledErrorTypes()

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -55,6 +55,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         config.Context = "My context";
         config.AppVersion = "1.2.3";
         config.BundleVersion = "1.2.3";
+        config.RedactedKeys = new string[] { "test", "password" };
         return config;
     }
 
@@ -133,6 +134,8 @@ public class MobileScenarioRunner : MonoBehaviour {
             case "Max Breadcrumbs":
                 config.MaximumBreadcrumbs = 5;
                 break;
+            case "NDK signal":
+                break;
             case "Custom App Type":
                 config.AppType = "test";
                 break;
@@ -173,6 +176,7 @@ public class MobileScenarioRunner : MonoBehaviour {
                 ThrowException();
                 break;
             case "throw Exception with breadcrumbs":
+                AddMetadataForRedaction();
                 LeaveBreadcrumbString();
                 LeaveBreadcrumbTuple();
                 ThrowException();
@@ -182,6 +186,7 @@ public class MobileScenarioRunner : MonoBehaviour {
                 LogError();
                 break;
             case "Java Background Crash":
+                AddMetadataForRedaction();
                 MobileNative.TriggerBackgroundJavaCrash();
                 break;
             case "Native exception":
@@ -222,6 +227,14 @@ public class MobileScenarioRunner : MonoBehaviour {
             default:
                 throw new System.Exception("Unknown scenario: " + scenarioName);
         }
+    }
+
+    private void AddMetadataForRedaction()
+    {
+        Bugsnag.Metadata.Add("User", new Dictionary<string, string>() {
+                    {"test","test" },
+                    { "password","password" }
+                });
     }
 
     public void LeaveFiveBreadcrumbs()

--- a/features/ios/ios_csharp_errors.feature
+++ b/features/ios/ios_csharp_errors.feature
@@ -67,7 +67,9 @@ Feature: iOS smoke tests for C# errors
         And the event "metaData.device.osLanguage" is not null
         And the event "metaData.app.companyName" equals "bugsnag"
         And the event "metaData.app.name" equals "Mazerunner"
-
+        And the event "metaData.User.test" equals "[REDACTED]"
+        And the event "metaData.User.password" equals "[REDACTED]"
+        
         # Runtime versions
         And the error payload field "events.0.device.runtimeVersions.osBuild" is not null
         And the error payload field "events.0.device.runtimeVersions.unity" is not null

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -61,6 +61,8 @@ extern "C" {
 
   void bugsnag_setDiscardClasses(const void *configuration, const char *classNames[], int count);
 
+  void bugsnag_setRedactedKeys(const void *configuration, const char *redactedKeys[], int count);
+
 
   void bugsnag_setAppHangThresholdMillis(const void *configuration, NSUInteger appHangThresholdMillis);
 
@@ -225,6 +227,18 @@ void bugsnag_setDiscardClasses(const void *configuration, const char *classNames
     }
   }
   ((__bridge BugsnagConfiguration *)configuration).discardClasses = ns_classNames;
+}
+
+void bugsnag_setRedactedKeys(const void *configuration, const char *redactedKeys[], int count){
+  NSMutableSet *ns_redactedKeys = [NSMutableSet new];
+  for (int i = 0; i < count; i++) {
+    const char *key = redactedKeys[i];
+    if (key != nil) {
+      NSString *ns_key = [NSString stringWithUTF8String: key];
+      [ns_redactedKeys addObject: ns_key];
+    }
+  }
+  ((__bridge BugsnagConfiguration *)configuration).redactedKeys = ns_redactedKeys;
 }
 
 void bugsnag_setAutoNotifyConfig(const void *configuration, bool autoNotify) {

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -284,6 +284,8 @@ namespace BugsnagUnity
                 metadata.AddToPayload(item.Key, item.Value);
             }
 
+            CheckMetadaForRedactedKeys(metadata);
+
             var @event = new Payload.Event(
               Configuration.Context,
               metadata,
@@ -332,6 +334,36 @@ namespace BugsnagUnity
                 Breadcrumbs.Leave(Breadcrumb.FromReport(report));
 
                 SessionTracking.AddException(report);
+            }
+        }
+
+        private void CheckMetadaForRedactedKeys(Metadata metadata)
+        {
+            foreach (var section in metadata)
+            {
+                var sectionDictionaryType = section.Value.GetType();
+                if (sectionDictionaryType == typeof(Dictionary<string, object>))
+                {
+                    var theSection = (Dictionary<string, object>)section.Value;
+                    foreach (var key in theSection.Keys.ToList())
+                    {
+                        if (Configuration.KeyIsRedacted(key))
+                        {
+                            theSection[key] = "[REDACTED]";
+                        }
+                    }
+                }
+                if (sectionDictionaryType == typeof(Dictionary<string, string>))
+                {
+                    var theSection = (Dictionary<string, string>)section.Value;
+                    foreach (var key in theSection.Keys.ToList())
+                    {
+                        if (Configuration.KeyIsRedacted(key))
+                        {
+                            theSection[key] = "[REDACTED]";
+                        }
+                    }
+                }
             }
         }
 

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -302,7 +302,7 @@ namespace BugsnagUnity
                 metadata.AddToPayload(item.Key, item.Value);
             }
 
-            CheckMetadaForRedactedKeys(metadata);
+            RedactMetadata(metadata);
 
             var @event = new Payload.Event(
               Configuration.Context,
@@ -355,7 +355,7 @@ namespace BugsnagUnity
             }
         }
 
-        private void CheckMetadaForRedactedKeys(Metadata metadata)
+        private void RedactMetadata(Metadata metadata)
         {
             foreach (var section in metadata)
             {

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -16,6 +16,24 @@ namespace BugsnagUnity
 
         public string AppType { get; set; }
 
+        public string[] RedactedKeys { get; set; } = new string[] { "password" };
+
+        public bool KeyIsRedacted(string key)
+        {
+            if (RedactedKeys == null || RedactedKeys.Length == 0)
+            {
+                return false;
+            }
+            foreach (var redactedKey in RedactedKeys)
+            {
+                if (key.ToLower() == redactedKey.ToLower())
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         public Configuration(string apiKey)
         {
             ApiKey = apiKey;

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -15,6 +15,10 @@ namespace BugsnagUnity
 
         string[] ProjectPackages { get; set; }
 
+        string[] RedactedKeys { get; set; }
+
+        bool KeyIsRedacted(string key);
+
         bool ErrorClassIsDiscarded(string className);
 
         ErrorTypes[] EnabledErrorTypes { get; set; }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -193,24 +193,6 @@ namespace BugsnagUnity
                 obj.Call("setEndpoints", endpointConfig);
             }
 
-            // set release stages
-            obj.Call("setReleaseStage", config.ReleaseStage);
-
-            if (config.NotifyReleaseStages != null)
-            {
-                using (AndroidJavaObject releaseStages = new AndroidJavaObject("java.util.HashSet"))
-                {
-                    foreach (var element in config.NotifyReleaseStages)
-                    {
-                        using (AndroidJavaObject stage = BuildJavaStringDisposable(element))
-                        {
-                            releaseStages.Call<Boolean>("add", stage);
-                        }
-                    }
-                    obj.Call("setEnabledReleaseStages", releaseStages);
-                }
-            }
-
             // set version/context/maxbreadcrumbs/AppType
             obj.Call("setAppVersion", config.AppVersion);
             obj.Call("setContext", config.Context);
@@ -241,32 +223,30 @@ namespace BugsnagUnity
                 }
             }
 
+            // set release stages
+            obj.Call("setReleaseStage", config.ReleaseStage);
+
+            if (config.NotifyReleaseStages != null)
+            {
+                obj.Call("setEnabledReleaseStages", GetAndroidStringSetFromArray(config.NotifyReleaseStages));
+            }
+
             // set DiscardedClasses
             if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
             {
-
-                using (AndroidJavaObject discardClasses = new AndroidJavaObject("java.util.HashSet"))
-                {
-                    foreach (var className in config.DiscardClasses)
-                    {
-                        discardClasses.Call<Boolean>("add", className);
-                    }
-                    obj.Call("setDiscardClasses", discardClasses);
-                }
+                obj.Call("setDiscardClasses", GetAndroidStringSetFromArray(config.DiscardClasses));
             }
 
             // set ProjectPackages
             if (config.ProjectPackages != null && config.ProjectPackages.Length > 0)
             {
+                obj.Call("setProjectPackages", GetAndroidStringSetFromArray(config.ProjectPackages));
+            }
 
-                using (AndroidJavaObject projectPackages = new AndroidJavaObject("java.util.HashSet"))
-                {
-                    foreach (var packageName in config.ProjectPackages)
-                    {
-                        projectPackages.Call<Boolean>("add", packageName);
-                    }
-                    obj.Call("setProjectPackages", projectPackages);
-                }
+            // set redacted keys
+            if (config.RedactedKeys != null && config.RedactedKeys.Length > 0)
+            {
+                obj.Call("setRedactedKeys", GetAndroidStringSetFromArray(config.RedactedKeys));
             }
 
             // add unity event callback
@@ -274,6 +254,16 @@ namespace BugsnagUnity
             obj.Call("addOnError", BugsnagUnity.CallStatic<AndroidJavaObject>("getNativeCallback", new object[] { }));
 
             return obj;
+        }
+
+        private AndroidJavaObject GetAndroidStringSetFromArray(string[] array)
+        {
+            AndroidJavaObject set = new AndroidJavaObject("java.util.HashSet");
+            foreach (var item in array)
+            {
+                set.Call<Boolean>("add", item);
+            }
+            return set;
         }
 
         private void ConfigureNotifierInfo(AndroidJavaObject client)

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -40,6 +40,10 @@ namespace BugsnagUnity
             {
                 NativeCode.bugsnag_setDiscardClasses(obj, config.DiscardClasses, config.DiscardClasses.Length);
             }
+            if (config.RedactedKeys != null && config.RedactedKeys.Length > 0)
+            {
+                NativeCode.bugsnag_setRedactedKeys(obj, config.RedactedKeys, config.RedactedKeys.Length);
+            }
             if (config.AppHangThresholdMillis > 0)
             {
                 NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -64,6 +64,9 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setDiscardClasses(IntPtr configuration, string[] classNames, int count);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_setRedactedKeys(IntPtr configuration, string[] redactedKeys, int count);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_setContextConfig(IntPtr configuration, string context);
 
         [DllImport(Import)]


### PR DESCRIPTION
## Goal

Setup metadata key redaction for the fallback/Windows and send the value through to iOS and Android

## Changeset

- Added RedactedKeys array to the config class
- Check for redacted keys in the client before serialising an event (as specificed by the notifier spec)
- Pass the value through to android and iOS

## Testing

Manually and added CI tests