### PR TITLE
Use Firefox for WebGL tests

### DIFF
--- a/scripts/ci-run-webgl-tests.sh
+++ b/scripts/ci-run-webgl-tests.sh
@@ -4,4 +4,4 @@ pushd features/fixtures/maze_runner/build
 popd
 
 bundle install
-bundle exec maze-runner --farm=local --browser=chrome features/desktop
+bundle exec maze-runner --farm=local --browser=firefox features/desktop


### PR DESCRIPTION
## Goal

Switch to using Firefox for automating the WebGL e2e tests.

## Design

Chrome and Chromedriver are very sensitive to being on the same major version as each other, so when Chrome auto-updates it breaks CI.  Firefox appears to be much less sensitive (on the basis that the Geckodriver hasn't been updated since April.

## Testing

Covered by a full CI run.