### PR TITLE
Bump bugsnag-android to v5.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 * Update bugsnag-cocoa to v6.14.2
   * Fix missing `configuration.user` and manually resumed `session` info in unhandled errors.
     [bugsnag-cocoa#1215](https://github.com/bugsnag/bugsnag-cocoa/pull/1215)
+* Update bugsnag-android to v5.15.0 
+  * Avoid reporting false-positive background ANRs with improved foreground detection
+    [bugsnag-android#1429](https://github.com/bugsnag/bugsnag-android/pull/1429)
+  * Prevent events being attached to phantom sessions when they are blocked by an `OnSessionCallback`
+    [bugsnag-android#1434](https://github.com/bugsnag/bugsnag-android/pull/1434)
+  * Plugins will correctly mirror metadata added using `addMetadata(String, Map)`
+    [bugsnag-android#1454](https://github.com/bugsnag/bugsnag-android/pull/1454)
 
 ## 5.4.1 (2021-10-25)
 


### PR DESCRIPTION
## Goal
Bumps the bugsnag-android dependency to v5.15.0.