### PR TITLE
fix(breadcrumbs): fix breadcrumbs not being editable in callbacks

### DIFF
--- a/features/desktop/breadcrumbs.feature
+++ b/features/desktop/breadcrumbs.feature
@@ -21,9 +21,10 @@ Feature: Leaving breadcrumbs to attach to reports
         Then the error is valid for the error reporting API sent by the Unity notifier
         And the exception "errorClass" equals "ExecutionEngineException"
         And the exception "message" equals "Invalid runtime"
-        And the event has a "log" breadcrumb named "Warning"
+        And the event has a "log" breadcrumb named "Failed to validate credentials"
         And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
-        And the event "breadcrumbs.1.metaData.message" equals "Failed to validate credentials"
+        And the event "breadcrumbs.1.name" equals "Failed to validate credentials"
+        And the event "breadcrumbs.1.metaData.logLevel" equals "Warning"
 
     Scenario: Attaching a complex breadcrumb to a report
         When I run the game in the "ComplexBreadcrumbNotify" state
@@ -69,6 +70,6 @@ Feature: Leaving breadcrumbs to attach to reports
         And the event "breadcrumbs.1.name" equals "Crumb 3"
         And the event "breadcrumbs.2.name" equals "Crumb 4"
         And the event "breadcrumbs.3.name" equals "Crumb 5"
-        And the event "breadcrumbs.4.name" equals "Log"
+        And the event "breadcrumbs.4.name" equals "Item #1 is: 1"
 
 

--- a/features/desktop/callbacks.feature
+++ b/features/desktop/callbacks.feature
@@ -30,6 +30,20 @@ Feature: Callbacks
         And the event "app.dsymUuid" equals "DsymUuid"
         And the event "app.inForeground" is false
         And the event "app.isLaunching" is false
+        
+        #exception data
+        And the event "exceptions.0.errorClass" equals "ErrorClass"
+        And the event "exceptions.0.stacktrace.0.method" equals "Method"
+        And the event "exceptions.0.stacktrace.0.lineNumber" equals 0
+
+        #breadcrumbs
+        And the event "breadcrumbs.0.type" equals "request"
+        And the event "breadcrumbs.0.name" equals "Custom Message"
+        And the event "breadcrumbs.0.metaData.test" equals "test"
+
+        #metadata
+        And the event "metaData.test1.test" equals "test"
+        And the event "metaData.test2" is null
 
 
         

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -302,6 +302,18 @@ public class Main : MonoBehaviour
 
                     @event.Errors[0].Stacktrace[0].Method = "Method";
 
+                    foreach (var crumb in @event.Breadcrumbs)
+                    {
+                        crumb.Message = "Custom Message";
+                        crumb.Type = BreadcrumbType.Request;
+                        crumb.Metadata = new Dictionary<string, object> { {"test", "test" } };
+                    }
+
+                    @event.AddMetadata("test1", new Dictionary<string, object> { { "test", "test" } });
+                    @event.AddMetadata("test2", new Dictionary<string, object> { { "test", "test" } });
+                    @event.ClearMetadata("test2");
+
+
                     return true;
                 });
                 break;

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -236,9 +236,11 @@ namespace BugsnagUnity
             }
             else if (Configuration.ShouldLeaveLogBreadcrumb(logType))
             {
-                Breadcrumbs.Leave(logType.ToString(), new Dictionary<string, object> {
-                    { "message", condition },
-                }, BreadcrumbType.Log );
+                var metadata = new Dictionary<string, object>()
+                {
+                    {"logLevel" , logType.ToString() }
+                };
+                Breadcrumbs.Leave(condition, metadata, BreadcrumbType.Log );
             }
         }
 

--- a/src/BugsnagUnity/Native/Android/Breadcrumbs.cs
+++ b/src/BugsnagUnity/Native/Android/Breadcrumbs.cs
@@ -31,7 +31,7 @@ namespace BugsnagUnity
         /// <param name="breadcrumb"></param>
         public void Leave(Breadcrumb breadcrumb)
         {
-            NativeInterface.LeaveBreadcrumb(breadcrumb.Name, breadcrumb.Type.ToString(), breadcrumb.Metadata);
+            NativeInterface.LeaveBreadcrumb(breadcrumb.Message, breadcrumb.Type.ToString(), breadcrumb.Metadata);
         }
 
         /// <summary>

--- a/src/BugsnagUnity/Native/Cocoa/Breadcrumbs.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Breadcrumbs.cs
@@ -39,12 +39,12 @@ namespace BugsnagUnity
                         writer.Flush();
                         stream.Position = 0;
                         var jsonString = reader.ReadToEnd();
-                        NativeCode.bugsnag_addBreadcrumb(breadcrumb.Name, breadcrumb.Type.ToString().ToLower(), jsonString);
+                        NativeCode.bugsnag_addBreadcrumb(breadcrumb.Message, breadcrumb.Type.ToString().ToLower(), jsonString);
                     }                    
                 }
                 else
                 {
-                    NativeCode.bugsnag_addBreadcrumb(breadcrumb.Name, breadcrumb.Type.ToString().ToLower(), null);
+                    NativeCode.bugsnag_addBreadcrumb(breadcrumb.Message, breadcrumb.Type.ToString().ToLower(), null);
                 }
             }
         }
@@ -68,7 +68,7 @@ namespace BugsnagUnity
         }
 
         [MonoPInvokeCallback(typeof(NativeCode.BreadcrumbInformation))]
