### PR TITLE
task(config): new configuration option PersistUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+* Add `PersistUser ` config option to set the [native Android option](https://docs.bugsnag.com/platforms/android/configuration-options/#persistuser) and the [native Cocoa option](https://docs.bugsnag.com/platforms/ios/configuration-options/#persistuser) [#372](https://github.com/bugsnag/bugsnag-unity/pull/372)
+
 * Add `RedactedKeys` configuration option to enable redacting specific keys in metadata [#367](https://github.com/bugsnag/bugsnag-unity/pull/367)
 
 * Add `Configuration.Endpoints` to enable setting custom endpoints for events and sessions [#366](https://github.com/bugsnag/bugsnag-unity/pull/366)

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -25,6 +25,8 @@ extern "C" {
 
   void bugsnag_setAppVersion(const void *configuration, char *appVersion);
 
+  void bugsnag_setPersistUser(const void *configuration, bool persistUser);
+
   void bugsnag_setAutoNotifyConfig(const void *configuration, bool autoNotify);
 
   void bugsnag_setAutoNotify(bool autoNotify);
@@ -243,6 +245,10 @@ void bugsnag_setRedactedKeys(const void *configuration, const char *redactedKeys
 
 void bugsnag_setAutoNotifyConfig(const void *configuration, bool autoNotify) {
   ((__bridge BugsnagConfiguration *)configuration).autoDetectErrors = autoNotify;
+}
+
+void bugsnag_setPersistUser(const void *configuration, bool persistUser) {
+  ((__bridge BugsnagConfiguration *)configuration).persistUser = persistUser;
 }
 
 void bugsnag_setAutoNotify(bool autoNotify) {

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -15,6 +15,8 @@ namespace BugsnagUnity
 
         public string[] RedactedKeys { get; set; } = new string[] { "password" };
 
+        public bool PersistUser { get; set; }
+
         public bool KeyIsRedacted(string key)
         {
             if (RedactedKeys == null || RedactedKeys.Length == 0)

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -17,6 +17,8 @@ namespace BugsnagUnity
 
         string[] RedactedKeys { get; set; }
 
+        bool PersistUser { get; set; }
+
         bool KeyIsRedacted(string key);
 
         bool ErrorClassIsDiscarded(string className);

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -193,10 +193,11 @@ namespace BugsnagUnity
                 obj.Call("setEndpoints", endpointConfig);
             }
 
-            // set version/context/maxbreadcrumbs/AppType
+            // set version/context/maxbreadcrumbs/AppType/PersistUser
             obj.Call("setAppVersion", config.AppVersion);
             obj.Call("setContext", config.Context);
             obj.Call("setMaxBreadcrumbs", config.MaximumBreadcrumbs);
+            obj.Call("setPersistUser",config.PersistUser);
 
             //Null or empty check necessary because android will set the app.type to empty if that or null is passed as default
             if (!string.IsNullOrEmpty(config.AppType))

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -36,6 +36,7 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
             NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
             NativeCode.bugsnag_setAppType(obj, config.AppType);
+            NativeCode.bugsnag_setPersistUser(obj,config.PersistUser);
             if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
             {
                 NativeCode.bugsnag_setDiscardClasses(obj, config.DiscardClasses, config.DiscardClasses.Length);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -43,7 +43,10 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setAutoNotify(bool autoNotify);
 
         [DllImport(Import)]
-        internal static extern void bugsnag_setAutoNotifyConfig(IntPtr configuration, bool autoNotify);       
+        internal static extern void bugsnag_setAutoNotifyConfig(IntPtr configuration, bool autoNotify);
+
+        [DllImport(Import)]
+        internal static extern void bugsnag_setPersistUser(IntPtr configuration, bool persistUser);
 
         [DllImport(Import)]
         internal static extern void bugsnag_setContext(IntPtr configuration, string context);


### PR DESCRIPTION
## Goal

New configuration option PersistUser to set the fallback, native Cocoa and android values

## Changeset

- Added  to the config class and interface
- Pass the value through to Cocoa and Android

## Testing

Manually tested, full CI tests will be added when unity persistance layer is added