### PR TITLE
Bump bugsnag-android to v5.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## TBD
 
+* Update bugsnag-android to v5.16.0
+  * Increase resilience of NDK stackframe method capture
+    [#1484](https://github.com/bugsnag/bugsnag-android/pull/1484)
+  * `redactedKeys` now correctly apply to metadata on Event breadcrumbs
+    [#1526](https://github.com/bugsnag/bugsnag-android/pull/1526)
+  * Improved the robustness of automatically logged `ERROR` breadcrumbs
+    [#1531](https://github.com/bugsnag/bugsnag-android/pull/1531)
+  * Improve performance on the breadcrumb storage "hot path" by removing Date formatting
+    [#1525](https://github.com/bugsnag/bugsnag-android/pull/1525)
+
 ## 5.4.2 (2021-11-16)
 
 * Update bugsnag-cocoa to v6.14.2


### PR DESCRIPTION
Bumps the bugsnag-android dependency to v5.16.0.