### PR TITLE
Increase WebGL memory size for example and test fixture

### DIFF
--- a/example/ProjectSettings/ProjectSettings.asset
+++ b/example/ProjectSettings/ProjectSettings.asset
@@ -498,7 +498,7 @@ PlayerSettings:
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
   spritePackerPolicy: 
-  webGLMemorySize: 256
+  webGLMemorySize: 512
   webGLExceptionSupport: 1
   webGLNameFilesAsHashes: 0
   webGLDataCaching: 0

--- a/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
+++ b/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
@@ -541,7 +541,7 @@ PlayerSettings:
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
   spritePackerPolicy: 
-  webGLMemorySize: 256
+  webGLMemorySize: 512
   webGLExceptionSupport: 3
   webGLNameFilesAsHashes: 0
   webGLDataCaching: 0


### PR DESCRIPTION
Increase WebGL memory size in the example and e2e test fixture, following some recent out of memory errors in our e2e tests with Unity 2021.