### PR TITLE
fix(CI): throw a threaded exception that works in unity 2017

### DIFF
--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -449,7 +449,7 @@ public class Main : MonoBehaviour
 
     private void BackgroundThreadCrash()
     {
-        var bgThread = new Thread(()=> { throw new System.Exception("Background Thread Crash"); })
+        var bgThread = new Thread(()=> { Debug.LogException(new System.Exception("Background Thread Crash"));})
         {
             IsBackground = true
         };


### PR DESCRIPTION
The recently added CI test "Report exception from background thread" in features/desktop/unhandled_errors was failing in unity 2017 builds.

I found out that in unity 2017 Application.logMessageReceivedThreaded does not fire for unhandled exceptions. It seems to be a bug, but i could not find any office mention of it anywhere.

It does fire if you call UnityEngine.Debug.LogException, and since this test is simply to check if our notify code is thread safe, I find this to be an acceptable solution.