### PR TITLE
Bump Maze Runner

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -311,7 +311,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2017.4.40f1.apk"
@@ -336,7 +337,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
@@ -358,7 +360,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2019.4.29f1.apk"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.29f1.apk"
@@ -380,7 +383,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2021.1.16f1.apk"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.1.16f1.apk"
@@ -572,7 +576,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2017.4.40f1.ipa"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2017.4.40f1.ipa"
@@ -594,7 +599,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
@@ -616,7 +622,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2019.4.29f1.ipa"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.29f1.ipa"
@@ -638,7 +645,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2021.1.16f1.ipa"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.1.16f1.ipa"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -186,7 +186,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2020.3.15f2.ipa"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.15f2.ipa"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "xcpretty"
 gem "xcodeproj"
 
 # Use official Maze Runner release
-gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v6.0.1"
+gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v6.2.1"
 
 # Use a specific Maze Runner branch
 #gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", branch: "tms/update-cucumber"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 2c334a7907ba78173e8436687cfb1765ad25a3c4
-  tag: v6.0.1
+  revision: e27004e424b165651f729a574ab21a277c75a355
+  tag: v6.2.1
   specs:
-    bugsnag-maze-runner (6.0.1)
+    bugsnag-maze-runner (6.2.1)
       appium_lib (~> 11.2.0)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
@@ -20,7 +20,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.3)
+    CFPropertyList (3.0.4)
+      rexml
     appium_lib (11.2.0)
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
@@ -83,7 +84,7 @@ GEM
     optimist (3.0.1)
     os (1.0.1)
     power_assert (2.0.1)
-    racc (1.5.2)
+    racc (1.6.0)
     rake (12.3.3)
     rexml (3.2.5)
     rouge (2.0.7)
@@ -100,7 +101,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xcodeproj (1.20.0)
+    xcodeproj (1.21.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)


### PR DESCRIPTION
Bump the version of Maze Runner for local running.

Also ensure the Maze Runner Docker image is always pulled in CI.  Without it, we have to wait for the Buildkite Docker cache to age off the `latest-v6-cli` image it knows about before it picks up any new Maze Runner versions.
