### PR TITLE
task(callbacks): add android session callbacks Part 1

### DIFF
--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -80,8 +80,20 @@ BugsnagUser * bugsnag_getUserFromSession(const void *session){
     return ((__bridge BugsnagSession *)session).user;
 }
 
+void bugsnag_setUserFromSession(const void *session, char *userId, char *userName, char *userEmail){
+    [((__bridge BugsnagSession *)session) setUser:userId == NULL ? nil : [NSString stringWithUTF8String:userId]
+            withEmail:userEmail == NULL ? nil : [NSString stringWithUTF8String:userEmail]
+             andName:userName == NULL ? nil : [NSString stringWithUTF8String:userName]];
+}
+
 BugsnagUser * bugsnag_getUserFromEvent(const void *event){
     return ((__bridge BugsnagEvent *)event).user;
+}
+
+void bugsnag_setUserFromEvent(const void *event, char *userId, char *userName, char *userEmail){
+    [((__bridge BugsnagEvent *)event) setUser:userId == NULL ? nil : [NSString stringWithUTF8String:userId]
+            withEmail:userEmail == NULL ? nil : [NSString stringWithUTF8String:userEmail]
+             andName:userName == NULL ? nil : [NSString stringWithUTF8String:userName]];
 }
 
 void bugsnag_getThreadsFromEvent(const void *event,const void *instance, void (*callback)(const void *instance, void *threads[], int threads_size)) {

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -60,19 +60,21 @@ namespace BugsnagUnity
             }
             public bool onSession(AndroidJavaObject session)
             {
-                try
+
+                var wrapper = new NativeSession(session);
+                foreach (var callback in _config.GetOnSessionCallbacks())
                 {
-                    var wrapper = new NativeSession(session);
-                    foreach (var callback in _config.GetOnSessionCallbacks())
+                    try
                     {
                         if (!callback.Invoke(wrapper))
                         {
                             return false;
                         }
                     }
+                    catch { }
+
                 }
-                catch { }
-               
+
                 return true;
             }
         }
@@ -249,7 +251,7 @@ namespace BugsnagUnity
                 var javaInteger = new AndroidJavaObject("java.lang.Integer", config.VersionCode);
                 obj.Call("setVersionCode", javaInteger);
             }
-            
+
             //Null or empty check necessary because android will set the app.type to empty if that or null is passed as default
             if (!string.IsNullOrEmpty(config.AppType))
             {
@@ -282,7 +284,7 @@ namespace BugsnagUnity
             {
                 obj.Call("setSendThreads", policy);
             }
-                                   
+
 
             // set release stages
             obj.Call("setReleaseStage", config.ReleaseStage);
@@ -317,8 +319,8 @@ namespace BugsnagUnity
             // set persistence directory
             if (!string.IsNullOrEmpty(config.PersistenceDirectory))
             {
-                AndroidJavaObject androidFile = new AndroidJavaObject("java.io.File",config.PersistenceDirectory);
-                obj.Call("setPersistenceDirectory",androidFile);
+                AndroidJavaObject androidFile = new AndroidJavaObject("java.io.File", config.PersistenceDirectory);
+                obj.Call("setPersistenceDirectory", androidFile);
             }
 
             return obj;
@@ -408,7 +410,7 @@ namespace BugsnagUnity
 
         public void StartSession()
         {
-            CallNativeVoidMethod("startSession", "()V", new object[] {  });
+            CallNativeVoidMethod("startSession", "()V", new object[] { });
         }
 
         public bool ResumeSession()
@@ -457,7 +459,7 @@ namespace BugsnagUnity
 
         public void MarkLaunchCompleted()
         {
-            CallNativeVoidMethod("markLaunchCompleted", "()V", new object[] {});
+            CallNativeVoidMethod("markLaunchCompleted", "()V", new object[] { });
         }
 
         public Dictionary<string, object> GetApp()
@@ -926,7 +928,7 @@ namespace BugsnagUnity
         public LastRunInfo GetlastRunInfo()
         {
             var javaLastRunInfo = CallNativeObjectMethodRef("getLastRunInfo", "()Lcom/bugsnag/android/LastRunInfo;", new object[] { });
-            var crashed = AndroidJNI.GetBooleanField(javaLastRunInfo , AndroidJNIHelper.GetFieldID(LastRunInfoClass,"crashed"));
+            var crashed = AndroidJNI.GetBooleanField(javaLastRunInfo, AndroidJNIHelper.GetFieldID(LastRunInfoClass, "crashed"));
             var consecutiveLaunchCrashes = AndroidJNI.GetIntField(javaLastRunInfo, AndroidJNIHelper.GetFieldID(LastRunInfoClass, "consecutiveLaunchCrashes"));
             var crashedDuringLaunch = AndroidJNI.GetBooleanField(javaLastRunInfo, AndroidJNIHelper.GetFieldID(LastRunInfoClass, "crashedDuringLaunch"));
             var lastRunInfo = new LastRunInfo

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -60,14 +60,19 @@ namespace BugsnagUnity
             }
             public bool onSession(AndroidJavaObject session)
             {
-                var wrapper = new NativeSession(session);
-                foreach (var callback in _config.GetOnSessionCallbacks())
+                try
                 {
-                    if (!callback.Invoke(wrapper))
+                    var wrapper = new NativeSession(session);
+                    foreach (var callback in _config.GetOnSessionCallbacks())
                     {
-                        return false;
+                        if (!callback.Invoke(wrapper))
+                        {
+                            return false;
+                        }
                     }
                 }
+                catch { }
+               
                 return true;
             }
         }

