### PR TITLE
task(config): add new configuration option EnabledReleaseStages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@
 
 * `Configuration.Endpoint` has been deprecated in favour of the new `Configuration.Endpoints` class and will be removed in the next major release.
 
-* `Configuration.SessionEndpoint` has been deprecated in favour of the new `Configuration.Endpoints` class and will be removed in the next major release.    
+* `Configuration.SessionEndpoint` has been deprecated in favour of the new `Configuration.Endpoints` class and will be removed in the next major release.   
+
+* `Configuration.NotifyReleaseStages` has been deprecated in favour of `Configuration.EnabledReleaseStages` and will be removed in the next major release. 
 
 ## 5.2.0 (2021-08-04)
 

--- a/features/android/android_release_stages.feature
+++ b/features/android/android_release_stages.feature
@@ -1,0 +1,20 @@
+Feature: Release stages
+
+    Background:
+        Given I wait for the mobile game to start
+
+    Scenario: Release stage enabled
+        When I run the "Enabled Release Stage" mobile scenario
+        And I wait for 8 seconds
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I wait to receive 1 error
+        And the event "app.releaseStage" equals "test"
+
+    Scenario: Release stage Disabled
+        When I run the "Disabled Release Stage" mobile scenario
+        And I wait for 8 seconds
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I should receive no errors
+

--- a/features/desktop/release_stages.feature
+++ b/features/desktop/release_stages.feature
@@ -1,0 +1,19 @@
+Feature: Enabled and disabled release stages
+
+    Scenario: Enable custom release stage
+        When I run the game in the "EnabledReleaseStage" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "Exception"
+        And the exception "message" equals "blorb"
+        And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main.DoNotify()      |
+            | Main.RunScenario(string scenario)  |
+            | Main.Start()        |
+
+   
+Scenario: Disable custom release stage
+        When I run the game in the "DisabledReleaseStage" state
+        Then I should receive no errors

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -135,6 +135,14 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "DisabledReleaseStage":
+                config.EnabledReleaseStages = new string[] { "test" };
+                config.ReleaseStage = "somevalue";
+                break;
+            case "EnabledReleaseStage":
+                config.EnabledReleaseStages = new string[] { "test" };
+                config.ReleaseStage =  "test";
+                break;
             case "RedactedKeys":
                 config.RedactedKeys = new string[] { "test", "password" };
                 break;
