### PR TITLE
task(launchErrors): add support for reporting mobile crashes on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Enhancements
 
+* Add `Bugsnag.GetLastRunInfo()` To get relevant crash information regarding the last run of the application [#379](https://github.com/bugsnag/bugsnag-unity/pull/379)
+
+* Add `Configuration.SendLaunchCrashesSynchronously` config option to set the [native Android option](https://docs.bugsnag.com/platforms/android/configuration-options/#launchdurationmillis) and the [native Cocoa option](https://docs.bugsnag.com/platforms/ios/configuration-options/#launchdurationmillis) [#379](https://github.com/bugsnag/bugsnag-unity/pull/379)
+
+* Add `Configuration.LaunchDurationMillis` config option to set the [native Android option](https://docs.bugsnag.com/platforms/android/configuration-options/#sendlaunchcrashessynchronously) and the [native Cocoa option](https://docs.bugsnag.com/platforms/ios/configuration-options/#sendlaunchcrashessynchronously) [#379](https://github.com/bugsnag/bugsnag-unity/pull/379)
+
 * Add `Configuration.VersionCode` config option to set the [native Android option](https://docs.bugsnag.com/platforms/android/configuration-options/#versioncode) [#373](https://github.com/bugsnag/bugsnag-unity/pull/373)
 
 * Add `Configuration.PersistenceDirectory` to set the [native Android option](https://docs.bugsnag.com/platforms/android/configuration-options/#persistencedirectory) [#368](https://github.com/bugsnag/bugsnag-unity/pull/368)

--- a/features/android/android_csharp_errors.feature
+++ b/features/android/android_csharp_errors.feature
@@ -113,6 +113,8 @@ Feature: Android smoke tests for C# errors
         And the error payload field "events.0.app.duration" is not null
         And the error payload field "events.0.app.durationInForeground" is not null
         And the event "app.inForeground" equals "true"
+        And the event "app.isLaunching" equals "true"
+
         And the error payload field "events.0.app.memoryUsage" is not null
         And the event "app.name" equals "Mazerunner"
         And the event "app.lowMemory" equals "false"
@@ -163,5 +165,16 @@ Feature: Android smoke tests for C# errors
         And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null
         And the error payload field "events.0.device.runtimeVersions.osBuild" is not null
         And the error payload field "events.0.device.runtimeVersions.unity" is not null
+
+     Scenario: Mark Launch Complete
+        When I run the "Mark Launch Complete" mobile scenario
+        Then I wait to receive an error
+
+        # Exception details
+        And the error payload field "events" is an array with 1 elements
+        And the exception "errorClass" equals "Exception"
+        And the exception "message" equals "You threw an exception!"
+        And the event "app.isLaunching" equals "false"
+
 
     

--- a/features/android/android_jvm_errors.feature
+++ b/features/android/android_jvm_errors.feature
@@ -131,4 +131,14 @@ Feature: Android manual smoke tests
         Then I wait to receive an error
         And the error payload field "events.0.threads.0" is null
 
+    Scenario: Last Run Info
+        When I run the "Java Background Crash" mobile scenario
+        And I wait for 8 seconds
+        And I relaunch the Unity mobile app
+        When I run the "Check Last Run Info" mobile scenario
+        Then I wait to receive 2 errors
+        And I discard the oldest error
+        And the exception "message" equals "Last Run Info Correct"
+        
+
  

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -38,6 +38,8 @@ public class MobileScenarioRunner : MonoBehaviour {
         {"21", "Java Background Crash No Threads" },
         {"22", "iOS Native Error" },
         {"23", "iOS Native Error No Threads" },
+        {"24", "Mark Launch Complete" },
+        {"25", "Check Last Run Info" },
 
 
 
@@ -186,6 +188,13 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         switch (scenarioName)
         {
+            case "Check Last Run Info":
+                CheckLastRunInfo();
+                break;
+            case "Mark Launch Complete":
+                Bugsnag.MarkLaunchCompleted();
+                ThrowException();
+                break;
             case "Android Persistence Directory":
                 CheckForCustomAndroidDir();
                 break;
@@ -264,6 +273,15 @@ public class MobileScenarioRunner : MonoBehaviour {
                 break;
             default:
                 throw new System.Exception("Unknown scenario: " + scenarioName);
+        }
+    }
+
+    private void CheckLastRunInfo()
+    {
+        var info = Bugsnag.GetLastRunInfo();
+        if (info.Crashed && info.CrashedDuringLaunch && info.ConsecutiveLaunchCrashes > 0)
+        {
+            Bugsnag.Notify(new System.Exception("Last Run Info Correct"));
         }
     }
 

--- a/features/ios/ios_csharp_errors.feature
+++ b/features/ios/ios_csharp_errors.feature
@@ -30,6 +30,8 @@ Feature: iOS smoke tests for C# errors
         And the event "app.type" equals "iOS"
         And the event "app.version" equals "1.2.3"
         And the event "app.bundleVersion" equals "1.2.3"
+        And the event "app.isLaunching" equals "true"
+
 #        And the event "app.versionCode" equals "1"
 #        And the error payload field "events.0.app.durationInForeground" is greater than 0
 #        And the event "app.inForeground" equals "true"
@@ -78,3 +80,14 @@ Feature: iOS smoke tests for C# errors
         When I run the "Custom App Type" mobile scenario
         Then I wait to receive an error
         And the event "app.type" equals "test"
+
+    Scenario: Mark Launch Complete
+        When I run the "Mark Launch Complete" mobile scenario
+        Then I wait to receive an error
+
+        # Exception details
+        And the error payload field "events" is an array with 1 elements
+        And the exception "errorClass" equals "Exception"
+        And the exception "message" equals "You threw an exception!"
+        And the event "app.isLaunching" equals "false"
+

--- a/features/ios/ios_native_errors.feature
+++ b/features/ios/ios_native_errors.feature
@@ -27,3 +27,11 @@ Feature: Native Errors
         Then I wait to receive an error
         And the error payload field "events.0.threads.0" is null
 
+    Scenario: Last Run Info
+        When I run the "iOS Native Error" mobile scenario
+        And I wait for 2 seconds
+        And I relaunch the Unity mobile app
+        When I run the "Check Last Run Info" mobile scenario
+        Then I wait to receive 2 errors
+        And I discard the oldest error
+        And the exception "message" equals "Last Run Info Correct"

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -46,6 +46,10 @@ def dial_number_for(name)
       "Java Background Crash No Threads" => 21,
       "iOS Native Error" => 22,
       "iOS Native Error No Threads" => 23,
+      "Mark Launch Complete" => 24,
+      "Check Last Run Info" => 25,
+
+
 
 
 
@@ -162,7 +166,7 @@ end
 
 Then("the error is valid for the error reporting API sent by the native Unity notifier") do
   # This step currently only applies to native errors on macOS macOS
-  check_error_reporting_api 'OSX Bugsnag Notifier'
+  check_error_reporting_api 'Bugsnag Unity (Cocoa)'
 end
 
 Then("the error is valid for the error reporting API sent by the Unity notifier") do

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -166,7 +166,7 @@ end
 
 Then("the error is valid for the error reporting API sent by the native Unity notifier") do
   # This step currently only applies to native errors on macOS macOS
-  check_error_reporting_api 'Bugsnag Unity (Cocoa)'
+  check_error_reporting_api 'OSX Bugsnag Notifier'
 end
 
 Then("the error is valid for the error reporting API sent by the Unity notifier") do

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -139,5 +139,21 @@ namespace BugsnagUnity
             Client.SetAutoDetectAnrs(autoDetectAnrs);
         }
 
+        /// <summary>
+        /// Setting Configuration.LaunchDurationMillis to 0 will cause Bugsnag to consider the app to be launching until Bugsnag.MarkLaunchCompleted() has been called.
+        /// </summary>
+        public static void MarkLaunchCompleted()
+        {
+            Client.MarkLaunchCompleted();
+        }
+
+        /// <summary>
+        /// Get information regarding the last application run. This will be null on non mobile platforms.
+        /// </summary>
+        public static LastRunInfo GetLastRunInfo()
+        {
+            return Client.LastRunInfo;
+        }
+
     }
 }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -17,6 +17,8 @@ namespace BugsnagUnity
 
         public ISessionTracker SessionTracking { get; }
 
+        public LastRunInfo LastRunInfo => NativeClient.GetLastRunInfo();
+
         public User User { get; }
 
         public Metadata Metadata { get; }
@@ -479,6 +481,11 @@ namespace BugsnagUnity
         {
             // Set the native property
             NativeClient.SetAutoDetectAnrs(autoDetectAnrs);
+        }
+
+        public void MarkLaunchCompleted()
+        {
+            NativeClient.MarkLaunchCompleted();
         }
     }
 }

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -16,8 +16,12 @@ namespace BugsnagUnity
         public string[] RedactedKeys { get; set; } = new string[] { "password" };
 
         public int VersionCode { get; set; } = -1;
-        
+
+        public long LaunchDurationMillis { get; set; } = 5000;
+
         public ThreadSendPolicy SendThreads { get; set; } = ThreadSendPolicy.UNHANDLED_ONLY;
+
+        public bool SendLaunchCrashesSynchronously { get; set; }
 
         public bool PersistUser { get; set; }
 

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -21,7 +21,7 @@ namespace BugsnagUnity
 
         public ThreadSendPolicy SendThreads { get; set; } = ThreadSendPolicy.UNHANDLED_ONLY;
 
-        public bool SendLaunchCrashesSynchronously { get; set; }
+        public bool SendLaunchCrashesSynchronously { get; set; } = true;
 
         public bool PersistUser { get; set; }
 

--- a/src/BugsnagUnity/IClient.cs
+++ b/src/BugsnagUnity/IClient.cs
@@ -12,6 +12,8 @@ namespace BugsnagUnity
 
         ISessionTracker SessionTracking { get; }
 
+        LastRunInfo LastRunInfo { get; }
+
         User User { get; }
 
         void Send(IPayload payload);
@@ -43,5 +45,7 @@ namespace BugsnagUnity
         void SetAutoDetectErrors(bool AutoDetectErrors);
 
         void SetAutoDetectAnrs(bool autoDetectAnrs);
+
+        void MarkLaunchCompleted();
     }
 }

