### PR TITLE
refac(tests): make the test for android custom persistence directory safer

### DIFF
--- a/features/android/android_custom_configs.feature
+++ b/features/android/android_custom_configs.feature
@@ -6,6 +6,8 @@ Feature: Android custom config setting
     Scenario: Android Persistence Directory
         When I run the "Android Persistence Directory" mobile scenario
         Then I wait to receive an error
+        And the exception "message" equals "Directory Found"
+
 
      Scenario: Custom App Type
         When I run the "Custom App Type" mobile scenario

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -279,7 +279,7 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         if (Directory.Exists(Application.persistentDataPath + "/myBugsnagCache"))
         {
-            ThrowException();
+            throw new System.Exception("Directory Found");
         }
     }
 


### PR DESCRIPTION
Changed the test to expect a particular exception message so that it only passes when the correct exception is thrown