### PR TITLE
task(config): make changes to EnabledErrorTypes config

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#addin nuget:?package=Cake.Git
+#addin nuget:?package=Cake.Git&version=1.1.0
 #tool "nuget:?package=NUnit.ConsoleRunner"
 
 var target = Argument("target", "Default");

--- a/features/desktop/enabled_error_types.feature
+++ b/features/desktop/enabled_error_types.feature
@@ -12,6 +12,7 @@ Feature: Enabled Error Types
         When I run the game in the "EnableLogLogs" state
         And I wait to receive an error
         Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "errorClass" equals "UnityLogLog"
         And I discard the oldest error
         Then I should receive no requests
 
@@ -20,5 +21,6 @@ Feature: Enabled Error Types
         When I run the game in the "EnableUnhandledExceptions" state
         And I wait to receive an error
         Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "message" equals "LogException"
         And I discard the oldest error
         Then I should receive no requests

--- a/features/desktop/handled_errors.feature
+++ b/features/desktop/handled_errors.feature
@@ -121,7 +121,7 @@ Feature: Handled Errors and Exceptions
         And the event "unhandled" is true
         And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
-            | Main:DoLogUnthrownAsUnhandled() |
+            | Main:DebugLogException() |
             | Main:RunScenario(String) |
             | Main:Start() |
 

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -89,7 +89,7 @@ Feature: Reporting unhandled events
         And the event "unhandled" is true
         And custom metadata is included in the event
         And the first significant stack frame methods and files should match:
-            | Main.UncaughtExceptionAsUnhandled() |
+            | Main.ThrowException() |
             | Main.RunScenario(System.String scenario) |
             | Main.Start()               |
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -163,26 +163,18 @@ public class Main : MonoBehaviour
                     ANRs = false,
                     AppHangs = false,
                     OOMs = false,
-                    NativeCrashes = false,
-                    UnhandledExceptions = true,
-                    UnityLogLogs = false,
-                    UnityWarningLogs = false,
-                    UnityAssertLogs = false,
-                    UnityErrorLogs = false
+                    Crashes = false,
+                    UnityLog = true
                 };
-                config.NotifyLogLevel = LogType.Log;
+                config.NotifyLogLevel = LogType.Exception;
                 break;
             case "EnableLogLogs":
                 config.EnabledErrorTypes = new EnabledErrorTypes() {
                     ANRs = false,
                     AppHangs = false,
                     OOMs = false,
-                    NativeCrashes = false,
-                    UnhandledExceptions = false,
-                    UnityLogLogs = true,
-                    UnityWarningLogs = false,
-                    UnityAssertLogs = false,
-                    UnityErrorLogs = false
+                    Crashes = false,
+                    UnityLog = true
                 };
                 config.NotifyLogLevel = LogType.Log;
                 break;
@@ -220,26 +212,26 @@ public class Main : MonoBehaviour
                 config.EnabledReleaseStages = new[] { "production" };
                 break;
             case "UncaughtExceptionAsUnhandled":
-                config.ReportUncaughtExceptionsAsHandled = false;
+                config.ReportExceptionLogsAsHandled = false;
                 break;
             case "LogUnthrownAsUnhandled":
-                config.ReportUncaughtExceptionsAsHandled = false;
+                config.ReportExceptionLogsAsHandled = false;
                 break;
             case "ReportLoggedWarning":
                 config.NotifyLogLevel = LogType.Warning;
-                config.EnabledErrorTypes.UnityWarningLogs = true;
+                config.EnabledErrorTypes.UnityLog = true;
                 break;
             case "ReportLoggedError":
                 config.NotifyLogLevel = LogType.Warning;
-                config.EnabledErrorTypes.UnityWarningLogs = true;
+                config.EnabledErrorTypes.UnityLog = true;
                 break;
             case "ReportLoggedWarningWithHandledConfig":
-                config.EnabledErrorTypes.UnityWarningLogs = true;
-                config.ReportUncaughtExceptionsAsHandled = false;
+                config.EnabledErrorTypes.UnityLog = true;
+                config.ReportExceptionLogsAsHandled = false;
                 config.NotifyLogLevel = LogType.Warning;
                 break;
             case "ManualSessionCrash":
-                config.ReportUncaughtExceptionsAsHandled = false;
+                config.ReportExceptionLogsAsHandled = false;
                 break;
             case "AutoSessionInNotifyReleaseStages":
                 config.ReleaseStage = "production";
@@ -256,9 +248,9 @@ public class Main : MonoBehaviour
                 config.EnabledReleaseStages = new[] { "no-op" };
                 break;
             case "ManualSessionMixedEvents":
