### PR TITLE
task(context): make Context a writable property of the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
     
 ### Deprecated
 
+* `Bugsnag.SetContext(string context)` has been deprecated in favour of the new `Bugsnag.Context` property and will be removed in the next major release.
+
 * `Configuration.Endpoint` has been deprecated in favour of the new `Configuration.Endpoints` class and will be removed in the next major release.
 
 * `Configuration.SessionEndpoint` has been deprecated in favour of the new `Configuration.Endpoints` class and will be removed in the next major release.   

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -542,7 +542,7 @@ public class Main : MonoBehaviour
 
     IEnumerator SetManualContextReloadSceneAndNotify()
     {
-        Bugsnag.SetContext("Manually-Set");
+        Bugsnag.Context = "Manually-Set";
         SceneManager.LoadScene(0);
         yield return new WaitForSeconds(0.5f);
         Bugsnag.Notify(new System.Exception("ManualContext"));

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -81,12 +81,30 @@ namespace BugsnagUnity
         /// <summary>
         /// Bugsnag uses the concept of contexts to help display and group your errors.
         /// Contexts represent what was happening in your game at the time an error
-        /// occurs. By default, this will be set to be your currently active Unity Scene.
+        /// occurs. Unless manually set, this will be automatically set to be your currently active Unity Scene.
         /// </summary>
         /// <param name="context"></param>
+        [Obsolete("SetContext is deprecated, please use the property Bugsnag.Context instead.", false)]
         public static void SetContext(string context)
         {
             Client.SetContext(context);
+        }
+
+        /// <summary>
+        /// Bugsnag uses the concept of contexts to help display and group your errors.
+        /// Contexts represent what was happening in your game at the time an error
+        /// occurs. Unless manually set, this will be automatically set to be your currently active Unity Scene.
+        /// </summary>
+        public static string Context
+        {
+            get
+            {
+                return Client.GetContext();
+            }
+            set
+            {
+                Client.SetContext(value);
+            }
         }
 
         /// <summary>

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -461,6 +461,11 @@ namespace BugsnagUnity
             NativeClient.SetContext(context);
         }
 
+        public string GetContext()
+        {
+            return Configuration.Context;
+        }
+
         public void SetAutoDetectErrors(bool autoDetectErrors)
         {
             // set the property on Configuration, as it currently controls whether C# errors are reported

--- a/src/BugsnagUnity/IClient.cs
+++ b/src/BugsnagUnity/IClient.cs
@@ -38,6 +38,8 @@ namespace BugsnagUnity
 
         void SetContext(string context);
 
+        string GetContext();
+
         void SetAutoDetectErrors(bool AutoDetectErrors);
 
         void SetAutoDetectAnrs(bool autoDetectAnrs);


### PR DESCRIPTION
## Goal

make Context a writable property of the client and Deprecate `Bugsnag.SetContext(string context)`

## Changeset

- Added new static string Bugsnag.Context property that calles the internal client methods SetContext and SetContext
- added deprecation warning to the existing SetContext method 

## Testing

Existing CI tests were updated for this new property