@@ -254,6 +262,10 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "DisabledReleaseStage":
+            case "EnabledReleaseStage":
+                DoNotify();
+                break;
             case "CustomAppType":
                 DoNotify();
                 break;

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -31,6 +31,10 @@ public class MobileScenarioRunner : MonoBehaviour {
         {"15", "Discard Error Class" },
         {"16", "Java Background Crash" },
         {"17", "Custom App Type" },
+        {"18", "Disabled Release Stage" },
+        {"19", "Enabled Release Stage" },
+
+
 
 
         // Commands
@@ -116,6 +120,14 @@ public class MobileScenarioRunner : MonoBehaviour {
 
         switch (scenarioName)
         {
+            case "Disabled Release Stage":
+                config.EnabledReleaseStages = new string[] { "test" };
+                config.ReleaseStage = "somevalue";
+                break;
+            case "Enabled Release Stage":
+                config.EnabledReleaseStages = new string[] { "test" };
+                config.ReleaseStage = "test";
+                break;
             case "Java Background Crash":
             case "Native exception":
                 config.ProjectPackages = new string[] { "test.test.test" };
@@ -160,6 +172,14 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         switch (scenarioName)
         {
+            case "Disabled Release Stage":
+            case "Enabled Release Stage":
+#if UNITY_ANDROID
+                MobileNative.TriggerBackgroundJavaCrash();
+#elif UNITY_IOS
+                NativeException();
+#endif  
+                break;
             case "Custom App Type":
                 ThrowException();
                 break;

--- a/features/ios/ios_release_stages.feature
+++ b/features/ios/ios_release_stages.feature
@@ -1,0 +1,21 @@
+Feature: Release stages
+
+    Background:
+        Given I wait for the mobile game to start
+        And I clear all persistent data
+
+    Scenario: Release stage enabled
+        When I run the "Enabled Release Stage" mobile scenario
+        And I wait for 8 seconds
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I wait to receive 1 error
+        And the event "app.releaseStage" equals "test"
+
+    Scenario: Release stage Disabled
+        When I run the "Disabled Release Stage" mobile scenario
+        And I wait for 8 seconds
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I should receive no errors
+

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -40,6 +40,8 @@ def dial_number_for(name)
       "Discard Error Class" => 15,
       "Java Background Crash" => 16,
       "Custom App Type" => 17,
+      "Disabled Release Stage" => 18,
+      "Enabled Release Stage" => 19,
 
 
       # Commands

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -433,8 +433,8 @@ namespace BugsnagUnity
         private bool ShouldSendRequests()
         {
             return Configuration.ReleaseStage == null
-                || Configuration.NotifyReleaseStages == null
-                || Configuration.NotifyReleaseStages.Contains(Configuration.ReleaseStage);
+                || Configuration.EnabledReleaseStages == null
+                || Configuration.EnabledReleaseStages.Contains(Configuration.ReleaseStage);
         }
 
         /// <summary>

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -98,7 +98,31 @@ namespace BugsnagUnity
 
         public virtual string ReleaseStage { get; set; } = "production";
 
-        public virtual string[] NotifyReleaseStages { get; set; }
+        private string[] _enabledReleaseStages;
+
+        [Obsolete("NotifyReleaseStages is deprecated, please use Configuration.EnabledReleaseStages instead.", false)]
+        public virtual string[] NotifyReleaseStages {
+            get
+            {
+                return _enabledReleaseStages;
+            }
+            set
+            {
+                _enabledReleaseStages = value;
+            }
+        }
+
+        public virtual string[] EnabledReleaseStages
+        {
+            get
+            {
+                return _enabledReleaseStages;
+            }
+            set
+            {
+                _enabledReleaseStages = value;
+            }
+        }
 
         public virtual string[] ProjectPackages { get; set; }
 

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -45,7 +45,7 @@ namespace BugsnagUnity
 
         string ReleaseStage { get; set; }
 
-        string[] NotifyReleaseStages { get; set; }
+        string[] EnabledReleaseStages { get; set; }
 
         string AppVersion { get; set; }
 

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -226,9 +226,9 @@ namespace BugsnagUnity
             // set release stages
             obj.Call("setReleaseStage", config.ReleaseStage);
 
-            if (config.NotifyReleaseStages != null)
+            if (config.EnabledReleaseStages != null && config.EnabledReleaseStages.Length > 0)
             {
-                obj.Call("setEnabledReleaseStages", GetAndroidStringSetFromArray(config.NotifyReleaseStages));
+                obj.Call("setEnabledReleaseStages", GetAndroidStringSetFromArray(config.EnabledReleaseStages));
             }
 
             // set DiscardedClasses

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -54,8 +54,8 @@ namespace BugsnagUnity
             {
                 NativeCode.bugsnag_setContextConfig(obj, config.Context);
             }
-            var releaseStages = config.NotifyReleaseStages;
-            if (releaseStages != null)
+            var releaseStages = config.EnabledReleaseStages;
+            if (releaseStages != null && releaseStages.Length > 0)
             {
                 NativeCode.bugsnag_setNotifyReleaseStages(obj, releaseStages, releaseStages.Length);
             }


### PR DESCRIPTION
## Goal

New configuration option: EnabledReleaseStages

The existing NotifyReleaseStages configuration option should be marked as deprecated and alias the new option.

## Changeset

- added deprecation warning NotifyReleaseStages and made it alias new field EnabledReleaseStages 
- updated all usages of NotifyReleaseStages in the intenal code to use EnabledReleaseStages

## Testing

Manually and added CI tests for fallback, Android and windows