--- a/src/BugsnagUnity/Native/Android/NativePayloadClassWrapper.cs
+++ b/src/BugsnagUnity/Native/Android/NativePayloadClassWrapper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using UnityEngine;
+
+namespace BugsnagUnity
+{
+    public class NativePayloadClassWrapper
+    {
+
+        public AndroidJavaObject NativePointer;
+
+        public NativePayloadClassWrapper(AndroidJavaObject nativePointer)
+        {
+            NativePointer = nativePointer;
+        }
+
+        public string GetNativeString(string key)
+        {
+            return NativePointer.Call<string>(key);
+        }
+
+        public void SetNativeString(string key, string value)
+        {
+            NativePointer.Call(key, value);
+        }
+    }
+}

--- a/src/BugsnagUnity/Native/Android/NativeSession.cs
+++ b/src/BugsnagUnity/Native/Android/NativeSession.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using BugsnagUnity.Payload;
+using UnityEngine;
+
+namespace BugsnagUnity
+{
+    public class NativeSession : NativePayloadClassWrapper, ISession
+    {
+        public NativeSession(AndroidJavaObject androidJavaObject) : base(androidJavaObject){}
+
+        public string Id { get => GetNativeString("getId"); set => SetNativeString("setId",value); }
+
+        public IDevice Device { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public IApp App { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public DateTime? StartedAt { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public IUser GetUser() => new NativeUser(NativePointer.Call<AndroidJavaObject>("getUser"));
+
+        public void SetUser(string id, string email, string name)
+        {
+            NativePointer.Call("setUser",id,email,name);
+        }
+    }
+}

--- a/src/BugsnagUnity/Native/Android/NativeUser.cs
+++ b/src/BugsnagUnity/Native/Android/NativeUser.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using UnityEngine;
+
+namespace BugsnagUnity
+{
+    public class NativeUser : NativePayloadClassWrapper, IUser
+    {
+        public NativeUser(AndroidJavaObject androidJavaObject) : base (androidJavaObject){}
+
+        public string Id => GetNativeString("getId"); 
+        public string Name => GetNativeString("getName"); 
+        public string Email => GetNativeString("getEmail");
+
+    }
+}

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -229,7 +229,13 @@ namespace BugsnagUnity
         internal static extern IntPtr bugsnag_getUserFromEvent(IntPtr @event);
 
         [DllImport(Import)]
+        internal static extern IntPtr bugsnag_setUserFromEvent(IntPtr @event, string userId, string userName, string userEmail);
+
+        [DllImport(Import)]
         internal static extern IntPtr bugsnag_getUserFromSession(IntPtr session);
+
+        [DllImport(Import)]
+        internal static extern IntPtr bugsnag_setUserFromSession(IntPtr session, string userId, string userName, string userEmail);
 
         [DllImport(Import)]
         internal static extern void bugsnag_setEventMetadata(IntPtr @event, string tab, string metadataJson);

--- a/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
@@ -122,9 +122,7 @@ namespace BugsnagUnity
 
         public void SetUser(string id, string email, string name)
         {
-            _user.Id = id;
-            _user.Email = email;
-            _user.Name = name;
+            NativeCode.bugsnag_setUserFromEvent(NativePointer,id,name,email);
         }
 
         public void AddMetadata(string section, string key, object value)

--- a/src/BugsnagUnity/Native/Cocoa/NativeSession.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeSession.cs
@@ -34,9 +34,7 @@ namespace BugsnagUnity
         
         public void SetUser(string id, string email, string name)
         {
-            _nativeUser.Id = id;
-            _nativeUser.Email = email;
-            _nativeUser.Name = name;
+            NativeCode.bugsnag_setUserFromSession(NativePointer, id, name, email);
         }
     }
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeUser.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeUser.cs
@@ -13,8 +13,8 @@ namespace BugsnagUnity
         {
         }
 
-        public string Id { get => GetNativeString(ID_KEY); set => SetNativeString(ID_KEY,value); }
-        public string Name { get => GetNativeString(NAME_KEY); set => SetNativeString(NAME_KEY, value); }
-        public string Email { get => GetNativeString(EMAIL_KEY); set => SetNativeString(EMAIL_KEY, value); }
+        public string Id => GetNativeString(ID_KEY);
+        public string Name => GetNativeString(NAME_KEY);
+        public string Email => GetNativeString(EMAIL_KEY);
     }
 }

--- a/src/BugsnagUnity/Payload/IUser.cs
+++ b/src/BugsnagUnity/Payload/IUser.cs
@@ -3,10 +3,10 @@ namespace BugsnagUnity
 {
     public interface IUser
     {
-        string Id { get; set; }
+        string Id { get; }
 
-        string Name { get; set; }
+        string Name { get; }
       
-        string Email { get; set; }
+        string Email { get; }
     }
 }


### PR DESCRIPTION
## Goal

This is Part 1 of the larger Unity/Android callbacks task. 

I'm breakign it down into small chunks because it's going to be a lot of changes. 

In this part, i setup the connection between Android and Unity and created a basic (incomplete) NativeSession wrapper class and NativeUser wrapper class

## Changeset

- Hooked into the Android layer session callbacks in the NativeInterface.cs class
- Created the Wrapper classes NativeSession and NativeUser
- Fixed an oversight in how Cocoa sessions and events called SetUser

## Testing

Manually tested, CI will be added at the end of the task