### PR TITLE
fix(breadcrumbs): fix crash caused by non string value types in nativ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   * Fix missing `configuration.user` and manually resumed `session` info in unhandled errors.
     [bugsnag-cocoa#1215](https://github.com/bugsnag/bugsnag-cocoa/pull/1215)
 
+### Bug fixes
+
+* Fixed an issue where breadcrumbs from non fatal apphang errors caused a crash on retrieval
+  [#431](https://github.com/bugsnag/bugsnag-unity/pull/431)
+
 ## 5.4.1 (2021-10-25)
 
 ### Enhancements

--- a/src/BugsnagUnity.mm
+++ b/src/BugsnagUnity.mm
@@ -470,7 +470,7 @@ void bugsnag_retrieveBreadcrumbs(const void *managedBreadcrumbs, void (*breadcru
 
     for (NSUInteger i = 0; i < (NSUInteger)count; i++) {
       c_keys[i] = [[keys objectAtIndex: i] UTF8String];
-      c_values[i] = [[values objectAtIndex: i] UTF8String];
+      c_values[i] = [[[values objectAtIndex: i] description] UTF8String];
     }
 
     breadcrumb(managedBreadcrumbs, message, timestamp, type, c_keys, count, c_values, count);


### PR DESCRIPTION
## Goal

fix crash caused by non string value types in breadcrumb metadata

## Changeset

- Cast all breadcrumb metadata values to strings on retrieval by the csharp layer