-        static void PopulateBreadcrumb(IntPtr instance, string name, string timestamp, string type, string metadataJson)
+        static void PopulateBreadcrumb(IntPtr instance, string message, string timestamp, string type, string metadataJson)
         {
             var handle = GCHandle.FromIntPtr(instance);
             if (handle.Target is List<Breadcrumb> breadcrumbs)
@@ -76,11 +76,11 @@ namespace BugsnagUnity
                 if (!string.IsNullOrEmpty(metadataJson))
                 {
                     var metadata = ((JsonObject)SimpleJson.DeserializeObject(metadataJson)).GetDictionary();
-                    breadcrumbs.Add(new Breadcrumb(name, timestamp, type, metadata));
+                    breadcrumbs.Add(new Breadcrumb(message, timestamp, type, metadata));
                 }
                 else
                 {
-                    breadcrumbs.Add(new Breadcrumb(name, timestamp, type, null));
+                    breadcrumbs.Add(new Breadcrumb(message, timestamp, type, null));
                 }
 
                 

--- a/src/BugsnagUnity/Payload/Breadcrumb.cs
+++ b/src/BugsnagUnity/Payload/Breadcrumb.cs
@@ -9,39 +9,37 @@ namespace BugsnagUnity.Payload
     /// </summary>
     public class Breadcrumb : PayloadContainer, IBreadcrumb
     {
-        private const string UNDEFINED_NAME = "Breadcrumb";
-        private const string NAME_KEY = "name";
-        private const string MESSAGE_KEY = "message";
+        private const string MESSAGE_KEY = "name";
         private const string TIMESTAMP_KEY = "timestamp";
         private const string METADATA_KEY = "metaData";
         private const string TYPE_KEY = "type";
 
         internal static Breadcrumb FromReport(Report report)
         {
-            var name = "Error";
+            var message = "Error";
             var metadata = new Dictionary<string, object> { };
             if (report.Context != null)
             {
                 metadata["context"] = report.Context;
             }
-
             if (report.Exceptions != null && report.Exceptions.Any())
             {
                 var exception = report.Exceptions.First();
-                name = exception.ErrorClass;
-                metadata.Add("message", exception.ErrorMessage);
+                metadata["message"] = exception.ErrorMessage;
+                metadata["errorClass"] = exception.ErrorClass;
+                metadata["unhandled"] = !report.IsHandled;
+                metadata["severity"] = report.OriginalSeverity;
+                message = exception.ErrorClass;
             }
-
-            return new Breadcrumb(name, metadata, BreadcrumbType.Error);
+            return new Breadcrumb(message, metadata, BreadcrumbType.Error);
         }
 
         /// <summary>
         /// Used to construct a breadcrumb from the native data obtained from a
         /// native notifier if present.
         /// </summary>
-        internal Breadcrumb(string name, string timestamp, string type, IDictionary<string, object> metadata)
+        internal Breadcrumb(string message, string timestamp, string type, IDictionary<string, object> metadata)
         {
-            Name = name;
             Timestamp = DateTimeOffset.Parse( timestamp );
             Metadata = metadata;
             if (string.IsNullOrEmpty(type))
@@ -52,35 +50,31 @@ namespace BugsnagUnity.Payload
             {
                 Type = ParseBreadcrumbType(type);
             }
+            Message = message;
         }
 
-        internal Breadcrumb(string name, IDictionary<string, object> metadata, BreadcrumbType type)
+        internal Breadcrumb(string message,IDictionary<string, object> metadata, BreadcrumbType type)
         {
-            if (name == null)
-            {
-                name = UNDEFINED_NAME;
-            }
-            Name = name;
             Timestamp = DateTime.UtcNow;
             Metadata = metadata;
             Type = type;
+            Message = message;
         }
 
         public IDictionary<string, object> Metadata
         {
             get
             {
+                if (Get(METADATA_KEY) == null)
+                {
+                    Metadata = new Dictionary<string, object>();
+                }
                 return Get(METADATA_KEY) as IDictionary<string, object>;
             }
             set
             {
                 Add(METADATA_KEY, value);
             }
-        }
-
-        public string Name {
-            get { return Get(NAME_KEY) as string; }
-            set { Add(NAME_KEY,value); }
         }
 
         public string Message
@@ -91,7 +85,6 @@ namespace BugsnagUnity.Payload
 
         public BreadcrumbType Type {
             get {
-
                 var stringValue = (string)Get(TYPE_KEY);
                 return ParseBreadcrumbType(stringValue);
             }

--- a/src/BugsnagUnity/Payload/Breadcrumb.cs
+++ b/src/BugsnagUnity/Payload/Breadcrumb.cs
@@ -9,6 +9,7 @@ namespace BugsnagUnity.Payload
     /// </summary>
     public class Breadcrumb : PayloadContainer, IBreadcrumb
     {
+        // Notifier spec specifies Message, but the pipeline is still expecting the legacy field name
         private const string MESSAGE_KEY = "name";
         private const string TIMESTAMP_KEY = "timestamp";
         private const string METADATA_KEY = "metaData";


### PR DESCRIPTION
## Goal

Fallback Breadcrumbs were not up to spec and this was causing confusion when trying to edit crumbs in an event callback

## Changeset

- Refactored Breadcrumb.cs to be up to spec
- Updated the automatic recording of log and error breadcrumbs to be up to spec

## Testing

Improved existing desktop tests