### PR TITLE
task(metadata): add app and device metadata fields to fallback/windows notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   * Added the `app.memoryTrimLevel` metadata to report a description of the latest `onTrimMemory` status [bugsnag-android#1344](https://github.com/bugsnag/bugsnag-android/pull/1344)
   * Added `STATE` Breadcrumbs for `onTrimMemory` events [bugsnag-android#1345](https://github.com/bugsnag/bugsnag-android/)
 
+* Add new automatically collected Device data to Windows, WebGL and Unity Editor events: `batteryLevel, charging, id, model, screenDensity, screenResolution, totalMemory` [#390](https://github.com/bugsnag/bugsnag-unity/pull/390)
+
+* Add new automatically collected App data to Windows, WebGL and Unity Editor events: `duration, id, isLaunching, lowMemory` [#390](https://github.com/bugsnag/bugsnag-unity/pull/390)
+
 * Add new Bugsnag.Notify overloads: `Notify(exception, stacktrace)`  `Notify(exception, stacktrace, callback)` `Notify(name, message, stacktrace)` `Notify(name, message, stacktrace, callback)` [#380](https://github.com/bugsnag/bugsnag-unity/pull/380)
 
 * Add `Bugsnag.GetLastRunInfo()` To get relevant crash information regarding the last run of the application [#379](https://github.com/bugsnag/bugsnag-unity/pull/379)

--- a/example/Assets/Scenes/Main.unity
+++ b/example/Assets/Scenes/Main.unity
@@ -2056,10 +2056,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 44886f35604eb42e1bb0b18af83eb216, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  APIKey: 228bd26426aa4ee1efd8a489876300e1
+  APIKey: 
   AutoDetectErrors: 1
   AutoDetectAnrs: 1
-  AutoTrackSessions: 0
+  AutoTrackSessions: 1
   NotifyLogLevel: 4
   SecondsPerUniqueLog: 5
   MaximumBreadcrumbs: 25

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -29,9 +29,9 @@ Feature: Reporting unhandled events
         
         #device metadata
         And the event "device.charging" is not null
-        And the event "device.batteryLevel" is not null
-        And the event "device.freeDisk" is not null
-        And the event "device.freeMemory" is not null
+        And the event "device.batteryLevel" is greater than -1
+        And the event "device.freeDisk" is greater than 0
+        And the event "device.freeMemory" is greater than 0
         And the event "device.hostname" is not null
         And the event "device.id" is not null
         And the event "device.locale" is not null
@@ -40,15 +40,15 @@ Feature: Reporting unhandled events
         And the event "device.osName" is not null
         And the event "device.osVersion" is not null
         And the event "device.runtimeVersions" is not null
-        And the event "device.screenDensity" is not null
+        And the event "device.screenDensity" is greater than 0
         And the event "device.screenResolution" is not null
         And the event "device.time" is a timestamp
         And the event "device.timezone" is not null
-        And the event "device.totalMemory" is not null
+        And the event "device.totalMemory" is greater than 0
 
         #app metadata
-        And the event "app.duration" is not null
-        And the event "app.durationInForeground" is not null
+        And the event "app.duration" is greater than 0
+        And the event "app.durationInForeground" is greater than 0
         And the event "app.inForeground" is not null
         And the event "app.isLaunching" is not null
         And the event "app.lowMemory" is not null

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -42,7 +42,7 @@ Feature: Reporting unhandled events
         And the event "device.runtimeVersions" is not null
         And the event "device.screenDensity" is not null
         And the event "device.screenResolution" is not null
-        And the event "device.time" is not null
+        And the event "device.time" is a timestamp
         And the event "device.timezone" is not null
         And the event "device.totalMemory" is not null
 

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -13,6 +13,50 @@ Feature: Reporting unhandled events
             | Main.RunScenario(System.String scenario)         | |
             | Main.Start()               | |
 
+    @windows_only
+    Scenario: Windows device and app data
+        When I run the game in the "UncaughtException" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "ExecutionEngineException"
+        And the exception "message" equals "Promise Rejection"
+        And the event "unhandled" is false
+        And custom metadata is included in the event
+        And the first significant stack frame methods and files should match:
+            | Main.DoUnhandledException(Int64 counter) | Main.DoUnhandledException(System.Int64 counter) |
+            | Main.RunScenario(System.String scenario)         | |
+            | Main.Start()               | |
+        
+        #device metadata
+        And the event "device.charging" is not null
+        And the event "device.batteryLevel" is not null
+        And the event "device.freeDisk" is not null
+        And the event "device.freeMemory" is not null
+        And the event "device.hostname" is not null
+        And the event "device.id" is not null
+        And the event "device.locale" is not null
+        And the event "device.manufacturer" is not null
+        And the event "device.model" is not null
+        And the event "device.osName" is not null
+        And the event "device.osVersion" is not null
+        And the event "device.runtimeVersions" is not null
+        And the event "device.screenDensity" is not null
+        And the event "device.screenResolution" is not null
+        And the event "device.time" is not null
+        And the event "device.timezone" is not null
+        And the event "device.totalMemory" is not null
+
+        #app metadata
+        And the event "app.duration" is not null
+        And the event "app.durationInForeground" is not null
+        And the event "app.inForeground" is not null
+        And the event "app.isLaunching" is not null
+        And the event "app.lowMemory" is not null
+        And the event "app.releaseStage" is not null
+        And the event "app.type" equals "Windows"
+        And the event "app.version" is not null
+
+
     @skip_webgl
     Scenario: Forcing uncaught exceptions to be unhandled
         When I run the game in the "UncaughtExceptionAsUnhandled" state

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,6 +14,10 @@ Before('@macos_only') do |_scenario|
   skip_this_scenario("Skipping scenario") unless Maze.config.os == 'macos'
 end
 
+Before('@windows_only') do |_scenario|
+  skip_this_scenario("Skipping scenario") unless Maze.config.os == 'windows'
+end
+
 AfterConfiguration do |_config|
   Maze.config.enforce_bugsnag_integrity = false
 

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -24,13 +24,13 @@ namespace BugsnagUnity
             Configuration = configuration;
             Breadcrumbs = new Breadcrumbs(configuration);
             Delivery = new Delivery();
-            Application.lowMemory += () => { _hasRecivedLowMemoryWarning = true; };
+            Application.lowMemory += () => { _hasReceivedLowMemoryWarning = true; };
         }
 
         public void PopulateApp(App app)
         {
             AddIsLaunching(app);
-            app.AddToPayload("lowMemory",_hasRecivedLowMemoryWarning);
+            app.AddToPayload("lowMemory", _hasReceivedLowMemoryWarning);
         }
 
         private void AddIsLaunching(App app)

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -17,7 +17,7 @@ namespace BugsnagUnity
 
         private bool _launchMarkedAsCompleted = false;
 
-        private bool _hasRecivedLowMemoryWarning = false;
+        private bool _hasReceivedLowMemoryWarning = false;
 
         public NativeClient(IConfiguration configuration)
         {

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -16,19 +16,20 @@ namespace BugsnagUnity
 
         private bool _launchMarkedAsCompleted = false;
 
-        private bool _hasRecivedLowMemoryWarning = false;
+        private bool _hasReceivedLowMemoryWarning = false;
 
         public NativeClient(IConfiguration configuration)
         {
             Configuration = configuration;
             Breadcrumbs = new Breadcrumbs(configuration);
             Delivery = new Delivery();
+            Application.lowMemory += () => { _hasReceivedLowMemoryWarning = true; };
         }
 
         public void PopulateApp(App app)
         {
             AddIsLaunching(app);
-            app.AddToPayload("lowMemory", _hasRecivedLowMemoryWarning);
+            app.AddToPayload("lowMemory", _hasReceivedLowMemoryWarning);
         }
 
         private void AddIsLaunching(App app)

--- a/src/BugsnagUnity/Payload/Device.cs
+++ b/src/BugsnagUnity/Payload/Device.cs
@@ -31,6 +31,13 @@ namespace BugsnagUnity.Payload
             this.AddToPayload("timezone", TimeZone.CurrentTimeZone.StandardName);
             this.AddToPayload("osName", OsName);
             this.AddToPayload("time", DateTime.UtcNow);
+            AddBatteryLevel();
+            this.AddToPayload("charging", SystemInfo.batteryStatus.Equals(BatteryStatus.Charging));
+            this.AddToPayload("id", SystemInfo.deviceUniqueIdentifier);
+            this.AddToPayload("screenDensity", Screen.dpi);
+            var res = Screen.currentResolution;
+            this.AddToPayload("screenResolution", string.Format("{0}x{1}", res.width, res.height));
+            this.AddToPayload("totalMemory", SystemInfo.systemMemorySize);
 
             // we expect that windows version strings look like:
             // "Microsoft Windows NT 10.0.17134.0"
@@ -47,6 +54,16 @@ namespace BugsnagUnity.Payload
       };
             this.AddToPayload("runtimeVersions", versions);
         }
+
+        private void AddBatteryLevel()
+        {
+            if (SystemInfo.batteryLevel > -1)
+            {
+                this.AddToPayload("batteryLevel",SystemInfo.batteryLevel);
+            }
+        }
+
+       
 
         internal void AddRuntimeVersions(IConfiguration config)
         {

--- a/tests/UnityEngine/Application.cs
+++ b/tests/UnityEngine/Application.cs
@@ -52,5 +52,10 @@ namespace UnityEngine
         public static void add_logMessageReceived(LogCallback cb) { }
 
         public delegate void LogCallback(string condition, string stackTrace, LogType type);
+
+        public delegate void LowMemoryCallback();
+
+        public static event LowMemoryCallback lowMemory;       
+
     }
 }

--- a/tests/UnityEngine/BatteryStatus.cs
+++ b/tests/UnityEngine/BatteryStatus.cs
@@ -1,0 +1,7 @@
+﻿namespace UnityEngine
+{
+    public enum BatteryStatus
+    {
+        Charging = 0
+    }
+}

--- a/tests/UnityEngine/Resolution.cs
+++ b/tests/UnityEngine/Resolution.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace UnityEngine
+{
+    public class Resolution
+    {
+        public int width { get; }
+        public int height { get; }
+    }
+}

--- a/tests/UnityEngine/Resolution.cs
+++ b/tests/UnityEngine/Resolution.cs
@@ -1,9 +1,24 @@
 ﻿using System;
 namespace UnityEngine
 {
-    public class Resolution
+    public struct Resolution
     {
-        public int width { get; }
-        public int height { get; }
-    }
+		/// <summary>
+		///   <para>Resolution width in pixels.</para>
+		/// </summary>
+		public int width
+		{
+			get;
+			set;
+		}
+
+		/// <summary>
+		///   <para>Resolution height in pixels.</para>
+		/// </summary>
+		public int height
+		{
+			get;
+			set;
+		}
+	}
 }

--- a/tests/UnityEngine/Screen.cs
+++ b/tests/UnityEngine/Screen.cs
@@ -5,6 +5,9 @@ namespace UnityEngine
     {
         public static float dpi { get; }
 
-        public static Resolution currentResolution { get; } = new Resolution();
+        public static Resolution currentResolution
+        {
+            get;
+        }
     }
 }

--- a/tests/UnityEngine/Screen.cs
+++ b/tests/UnityEngine/Screen.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace UnityEngine
+{
+    public class Screen
+    {
+        public static float dpi { get; }
+
+        public static Resolution currentResolution { get; } = new Resolution();
+    }
+}

--- a/tests/UnityEngine/SystemInfo.cs
+++ b/tests/UnityEngine/SystemInfo.cs
@@ -9,8 +9,11 @@ namespace UnityEngine
         public static string graphicsDeviceVersion { get; }
         public static int graphicsMemorySize { get; }
         public static int graphicsShaderLevel { get; }
+        public static int systemMemorySize { get; }
         public static string processorType { get; }
         public static string systemLanguage { get; }
+        public static float batteryLevel { get; }
+        public static BatteryStatus batteryStatus { get; }
     }
     namespace Events
     {

--- a/tests/UnityEngine/Time.cs
+++ b/tests/UnityEngine/Time.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace UnityEngine
+{
+    public class Time
+    {
+
+        public static float realtimeSinceStartup { get; set; }
+       
+    }
+}


### PR DESCRIPTION
## Goal

Add app and device metadata fields to fallback/windows notifier

## Changeset

- Added generic (data present on both windows and fallbacks) data collection to the App and Device constructors
- Added platform specific data collection (lowmemory, isLaunching) to the PopulateApp and PopulateDevice methods in the fallback and windows NativeClient classes
- Added a lowMemoryWarning listener to the fallback and windows native client classes
- Added MarkLaunchAsCompleted implementation to the fallback and windows native client classes

## Testing

Added Windows CI test