-                config.ReportUncaughtExceptionsAsHandled = false;
+                config.ReportExceptionLogsAsHandled = false;
                 config.NotifyLogLevel = LogType.Warning;
-                config.EnabledErrorTypes.UnityWarningLogs = true;
+                config.EnabledErrorTypes.UnityLog = true;
                 break;
             case "UncaughtExceptionWithoutAutoNotify":
                 config.AutoDetectErrors = false;
@@ -268,7 +260,7 @@ public class Main : MonoBehaviour
                 break;
             case "LoggedExceptionWithoutAutoNotify":
                 config.AutoDetectErrors = false;
-                config.ReportUncaughtExceptionsAsHandled = false;
+                config.ReportExceptionLogsAsHandled = false;
                 break;
             case "NativeCrashWithoutAutoNotify":
                 config.AutoDetectErrors = false;
@@ -279,7 +271,7 @@ public class Main : MonoBehaviour
                 break;
             case "ReportLoggedWarningThreaded":
                 config.NotifyLogLevel = LogType.Warning;
-                config.EnabledErrorTypes.UnityWarningLogs = true;
+                config.EnabledErrorTypes.UnityLog = true;
                 break;
             case "EventCallbacks":
                 config.AddOnError((@event)=> {
@@ -348,10 +340,11 @@ public class Main : MonoBehaviour
                 DoUnhandledException(0);
                 break;
             case "EnableUnhandledExceptions":
-                CheckEnabledErrorTypes();
+                Debug.Log("LogLog");
+                Debug.LogException(new Exception("LogException"));
                 break;
             case "EnableLogLogs":
-                CheckEnabledErrorTypes();
+                Debug.Log("EnableLogLogs");
                 break;
             case "DisableAllErrorTypes":
                 CheckDisabledErrorTypes();

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -410,10 +410,10 @@ public class Main : MonoBehaviour
                 MakeAssertionFailure(4);
                 break;
             case "UncaughtExceptionAsUnhandled":
-                UncaughtExceptionAsUnhandled();
+                ThrowException();
                 break;
             case "LogUnthrownAsUnhandled":
-                DoLogUnthrownAsUnhandled();
+                DebugLogException();
                 break;
             case "ReportLoggedWarningThreaded":
                 new System.Threading.Thread(() => DoLogWarning()).Start();
@@ -432,7 +432,7 @@ public class Main : MonoBehaviour
                 break;
             case "ManualSessionCrash":
                 Bugsnag.StartSession();
-                UncaughtExceptionAsUnhandled();
+                ThrowException();
                 break;
             case "ManualSessionNotify":
                 Bugsnag.StartSession();
@@ -452,7 +452,7 @@ public class Main : MonoBehaviour
                 Bugsnag.StartSession();
                 DoNotify();
                 DoLogWarning();
-                UncaughtExceptionAsUnhandled();
+                ThrowException();
                 break;
             case "StoppedSession":
                 Bugsnag.StartSession();
@@ -475,7 +475,7 @@ public class Main : MonoBehaviour
                 DoNotify();
                 break;
             case "LoggedExceptionWithoutAutoNotify":
-                DoLogUnthrownAsUnhandled();
+                DebugLogException();
                 break;
             case "NativeCrashWithoutAutoNotify":
                 crashy_signal_runner(8);
@@ -589,7 +589,7 @@ public class Main : MonoBehaviour
         Bugsnag.Notify(new System.Exception("Second Error"));
     }
 
-    void UncaughtExceptionAsUnhandled()
+    void ThrowException()
     {
         throw new ExecutionEngineException("Invariant state failure");
     }
@@ -674,7 +674,7 @@ public class Main : MonoBehaviour
         Bugsnag.Notify(new System.Exception("blorb"));
     }
 
