### PR TITLE
Update tests to use Unity 2021.1.27f1

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -67,7 +67,7 @@ steps:
     agents:
       queue: opensource-mac-unity
     env:
-      UNITY_VERSION: "2021.1.16f1"
+      UNITY_VERSION: "2021.1.27f1"
     plugins:
       artifacts#v1.2.0:
         download:
@@ -76,8 +76,8 @@ steps:
     commands:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
-      - features/fixtures/maze_runner/build/MacOS-2021.1.16f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2021.1.16f1.zip
+      - features/fixtures/maze_runner/build/MacOS-2021.1.27f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2021.1.27f1.zip
 
   #
   # Run macOS desktop tests
@@ -139,11 +139,11 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.15
     env:
-      UNITY_VERSION: "2021.1.16f1"
+      UNITY_VERSION: "2021.1.27f1"
     plugins:
       artifacts#v1.2.0:
         download:
-          - features/fixtures/maze_runner/build/MacOS-2021.1.16f1.zip
+          - features/fixtures/maze_runner/build/MacOS-2021.1.27f1.zip
         upload:
           - maze_output/*
           - Mazerunner.log
@@ -208,11 +208,11 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     env:
-      UNITY_VERSION: "2021.1.16f1"
+      UNITY_VERSION: "2021.1.27f1"
     plugins:
       artifacts#v1.2.0:
         download:
-          - features/fixtures/maze_runner/build/WebGL-2021.1.16f1.zip
+          - features/fixtures/maze_runner/build/WebGL-2021.1.27f1.zip
         upload:
           - maze_output/failed/**/*
     commands:
@@ -285,14 +285,14 @@ steps:
     agents:
       queue: opensource-mac-unity
     env:
-      UNITY_VERSION: "2021.1.16f1"
+      UNITY_VERSION: "2021.1.27f1"
     plugins:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
         upload:
-          - features/fixtures/maze_runner/mazerunner_2021.1.16f1.apk
+          - features/fixtures/maze_runner/mazerunner_2021.1.27f1.apk
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
@@ -380,14 +380,14 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2021.1.16f1.apk"
+          - "features/fixtures/maze_runner/mazerunner_2021.1.27f1.apk"
         upload:
           - "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.1.16f1.apk"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.1.27f1.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "features/android"
@@ -528,7 +528,7 @@ steps:
     agents:
       queue: opensource-mac-unity
     env:
-      UNITY_VERSION: "2021.1.16f1"
+      UNITY_VERSION: "2021.1.27f1"
     plugins:
       artifacts#v1.2.0:
         download:
@@ -548,7 +548,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     env:
-      UNITY_VERSION: "2021.1.16f1"
+      UNITY_VERSION: "2021.1.27f1"
     plugins:
       artifacts#v1.2.0:
         download:
@@ -556,7 +556,7 @@ steps:
           - Bugsnag-with-android-64bit.unitypackage
           - project_2021.tgz
         upload:
-          - features/fixtures/maze_runner/mazerunner_2021.1.16f1.ipa
+          - features/fixtures/maze_runner/mazerunner_2021.1.27f1.ipa
           - features/fixtures/unity.log
     commands:
       - tar -zxf project_2021.tgz features/fixtures/maze_runner
@@ -645,14 +645,14 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2021.1.16f1.ipa"
+          - "features/fixtures/maze_runner/mazerunner_2021.1.27f1.ipa"
         upload:
           - "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.1.16f1.ipa"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.1.27f1.ipa"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
@@ -710,7 +710,7 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2021.1.19f1"
+      UNITY_VERSION: "2021.1.27f1"
     commands:
       - scripts/ci-build-windows-package.bat
     artifact_paths:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -38,6 +38,7 @@ steps:
     commands:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
+      - unity.log
       - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
       - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
 
@@ -57,6 +58,7 @@ steps:
     commands:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
+      - unity.log
       - features/fixtures/maze_runner/build/MacOS-2019.4.29f1.zip
       - features/fixtures/maze_runner/build/WebGL-2019.4.29f1.zip
 
@@ -76,6 +78,7 @@ steps:
     commands:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
+      - unity.log
       - features/fixtures/maze_runner/build/MacOS-2021.1.27f1.zip
       - features/fixtures/maze_runner/build/WebGL-2021.1.27f1.zip
 
@@ -675,6 +678,7 @@ steps:
     command:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
+      - unity.log
       - features/fixtures/maze_runner/build/Windows-2017.4.40f1.zip
 
   - label: Build Unity 2018 Windows test fixture
@@ -688,6 +692,7 @@ steps:
     command:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
+      - unity.log
       - features/fixtures/maze_runner/build/Windows-2018.4.36f1.zip
 
   - label: Build Unity 2019 Windows test fixture
@@ -701,6 +706,7 @@ steps:
     command:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
+      - unity.log
       - features/fixtures/maze_runner/build/Windows-2019.4.30f1.zip
 
   - label: Build Unity 2021 Windows test fixture
@@ -714,6 +720,7 @@ steps:
     commands:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
+      - unity.log
       - features/fixtures/maze_runner/build/Windows-2021.1.19f1.zip
 
   #

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -721,7 +721,7 @@ steps:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/Windows-2021.1.19f1.zip
+      - features/fixtures/maze_runner/build/Windows-2021.1.27f1.zip
 
   #
   # Run Windows e2e tests
@@ -768,7 +768,7 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2021.1.19f1"
+      UNITY_VERSION: "2021.1.27f1"
     command:
       - scripts/ci-run-windows-tests.bat
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,6 +36,7 @@ steps:
     commands:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
+      - unity.log
       - features/fixtures/maze_runner/build/MacOS-2020.3.15f2.zip
       - features/fixtures/maze_runner/build/WebGL-2020.3.15f2.zip
 
@@ -213,6 +214,7 @@ steps:
     commands:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
+      - unity.log
       - features/fixtures/maze_runner/build/Windows-2020.3.17f1.zip
 
   #

--- a/scripts/ci-build-windows-package.bat
+++ b/scripts/ci-build-windows-package.bat
@@ -2,5 +2,7 @@ REM Using the artifacts plugin v1.3 on Windows seems to break the whole step
 buildkite-agent artifact download "Bugsnag.unitypackage" .
 cd features\scripts
 C:\Progra~1\Git\bin\bash.exe build_maze_runner.sh windows
+IF NOT [%ERRORLEVEL%] EQU [0] EXIT /B %ERRORLEVEL%
+
 cd ..\fixtures\maze_runner\build
 7z a -r Windows-%UNITY_VERSION%.zip Windows


### PR DESCRIPTION
## Goal

Update the e2e tests to use the latest point version of Unity 2021 currently available - 2021.1.27f1.

## Changeset

Also some general improvements:
- Fail the Windows build step if the build fails
- Upload unity.log files

## Testing

Covered by a full CI run.