### PR TITLE
[PLAT-7190] Set notifier name before starting Cocoa notifier

### DIFF
--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -166,7 +166,7 @@ end
 
 Then("the error is valid for the error reporting API sent by the native Unity notifier") do
   # This step currently only applies to native errors on macOS macOS
-  check_error_reporting_api 'OSX Bugsnag Notifier'
+  check_error_reporting_api 'Unity Bugsnag Notifier'
 end
 
 Then("the error is valid for the error reporting API sent by the Unity notifier") do
@@ -180,7 +180,7 @@ Then("the error is valid for the error reporting API sent by the Unity notifier"
   end
 
   if os == 'ios'
-    notifier_name = 'iOS Bugsnag Notifier'
+    notifier_name = 'Unity Bugsnag Notifier'
   elsif os == 'android'
     notifier_name = 'Android Bugsnag Notifier'
   else

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -1,5 +1,5 @@
 #import "Bugsnag.h"
-#import "BugsnagConfiguration.h"
+#import "BugsnagConfiguration+Private.h"
 #import "BugsnagLogger.h"
 #import "BugsnagUser.h"
 #import "BugsnagNotifier.h"
@@ -364,16 +364,16 @@ void bugsnag_removeMetadata(const void *configuration, const char *tab) {
 }
 
 void bugsnag_startBugsnagWithConfiguration(const void *configuration, char *notifierVersion) {
+  if (notifierVersion) {
+    ((__bridge BugsnagConfiguration *)configuration).notifier =
+      [[BugsnagNotifier alloc] initWithName:@"Unity Bugsnag Notifier"
+                                    version:@(notifierVersion)
+                                        url:@"https://github.com/bugsnag/bugsnag-unity"
+                               dependencies:@[[[BugsnagNotifier alloc] init]]];
+  }
   [Bugsnag startWithConfiguration: (__bridge BugsnagConfiguration *)configuration];
   // Memory introspection is unused in a C/C++ context
   [BSG_KSCrash sharedInstance].introspectMemory = NO;
-  if (notifierVersion != NULL) {
-    NSString *ns_version = [NSString stringWithUTF8String:notifierVersion];
-    BugsnagNotifier *notifier = Bugsnag.client.notifier;
-    notifier.version = ns_version;
-    notifier.name = @"Bugsnag Unity (Cocoa)";
-    notifier.url = @"https://github.com/bugsnag/bugsnag-unity";
-  }
 }
 
 void bugsnag_addBreadcrumb(char *message, char *type, char *metadata[], int metadataCount) {


### PR DESCRIPTION
## Goal

Ensure payloads sent during `Bugsnag.start()` have "Unity Bugsnag Notifier" in `notifier.name`.

## Changeset

`bugsnag-cocoa` now allows the `notifier` payload to be set on the configuration object (via a private API) before start. This change has not been included in a release yet, so this PR uses the `next` branch of `bugsnag-cocoa`.
* https://github.com/bugsnag/bugsnag-cocoa/pull/1182

This PR makes use of the new mechanism to configure the notifier info before start.

The notifier name has been changed from `"Bugsnag Unity (Cocoa)"` to `"Unity Bugsnag Notifier"` after discussion with @tomlongridge 

## Testing

Updated E2E test steps to verify that the notifier name is as expected.