--- a/src/BugsnagUnity/IConfiguration.cs
+++ b/src/BugsnagUnity/IConfiguration.cs
@@ -9,7 +9,11 @@ namespace BugsnagUnity
     {
         string ApiKey { get; }
 
+        long LaunchDurationMillis { get; set; }
+
         bool ReportUncaughtExceptionsAsHandled { get; set; }
+
+        bool SendLaunchCrashesSynchronously { get; set; }
 
         string[] DiscardClasses { get; set; }
 

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -81,5 +81,15 @@ namespace BugsnagUnity
         /// <param name="autoDetectAnrs"></param>
         void SetAutoDetectAnrs(bool autoDetectAnrs);
 
+        /// <summary>
+        /// Setting Configuration.LaunchDurationMillis to 0 will cause Bugsnag to consider the app to be launching until Bugsnag.MarkLaunchCompleted() has been called.
+        /// </summary>
+        void MarkLaunchCompleted();
+
+        /// <summary>
+        /// Get the last run information from Android and cocoa platforms
+        /// </summary>
+        LastRunInfo GetLastRunInfo();
+
     }
 }

--- a/src/BugsnagUnity/LastRunInfo.cs
+++ b/src/BugsnagUnity/LastRunInfo.cs
@@ -1,0 +1,13 @@
+﻿namespace BugsnagUnity
+{
+    public class LastRunInfo
+    {
+
+        public int ConsecutiveLaunchCrashes;
+
+        public bool Crashed;
+
+        public bool CrashedDuringLaunch;
+
+    }
+}

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -99,6 +99,16 @@ namespace BugsnagUnity
         {
             NativeInterface.SetAutoDetectAnrs(autoDetectAnrs);
         }