-    void DoLogUnthrownAsUnhandled()
+    void DebugLogException()
     {
         Debug.LogException(new System.Exception("WAT"));
     }

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -282,12 +282,12 @@ public class MobileScenarioRunner : MonoBehaviour {
                 break;
             case "Start SDK no errors":
                 config.AutoDetectErrors = false;
-                config.EnabledErrorTypes.NativeCrashes = false;
-                config.EnabledErrorTypes.UnhandledExceptions = false;
+                config.EnabledErrorTypes.Crashes = false;
+                config.EnabledErrorTypes.UnityLog = false;
                 config.DiscardClasses = new string[] { "St13runtime_error" };
                 break;
             case "Disable Native Errors":
-                config.EnabledErrorTypes.NativeCrashes = false;
+                config.EnabledErrorTypes.Crashes = false;
                 config.DiscardClasses = new string[] { "St13runtime_error" };
                 break;
             case "Log error":

--- a/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
+++ b/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
@@ -176,12 +176,8 @@ namespace BugsnagUnity.Editor
                 settings.EnabledErrorTypes.ANRs = EditorGUILayout.Toggle("ANRs (Android)", settings.EnabledErrorTypes.ANRs);
                 settings.EnabledErrorTypes.AppHangs = EditorGUILayout.Toggle("AppHangs (Cocoa)", settings.EnabledErrorTypes.AppHangs);
                 settings.EnabledErrorTypes.OOMs = EditorGUILayout.Toggle("OOMs (Cocoa)", settings.EnabledErrorTypes.OOMs);
-                settings.EnabledErrorTypes.NativeCrashes = EditorGUILayout.Toggle("Native Crashes", settings.EnabledErrorTypes.NativeCrashes);
-                settings.EnabledErrorTypes.UnhandledExceptions = EditorGUILayout.Toggle("Unhandled Exceptions", settings.EnabledErrorTypes.UnhandledExceptions);
-                settings.EnabledErrorTypes.UnityLogLogs = EditorGUILayout.Toggle("Unity.Log Logs", settings.EnabledErrorTypes.UnityLogLogs);
-                settings.EnabledErrorTypes.UnityAssertLogs = EditorGUILayout.Toggle("Unity.Assert Logs", settings.EnabledErrorTypes.UnityAssertLogs);
-                settings.EnabledErrorTypes.UnityWarningLogs = EditorGUILayout.Toggle("Unity.Warning Logs", settings.EnabledErrorTypes.UnityWarningLogs);
-                settings.EnabledErrorTypes.UnityErrorLogs = EditorGUILayout.Toggle("Unity.Error Logs", settings.EnabledErrorTypes.UnityErrorLogs);
+                settings.EnabledErrorTypes.Crashes = EditorGUILayout.Toggle("Crashes", settings.EnabledErrorTypes.Crashes);
+                settings.EnabledErrorTypes.UnityLog = EditorGUILayout.Toggle("Unity Logs", settings.EnabledErrorTypes.UnityLog);
                 EditorGUI.indentLevel -= 2;
             }
         }

--- a/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
+++ b/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
@@ -29,7 +29,7 @@ namespace BugsnagUnity.Editor
         public string SessionEndpoint;
         public string[] RedactedKeys = new string[] { "password" };
         public string ReleaseStage = "production";
-        public bool ReportUncaughtExceptionsAsHandled = true;
+        public bool ReportExceptionLogsAsHandled = true;
         public bool SendLaunchCrashesSynchronously = true;
         public double SecondsPerUniqueLog = 5;
         public int VersionCode;
@@ -82,7 +82,7 @@ namespace BugsnagUnity.Editor
             {
                 config.ReleaseStage = Debug.isDebugBuild ? "development" : "production";
             }
