### PR TITLE
task(package): only build one 64 bit capable package

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -15,7 +15,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
     commands:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
@@ -35,7 +34,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
     commands:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
@@ -55,7 +53,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
     commands:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
@@ -183,7 +180,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk
           - features/fixtures/unity.log
@@ -202,7 +198,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2019.4.29f1.apk
           - features/fixtures/unity.log
@@ -221,7 +216,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2021.1.27f1.apk
           - features/fixtures/unity.log
@@ -315,7 +309,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
         upload:
           - features/fixtures/unity.log
           - project_2018.tgz
@@ -335,7 +328,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
           - project_2018.tgz
         upload:
           - features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa
@@ -356,7 +348,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
         upload:
           - features/fixtures/unity.log
           - project_2019.tgz
@@ -376,7 +367,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
           - project_2019.tgz
         upload:
           - features/fixtures/maze_runner/mazerunner_2019.4.29f1.ipa
@@ -397,7 +387,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
         upload:
           - features/fixtures/unity.log
           - project_2021.tgz
@@ -417,7 +406,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
           - project_2021.tgz
         upload:
           - features/fixtures/maze_runner/mazerunner_2021.1.27f1.ipa

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,6 @@ steps:
       - bundle exec rake plugin:export
     artifact_paths:
       - Bugsnag.unitypackage
-      - Bugsnag-with-android-64bit.unitypackage
 
   #
   # Build macOS and WebGL test fixtures
@@ -32,7 +31,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
     commands:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
@@ -94,7 +92,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2020.3.15f2.apk
           - features/fixtures/unity.log
@@ -141,7 +138,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2020.3.15f2.ipa
           - features/fixtures/unity.log
@@ -162,7 +158,6 @@ steps:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
-          - Bugsnag-with-android-64bit.unitypackage
           - project_2020.tgz
         upload:
           - features/fixtures/maze_runner/mazerunner_2020.3.15f2.ipa

--- a/Rakefile
+++ b/Rakefile
@@ -328,16 +328,16 @@ namespace :plugin do
 
   desc "Generate release artifacts"
   task export: ["plugin:build:clean"] do
-    Rake::Task["plugin:build:all"].invoke
-    export_package("Bugsnag.unitypackage")
+    #Rake::Task["plugin:build:all"].invoke
+    #export_package("Bugsnag.unitypackage")
     Rake::Task["plugin:build:all_android64"].invoke
-    export_package("Bugsnag-with-android-64bit.unitypackage")
+    export_package("Bugsnag.unitypackage")
   end
 
   desc "Generate release artifacts from cache (using Android 64-bit)"
   task :quick_export do
     Rake::Task["plugin:build:all_android64"].invoke
-    export_package("Bugsnag-with-android-64bit.unitypackage")
+    export_package("Bugsnag.unitypackage")
   end
 end
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -97,9 +97,8 @@ To build any test fixture, from the root of the repository, first build the noti
 ```
 rake plugin:export
 ```
-This will generate the following files:
+This will generate the following file:
 * `Bugsnag.unitypackage`
-* `Bugsnag-with-android-64bit.unitypackage`
 
 #### MacOS
 

--- a/features/scripts/mobile/prepare_fixture.sh
+++ b/features/scripts/mobile/prepare_fixture.sh
@@ -40,11 +40,3 @@ $UNITY_PATH/Unity $DEFAULT_CLI_ARGS \
                   -importPackage $script_path/../../../Bugsnag.unitypackage
 RESULT=$?
 if [ $RESULT -ne 0 ]; then exit $RESULT; fi
-
-echo "Importing Bugsnag-with-android-64bit.unitypackage into $project_path"
-$UNITY_PATH/Unity $DEFAULT_CLI_ARGS \
-                  -projectPath $project_path \
-                  -ignoreCompilerErrors \
-                  -importPackage $script_path/../../../Bugsnag-with-android-64bit.unitypackage
-RESULT=$?
-if [ $RESULT -ne 0 ]; then exit $RESULT; fi


### PR DESCRIPTION
## Goal

With the launch of V6, we will no longer officially support unity 2017, which means we no longer need the extra 32 bit package for Android builds running in < unity 2017.4

## Changeset

- Made the rake file only output the 64 bit version
- Refactored the fixture build scripts to not expect the 64 bit named package
- Removed any artifact mentions of the old package in the CI pipeline 

## Testing

Manually tested in builds and passing CI Tests should indicate everything working well