### PR TITLE
Allow retry on build steps for lost agents and timeouts

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -21,6 +21,12 @@ steps:
     artifact_paths:
       - features/fixtures/maze_runner/build/MacOS-2017.4.40f1.zip
       - features/fixtures/maze_runner/build/WebGL-2017.4.40f1.zip
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: Build Unity 2018 MacOS and WebGL test fixtures
     key: 'cocoa-webgl-2018-fixtures'
@@ -41,6 +47,12 @@ steps:
       - unity.log
       - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
       - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: Build Unity 2019 MacOS and WebGL test fixtures
     key: 'cocoa-webgl-2019-fixtures'
@@ -61,6 +73,12 @@ steps:
       - unity.log
       - features/fixtures/maze_runner/build/MacOS-2019.4.32f1.zip
       - features/fixtures/maze_runner/build/WebGL-2019.4.32f1.zip
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: Build Unity 2021 MacOS and WebGL test fixtures
     key: 'cocoa-webgl-2021-fixtures'
@@ -81,6 +99,12 @@ steps:
       - unity.log
       - features/fixtures/maze_runner/build/MacOS-2021.2.3f1.zip
       - features/fixtures/maze_runner/build/WebGL-2021.2.3f1.zip
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   #
   # Run macOS desktop tests
@@ -242,6 +266,12 @@ steps:
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':android: Build Android test fixture for Unity 2018'
     key: 'build-android-fixture-2018'
@@ -261,6 +291,12 @@ steps:
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':android: Build Android test fixture for Unity 2019'
     key: 'build-android-fixture-2019'
@@ -280,6 +316,12 @@ steps:
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':android: Build Android test fixture for Unity 2021'
     key: 'build-android-fixture-2021'
@@ -299,6 +341,12 @@ steps:
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   #
   # Run Android tests
@@ -421,6 +469,12 @@ steps:
     commands:
       - rake test:ios:generate_xcode
       - tar -zvcf project_2017.tgz  features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':ios: Build iOS test fixture for Unity 2017'
     key: 'build-ios-fixture-2017'
@@ -442,6 +496,12 @@ steps:
     commands:
       - tar -zxf project_2017.tgz features/fixtures/maze_runner
       - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':ios: Generate Xcode project - Unity 2018'
     key: 'generate-fixture-project-2018'
@@ -462,6 +522,12 @@ steps:
     commands:
       - rake test:ios:generate_xcode
       - tar -zvcf project_2018.tgz  features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':ios: Build iOS test fixture for Unity 2018'
     key: 'build-ios-fixture-2018'
@@ -483,6 +549,12 @@ steps:
     commands:
       - tar -zxf project_2018.tgz features/fixtures/maze_runner
       - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':ios: Generate Xcode project - Unity 2019'
     key: 'generate-fixture-project-2019'
@@ -503,6 +575,12 @@ steps:
     commands:
       - rake test:ios:generate_xcode
       - tar -zvcf project_2019.tgz features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':ios: Build iOS test fixture for Unity 2019'
     key: 'build-ios-fixture-2019'
@@ -524,6 +602,12 @@ steps:
     commands:
       - tar -zxf project_2019.tgz features/fixtures/maze_runner
       - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':ios: Generate Xcode project - Unity 2021'
     key: 'generate-fixture-project-2021'
@@ -544,6 +628,12 @@ steps:
     commands:
       - rake test:ios:generate_xcode
       - tar -zvcf project_2021.tgz features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':ios: Build iOS test fixture for Unity 2021'
     key: 'build-ios-fixture-2021'
@@ -565,6 +655,12 @@ steps:
     commands:
       - tar -zxf project_2021.tgz features/fixtures/maze_runner
       - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   #
   # Run iOS tests
@@ -681,6 +777,12 @@ steps:
     artifact_paths:
       - unity.log
       - features/fixtures/maze_runner/build/Windows-2017.4.40f1.zip
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: Build Unity 2018 Windows test fixture
     key: 'windows-2018-fixture'
@@ -695,6 +797,12 @@ steps:
     artifact_paths:
       - unity.log
       - features/fixtures/maze_runner/build/Windows-2018.4.36f1.zip
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: Build Unity 2019 Windows test fixture
     key: 'windows-2019-fixture'
@@ -709,6 +817,12 @@ steps:
     artifact_paths:
       - unity.log
       - features/fixtures/maze_runner/build/Windows-2019.4.30f1.zip
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: Build Unity 2021 Windows test fixture
     key: 'windows-2021-fixture'
@@ -723,6 +837,12 @@ steps:
     artifact_paths:
       - unity.log
       - features/fixtures/maze_runner/build/Windows-2021.2.3f1.zip
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   #
   # Run Windows e2e tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,12 @@ steps:
       - unity.log
       - features/fixtures/maze_runner/build/MacOS-2020.3.23f1.zip
       - features/fixtures/maze_runner/build/WebGL-2020.3.23f1.zip
-
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
   #
   # Run desktop tests
   #
@@ -100,6 +105,12 @@ steps:
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   #
   # Run Android tests
@@ -151,6 +162,12 @@ steps:
     commands:
       - rake test:ios:generate_xcode
       - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   - label: ':ios: Build iOS test fixture for Unity 2020'
     key: 'build-ios-fixture-2020'
@@ -172,6 +189,12 @@ steps:
     commands:
       - tar -zxf project_2020.tgz features/fixtures/maze_runner
       - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   #
   # Run iOS tests
@@ -216,6 +239,12 @@ steps:
     artifact_paths:
       - unity.log
       - features/fixtures/maze_runner/build/Windows-2020.3.17f1.zip
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 1
+        - exit_status: 255 # Forced agent shutdown (e.g. timeout)
+          limit: 1
 
   #
   # Run Windows e2e tests


### PR DESCRIPTION
## Goal

Allow retry on build (but not test) steps for lost agents and timeouts.

## Design

Allowing retries on test steps as well feels risky, as we might might miss a genuine, intermittent, issue.

## Changeset

Only an update to the CI pipeline to allow retries.

## Testing

Covered by CI.