-            config.ReportUncaughtExceptionsAsHandled = ReportUncaughtExceptionsAsHandled;
+            config.ReportExceptionLogsAsHandled = ReportExceptionLogsAsHandled;
             config.SendLaunchCrashesSynchronously = SendLaunchCrashesSynchronously;
             config.UniqueLogsTimePeriod = TimeSpan.FromSeconds(SecondsPerUniqueLog);
             config.VersionCode = VersionCode;

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -198,7 +198,7 @@ namespace BugsnagUnity
         void MultiThreadedNotify(string condition, string stackTrace, LogType logType)
         {
             // Discard messages from the main thread as they will be reported separately
-            if (!object.ReferenceEquals(Thread.CurrentThread, MainThread))
+            if (!ReferenceEquals(Thread.CurrentThread, MainThread))
             {
                 Notify(condition, stackTrace, logType);
             }
@@ -214,8 +214,11 @@ namespace BugsnagUnity
         /// <param name="logType"></param>
         void Notify(string condition, string stackTrace, LogType logType)
         {
-
-            if (Configuration.AutoDetectErrors && logType.IsGreaterThanOrEqualTo(Configuration.NotifyLogLevel) && Configuration.IsUnityLogErrorTypeEnabled(logType))
+            if (!Configuration.EnabledErrorTypes.UnityLog)
+            {
+                return;
+            }
+            if (Configuration.AutoDetectErrors && logType.IsGreaterThanOrEqualTo(Configuration.NotifyLogLevel))
             {
                 var logMessage = new UnityLogMessage(condition, stackTrace, logType);
                 var shouldSend = Error.ShouldSend(logMessage)
@@ -225,7 +228,7 @@ namespace BugsnagUnity
                 {
                     var severity = Configuration.LogTypeSeverityMapping.Map(logType);
                     var backupStackFrames = new System.Diagnostics.StackTrace(1, true).GetFrames();
-                    var forceUnhandled = logType == LogType.Exception && !Configuration.ReportUncaughtExceptionsAsHandled;
+                    var forceUnhandled = logType == LogType.Exception && !Configuration.ReportExceptionLogsAsHandled;
                     var exception = Error.FromUnityLogMessage(logMessage, backupStackFrames, severity, forceUnhandled);
                     Notify(new Error[] { exception }, exception.HandledState, null, logType);
                 }

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -56,7 +56,7 @@ namespace BugsnagUnity
 
         public string PersistenceDirectory;
 
-        public bool ReportUncaughtExceptionsAsHandled = true;
+        public bool ReportExceptionLogsAsHandled = true;
 
         public TimeSpan MaximumLogsTimePeriod = TimeSpan.FromSeconds(1);
 
@@ -174,29 +174,6 @@ namespace BugsnagUnity
             return DiscardClasses != null && DiscardClasses.Contains(className);
         }
 
-        internal bool IsUnityLogErrorTypeEnabled(LogType logType)
-        {
-            if (!AutoDetectErrors)
-            {
-                return false;
-            }
-            switch (logType)
-            {
-                case LogType.Error:
-                    return EnabledErrorTypes.UnityErrorLogs;
-                case LogType.Warning:
-                    return EnabledErrorTypes.UnityWarningLogs;
-                case LogType.Log:
-                    return EnabledErrorTypes.UnityLogLogs;
-                case LogType.Exception:
-                    return EnabledErrorTypes.UnhandledExceptions;
-                case LogType.Assert:
-                    return EnabledErrorTypes.UnityAssertLogs;
-                default:
-                    return false;
-            }
-        }
-
         private bool IsRunningInEditor()
         {
             return Application.platform == RuntimePlatform.OSXEditor
@@ -297,12 +274,8 @@ namespace BugsnagUnity
         public bool ANRs = true;
         public bool AppHangs = true;
         public bool OOMs = true;
-        public bool NativeCrashes = true;
-        public bool UnhandledExceptions = true;
-        public bool UnityLogLogs = false;
-        public bool UnityWarningLogs = false;
-        public bool UnityAssertLogs = false;
-        public bool UnityErrorLogs = true;
+        public bool Crashes = true;
+        public bool UnityLog = true;
 
         public EnabledErrorTypes()
         { }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -245,8 +245,8 @@ namespace BugsnagUnity
             using (AndroidJavaObject errorTypes = new AndroidJavaObject("com.bugsnag.android.ErrorTypes"))
             {
                 errorTypes.Call("setAnrs", config.EnabledErrorTypes.ANRs);
-                errorTypes.Call("setNdkCrashes", config.EnabledErrorTypes.NativeCrashes);
-                errorTypes.Call("setUnhandledExceptions", config.EnabledErrorTypes.NativeCrashes);
+                errorTypes.Call("setNdkCrashes", config.EnabledErrorTypes.Crashes);
+                errorTypes.Call("setUnhandledExceptions", config.EnabledErrorTypes.Crashes);
                 obj.Call("setEnabledErrorTypes", errorTypes);
             }
 

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -155,7 +155,7 @@ namespace BugsnagUnity
             {
                 enabledTypes.Add("AppHangs");
             }
-            if (config.EnabledErrorTypes.NativeCrashes)
+            if (config.EnabledErrorTypes.Crashes)
             {
                 enabledTypes.Add("UnhandledExceptions");
                 enabledTypes.Add("Signals");

--- a/tests/BugsnagUnity.Tests/ConfigurationTests.cs
+++ b/tests/BugsnagUnity.Tests/ConfigurationTests.cs
@@ -12,7 +12,7 @@ namespace BugsnagUnity.Payload.Tests
         public void DefaultConfigurationValues()
         {
             var config = new Configuration("foo");
-            Assert.IsTrue(config.ReportUncaughtExceptionsAsHandled);
+            Assert.IsTrue(config.ReportExceptionLogsAsHandled);
             Assert.IsTrue(config.AutoDetectErrors);
             Assert.IsTrue(config.AutoTrackSessions);
             Assert.AreEqual("production", config.ReleaseStage);


### PR DESCRIPTION
## Goal

Make the changes  to EnabledErrorTypes specificed by the product team

## Changeset

- Removed granular UnityLogType error types
- Replaced them with just UnityLog error type
- Removed Unhandled Exceptions type
- Renamed NativeCrashes to Crashes
- Renamed reportUncaughtExceptionsAsHandled to reportExceptionLogsAsHandled

## Testing

Updated existing CI tests