+
+        public void MarkLaunchCompleted()
+        {
+            NativeInterface.MarkLaunchCompleted();
+        }
+
+        public LastRunInfo GetLastRunInfo()
+        {
+            return NativeInterface.GetlastRunInfo();
+        }
     }
 
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -24,9 +24,13 @@ namespace BugsnagUnity
         internal static extern void bugsnag_retrieveAppData(IntPtr instance, Action<IntPtr, string, string> populate);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_retrieveLastRunInfo(IntPtr instance, Action<IntPtr, bool, bool, int> populate);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_retrieveDeviceData(IntPtr instance, Action<IntPtr, string, string> populate);
 
         internal delegate void MetadataInformation(IntPtr instance, string tab, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] string[] keys, int keysSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)] string[] values, int valuesSize);
+
         [DllImport(Import)]
         internal static extern void bugsnag_retrieveMetaData(IntPtr instance, MetadataInformation visitor);
 
@@ -49,10 +53,19 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setPersistUser(IntPtr configuration, bool persistUser);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_setSendLaunchCrashesSynchronously(IntPtr configuration, bool sendLaunchCrashesSynchronously);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_setContext(IntPtr configuration, string context);
 
         [DllImport(Import)]
         internal static extern void bugsnag_setMaxBreadcrumbs(IntPtr configuration, int maxBreadcrumbs);
+
+        [DllImport(Import)]
+        internal static extern void bugsnag_setLaunchDurationMillis(IntPtr configuration, ulong launchDurationMillis);
+
+        [DllImport(Import)]
+        internal static extern void bugsnag_markLaunchCompleted();
 
         [DllImport(Import)]
         internal static extern void bugsnag_setMaxPersistedEvents(IntPtr configuration, int maxPersistedEvents);

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -92,5 +92,14 @@ namespace BugsnagUnity
                     return string.Empty;
             }
         }
+
+        public void MarkLaunchCompleted()
+        {
+        }
+
+        public LastRunInfo GetLastRunInfo()
+        {
+            return null;
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -90,7 +90,9 @@ namespace BugsnagUnity
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         static extern bool GlobalMemoryStatusEx([In, Out] MEMORYSTATUSEX lpBuffer);
 
-
+        public void MarkLaunchCompleted()
+        {
+        }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         private class MEMORYSTATUSEX
@@ -108,6 +110,11 @@ namespace BugsnagUnity
             {
                 dwLength = (uint)Marshal.SizeOf(this);
             }
+        }
+
+        public LastRunInfo GetLastRunInfo()
+        {
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Goal

Support proper configuration of event reporting during the app launch perioud 

## Changeset

- Added LaunchDurationMillis and SendLaunchCrashesSynchronously to the Configuration class and interface
- Pass LaunchDurationMillis and SendLaunchCrashesSynchronously values to Android and Cocoa
- Added Bugsnag.GetLastRunInfo() that gets the information from Android and Cocoa
- Added support for App.isLaunching field in csharp errors on Android and Cocoa platforms

## Testing

Extended existing and added new CI tests