### PR TITLE
task(config): add new configuration option: MaxPersistedEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+* Add `MaxPersistedEvents ` config option to set the [native Android option](https://docs.bugsnag.com/platforms/android/configuration-options/#maxpersistedevents) and the [native Cocoa option](https://docs.bugsnag.com/platforms/ios/configuration-options/#maxpersistedevents) [#371](https://github.com/bugsnag/bugsnag-unity/pull/371)
+
 * Add `RedactedKeys` configuration option to enable redacting specific keys in metadata [#367](https://github.com/bugsnag/bugsnag-unity/pull/367)
 
 * Add `Configuration.Endpoints` to enable setting custom endpoints for events and sessions [#366](https://github.com/bugsnag/bugsnag-unity/pull/366)

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -40,7 +40,6 @@ extern "C" {
   void bugsnag_setEnabledBreadcrumbTypes(const void *configuration, const char *types[], int count);
 
   void bugsnag_setMaxPersistedEvents(const void *configuration, int maxPersistedEvents);
-  void bugsnag_setMaxPersistedSessions(const void *configuration, int maxPersistedSessions);
 
 
   void bugsnag_setNotifyUrl(const void *configuration, char *notifyURL);
@@ -133,10 +132,6 @@ void bugsnag_setMaxBreadcrumbs(const void *configuration, int maxBreadcrumbs) {
 
 void bugsnag_setMaxPersistedEvents(const void *configuration, int maxPersistedEvents) {
   ((__bridge BugsnagConfiguration *)configuration).maxPersistedEvents = maxPersistedEvents;
-}
-
-void bugsnag_setMaxPersistedSessions(const void *configuration, int maxPersistedSessions) {
-  ((__bridge BugsnagConfiguration *)configuration).maxPersistedSessions = maxPersistedSessions;
 }
 
 void bugsnag_setEnabledBreadcrumbTypes(const void *configuration, const char *types[], int count){

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -39,6 +39,10 @@ extern "C" {
   void bugsnag_setMaxBreadcrumbs(const void *configuration, int maxBreadcrumbs);
   void bugsnag_setEnabledBreadcrumbTypes(const void *configuration, const char *types[], int count);
 
+  void bugsnag_setMaxPersistedEvents(const void *configuration, int maxPersistedEvents);
+  void bugsnag_setMaxPersistedSessions(const void *configuration, int maxPersistedSessions);
+
+
   void bugsnag_setNotifyUrl(const void *configuration, char *notifyURL);
 
   void bugsnag_setMetadata(const void *configuration, const char *tab, const char *metadata[], int metadataCount);
@@ -125,6 +129,14 @@ void bugsnag_setContextConfig(const void *configuration, char *context) {
 
 void bugsnag_setMaxBreadcrumbs(const void *configuration, int maxBreadcrumbs) {
   ((__bridge BugsnagConfiguration *)configuration).maxBreadcrumbs = maxBreadcrumbs;
+}
+
+void bugsnag_setMaxPersistedEvents(const void *configuration, int maxPersistedEvents) {
+  ((__bridge BugsnagConfiguration *)configuration).maxPersistedEvents = maxPersistedEvents;
+}
+
+void bugsnag_setMaxPersistedSessions(const void *configuration, int maxPersistedSessions) {
+  ((__bridge BugsnagConfiguration *)configuration).maxPersistedSessions = maxPersistedSessions;
 }
 
 void bugsnag_setEnabledBreadcrumbTypes(const void *configuration, const char *types[], int count){

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -259,8 +259,6 @@ namespace BugsnagUnity
 
         public int MaxPersistedEvents { get; set; } = 32;
 
-        public int MaxPersistedSessions { get; set; } = 128;
-
         public virtual bool ErrorClassIsDiscarded(string className)
         {
             return DiscardClasses != null && DiscardClasses.Contains(className);

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -257,6 +257,10 @@ namespace BugsnagUnity
 
         public string[] DiscardClasses { get; set; }
 
+        public int MaxPersistedEvents { get; set; } = 32;
+
+        public int MaxPersistedSessions { get; set; } = 128;
+
         public virtual bool ErrorClassIsDiscarded(string className)
         {
             return DiscardClasses != null && DiscardClasses.Contains(className);

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -17,6 +17,10 @@ namespace BugsnagUnity
 
         string[] RedactedKeys { get; set; }
 
+        int MaxPersistedEvents { get; set; }
+
+        int MaxPersistedSessions { get; set; }
+
         bool KeyIsRedacted(string key);
 
         bool ErrorClassIsDiscarded(string className);

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -19,8 +19,6 @@ namespace BugsnagUnity
 
         int MaxPersistedEvents { get; set; }
 
-        int MaxPersistedSessions { get; set; }
-
         bool KeyIsRedacted(string key);
 
         bool ErrorClassIsDiscarded(string className);

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -193,10 +193,14 @@ namespace BugsnagUnity
                 obj.Call("setEndpoints", endpointConfig);
             }
 
-            // set version/context/maxbreadcrumbs/AppType
+            // set version/context/maxbreadcrumbs/AppType/maxPersistedEvents/maxPersistedSessions
             obj.Call("setAppVersion", config.AppVersion);
             obj.Call("setContext", config.Context);
             obj.Call("setMaxBreadcrumbs", config.MaximumBreadcrumbs);
+            obj.Call("setMaxPersistedEvents", config.MaxPersistedEvents);
+            obj.Call("setMaxPersistedSessions", config.MaxPersistedSessions);
+
+
 
             //Null or empty check necessary because android will set the app.type to empty if that or null is passed as default
             if (!string.IsNullOrEmpty(config.AppType))

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -198,7 +198,6 @@ namespace BugsnagUnity
             obj.Call("setContext", config.Context);
             obj.Call("setMaxBreadcrumbs", config.MaximumBreadcrumbs);
             obj.Call("setMaxPersistedEvents", config.MaxPersistedEvents);
-            obj.Call("setMaxPersistedSessions", config.MaxPersistedSessions);
 
 
 

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -36,6 +36,8 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
             NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
             NativeCode.bugsnag_setAppType(obj, config.AppType);
+            NativeCode.bugsnag_setMaxPersistedEvents(obj, config.MaxPersistedEvents);
+            NativeCode.bugsnag_setMaxPersistedSessions(obj,config.MaxPersistedSessions);
             if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
             {
                 NativeCode.bugsnag_setDiscardClasses(obj, config.DiscardClasses, config.DiscardClasses.Length);

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -37,7 +37,6 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
             NativeCode.bugsnag_setAppType(obj, config.AppType);
             NativeCode.bugsnag_setMaxPersistedEvents(obj, config.MaxPersistedEvents);
-            NativeCode.bugsnag_setMaxPersistedSessions(obj,config.MaxPersistedSessions);
             if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
             {
                 NativeCode.bugsnag_setDiscardClasses(obj, config.DiscardClasses, config.DiscardClasses.Length);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -52,6 +52,12 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setMaxBreadcrumbs(IntPtr configuration, int maxBreadcrumbs);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_setMaxPersistedEvents(IntPtr configuration, int maxPersistedEvents);
+
+        [DllImport(Import)]
+        internal static extern void bugsnag_setMaxPersistedSessions(IntPtr configuration, int maxPersistedSessions);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_setAppHangThresholdMillis(IntPtr configuration, ulong appHangThresholdMillis);
 
         [DllImport(Import)]

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -55,9 +55,6 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setMaxPersistedEvents(IntPtr configuration, int maxPersistedEvents);
 
         [DllImport(Import)]
-        internal static extern void bugsnag_setMaxPersistedSessions(IntPtr configuration, int maxPersistedSessions);
-
-        [DllImport(Import)]
         internal static extern void bugsnag_setAppHangThresholdMillis(IntPtr configuration, ulong appHangThresholdMillis);
 
         [DllImport(Import)]


### PR DESCRIPTION
## Goal

New configuration option MaxPersistedEvents to control the maximum number of persisted event files and also to set the native Cocoa and android options

## Changeset

- Added MaxPersistedEvents field to the config class and interface
- Passed the value through to Android and cocoa on init

## Testing

Manually tested on device. CI testes will be added when persistence is added to the unity layer