### PR TITLE
fix(metadata): fix ClearMetadata

### DIFF
--- a/features/android/android_metadata.feature
+++ b/features/android/android_metadata.feature
@@ -1,0 +1,21 @@
+Feature: Android smoke tests for Metadata
+
+    Background:
+        Given I wait for the mobile game to start
+
+    Scenario: Clear Metadata
+        When I run the "Clear Metadata" mobile scenario
+        Then I wait to receive an error
+       
+        # MetaData
+        And the event "metaData.test.test1" equals "test1"
+        And the event "metaData.test.test2" is null
+        And the event "metaData.test3.test3" equals "test3"
+        And the event "metaData.test4" is null
+
+
+
+
+
+
+

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -36,7 +36,6 @@ public class Main : MonoBehaviour
         ParseUrlParameters();
  
 #endif
-
         var scenario = GetEvnVar("BUGSNAG_SCENARIO");
         var config = PrepareConfig(scenario);
         Invoke("CloseApplication", _closeTime);
@@ -46,6 +45,11 @@ public class Main : MonoBehaviour
         Bugsnag.AddMetadata("init", new Dictionary<string, object>(){
             {"foo", "bar" },
         });
+
+        Bugsnag.AddMetadata("test","test1","test1");
+
+        Bugsnag.AddMetadata("test", "test2", "test2");
+
         Bugsnag.AddMetadata("custom", new Dictionary<string, object>(){
             {"letter", "QX" },
             {"better", 400 },
@@ -53,12 +57,17 @@ public class Main : MonoBehaviour
             {"int-array", new int []{1,2,3} },
             {"dict", new Dictionary<string,object>(){ {"test" , 123 } } }  
         });
+
         Bugsnag.AddMetadata("app", new Dictionary<string, object>(){
             {"buildno", "0.1" },
             {"cache", null },
         });
+
         // Remove a tab
         Bugsnag.ClearMetadata("init");
+
+        // Remove a value
+        Bugsnag.ClearMetadata("test","test2");
 
         // trigger the crash
         RunScenario(scenario);

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -45,6 +45,8 @@ public class MobileScenarioRunner : MonoBehaviour {
         { "28", "Session Callback" },
         { "29", "On Send Native Callback" },
         { "30", "Inf Launch Duration" },
+        { "31", "Clear Metadata" },
+
 
         // Commands
         {"90", "Clear iOS Data" },
@@ -360,6 +362,17 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         switch (scenarioName)
         {
+            case "Clear Metadata":
+
+                Bugsnag.AddMetadata("test","test1","test1");
+                Bugsnag.AddMetadata("test", "test2", "test2");
+                Bugsnag.ClearMetadata("test","test2");
+                Bugsnag.AddMetadata("test3", "test3", "test3");
+                Bugsnag.AddMetadata("test4", "test4", "test4");
+                Bugsnag.ClearMetadata("test4");
+                ThrowException();
+
+                break;
             case "Inf Launch Duration":
                 Invoke("ThrowException",6);
                 break;

--- a/features/ios/ios_metadata.feature
+++ b/features/ios/ios_metadata.feature
@@ -1,0 +1,21 @@
+Feature: Android smoke tests for Metadata
+
+    Background:
+        Given I wait for the mobile game to start
+
+    Scenario: Clear Metadata
+        When I run the "Clear Metadata" mobile scenario
+        Then I wait to receive an error
+       
+        # MetaData
+        And the event "metaData.test.test1" equals "test1"
+        And the event "metaData.test.test2" is null
+        And the event "metaData.test3.test3" equals "test3"
+        And the event "metaData.test4" is null
+
+
+
+
+
+
+

--- a/features/ios/ios_metadata.feature
+++ b/features/ios/ios_metadata.feature
@@ -13,10 +13,3 @@ Feature: Android smoke tests for Metadata
         And the event "metaData.test.test2" is null
         And the event "metaData.test3.test3" equals "test3"
         And the event "metaData.test4" is null
-
-
-
-
-
-
-

--- a/features/ios/ios_metadata.feature
+++ b/features/ios/ios_metadata.feature
@@ -2,6 +2,7 @@ Feature: Android smoke tests for Metadata
 
     Background:
         Given I wait for the mobile game to start
+        And I clear all persistent data
 
     Scenario: Clear Metadata
         When I run the "Clear Metadata" mobile scenario

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -53,6 +53,7 @@ def dial_number_for(name)
       "Session Callback" => 28,
       "On Send Native Callback" => 29,
       "Inf Launch Duration" => 30,
+      "Clear Metadata" => 31,
 
 
 
@@ -243,6 +244,8 @@ Then("custom metadata is included in the event") do
     And the event "metaData.init" is null
     And the event "metaData.custom.letter" equals "QX"
     And the event "metaData.custom.better" equals 400
+    And the event "metaData.test.test1" equals "test1"
+    And the event "metaData.test.test2" is null
     And the error payload field "events.0.metaData.custom.int-array" is a non-empty array
     And the error payload field "events.0.metaData.custom.string-array" is a non-empty array
     And the error payload field "events.0.metaData.custom.dict" is not null

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -39,6 +39,22 @@ const char * getMetadataJson(NSDictionary* dictionary){
     return NULL;
 }
 
+void bugsnag_clearMetadata(const char * section){
+    if(section == NULL)
+    {
+        return;   
+    }
+    [Bugsnag clearMetadataFromSection:@(section)];
+}
+
+void bugsnag_clearMetadataWithKey(const char * section, const char * key){
+    if(section == NULL || key == NULL)
+    {
+        return;   
+    }
+    [Bugsnag clearMetadataFromSection:@(section) withKey:@(key)];
+}
+
 NSDictionary * getDictionaryFromMetadataJson(const char * jsonString){
     @try {
         NSError *error = nil;

--- a/src/BugsnagUnity/AutomaticDataCollector.cs
+++ b/src/BugsnagUnity/AutomaticDataCollector.cs
@@ -14,7 +14,7 @@ namespace BugsnagUnity
             var appMetadata = new Dictionary<string, object>();
             appMetadata.Add("companyName", Application.companyName);
             appMetadata.Add("name", Application.productName);
-            nativeClient.SetNativeMetadata("app",appMetadata);
+            nativeClient.AddNativeMetadata("app",appMetadata);
 
             //data added to metadata.device
             var deviceMetadata = new Dictionary<string, object>();
@@ -30,7 +30,7 @@ namespace BugsnagUnity
                 deviceMetadata.Add("processorType", processorType);
             }
             deviceMetadata.Add("osLanguage", Application.systemLanguage.ToString());
-            nativeClient.SetNativeMetadata("device", deviceMetadata);
+            nativeClient.AddNativeMetadata("device", deviceMetadata);
         }
 
         internal static void AddStatefulDeviceData(Metadata metadata)

--- a/src/BugsnagUnity/AutomaticDataCollector.cs
+++ b/src/BugsnagUnity/AutomaticDataCollector.cs
@@ -14,7 +14,7 @@ namespace BugsnagUnity
             var appMetadata = new Dictionary<string, object>();
             appMetadata.Add("companyName", Application.companyName);
             appMetadata.Add("name", Application.productName);
-            nativeClient.SetMetadata("app",appMetadata);
+            nativeClient.SetNativeMetadata("app",appMetadata);
 
             //data added to metadata.device
             var deviceMetadata = new Dictionary<string, object>();
@@ -30,7 +30,7 @@ namespace BugsnagUnity
                 deviceMetadata.Add("processorType", processorType);
             }
             deviceMetadata.Add("osLanguage", Application.systemLanguage.ToString());
-            nativeClient.SetMetadata("device", deviceMetadata);
+            nativeClient.SetNativeMetadata("device", deviceMetadata);
         }
 
         internal static void AddStatefulDeviceData(Metadata metadata)

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -355,7 +355,7 @@ namespace BugsnagUnity
 
             var eventMetadata = new Metadata();
 
-            NativeClient.PopulateMetadata(eventMetadata);
+            eventMetadata.MergeMetadata(NativeClient.GetNativeMetadata());
 
             AutomaticDataCollector.AddStatefulDeviceData(eventMetadata);
 

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -48,12 +48,6 @@ namespace BugsnagUnity
         void PopulateDeviceWithState(DeviceWithState device);
 
         /// <summary>
-        /// Adds the metadata to the native clients metadata
-        /// </summary>
-        /// <param name="metadata"></param>
-        void SetMetadata(string section, Dictionary<string, object> metadata);
-
-        /// <summary>
         /// Send the start session message to a native notifier
         /// </summary>
         void StartSession();
@@ -90,12 +84,6 @@ namespace BugsnagUnity
         void PopulateUser(User user);
 
         /// <summary>
-        /// Populates any native metadata.
-        /// </summary>
-        /// <param name="metadata"></param>
-        void PopulateMetadata(Metadata metadata);
-
-        /// <summary>
         /// Mutates the context.
         /// </summary>
         /// <param name="context"></param>
@@ -110,6 +98,14 @@ namespace BugsnagUnity
         /// Get the last run information from Android and cocoa platforms
         /// </summary>
         LastRunInfo GetLastRunInfo();
+
+        void ClearNativeMetadata(string section);
+
+        void ClearNativeMetadata(string section, string key);
+
+        void SetNativeMetadata(string section, IDictionary<string, object> data);
+
+        IDictionary<string, object> GetNativeMetadata();
 
     }
 }

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -103,7 +103,7 @@ namespace BugsnagUnity
 
         void ClearNativeMetadata(string section, string key);
 
-        void SetNativeMetadata(string section, IDictionary<string, object> data);
+        void AddNativeMetadata(string section, IDictionary<string, object> data);
 
         IDictionary<string, object> GetNativeMetadata();
 

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -127,7 +127,7 @@ namespace BugsnagUnity
             return NativeInterface.GetMetadata();
         }
 
-        public void SetNativeMetadata(string section, IDictionary<string, object> data)
+        public void AddNativeMetadata(string section, IDictionary<string, object> data)
         {
             foreach (var pair in data)
             {

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -57,27 +57,7 @@ namespace BugsnagUnity
             {
                 user.Payload.AddToPayload(entry.Key, entry.Value.ToString());
             }
-        }
-
-        public void SetMetadata(string section, Dictionary<string, object> metadata)
-        {
-            if (metadata != null)
-            {
-                foreach (var item in metadata)
-                {
-                    NativeInterface.AddToTab(section, item.Key, item.Value.ToString());
-                }
-            }
-            else
-            {
-                NativeInterface.RemoveMetadata(section);
-            }
-        }
-
-        public void PopulateMetadata(Metadata metadata)
-        {
-            metadata.MergeMetadata(NativeInterface.GetMetadata());
-        }
+        }       
 
         private void MergeDictionaries(IDictionary<string, object> dest, IDictionary<string, object> another)
         {
@@ -132,6 +112,28 @@ namespace BugsnagUnity
             return NativeInterface.GetlastRunInfo();
         }
 
+        public void ClearNativeMetadata(string section)
+        {
+            NativeInterface.ClearMetadata(section);
+        }
+
+        public void ClearNativeMetadata(string section, string key)
+        {
+            NativeInterface.ClearMetadata(section,key);
+        }
+
+        public IDictionary<string, object> GetNativeMetadata()
+        {
+            return NativeInterface.GetMetadata();
+        }
+
+        public void SetNativeMetadata(string section, IDictionary<string, object> data)
+        {
+            foreach (var pair in data)
+            {
+                NativeInterface.AddMetadata(section,pair.Key,pair.Value.ToString());
+            }
+        }
     }
 
 }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -525,7 +525,7 @@ namespace BugsnagUnity
             return GetJavaMapData("getUser");
         }
 
-        public void RemoveMetadata(string tab)
+        public void ClearMetadata(string tab)
         {
             if (tab == null)
             {
@@ -534,7 +534,16 @@ namespace BugsnagUnity
             CallNativeVoidMethod("clearMetadata", "(Ljava/lang/String;Ljava/lang/String;)V", new object[] { tab, null });
         }
 
-        public void AddToTab(string tab, string key, string value)
+        public void ClearMetadata(string tab, string key)
+        {
+            if (tab == null)
+            {
+                return;
+            }
+            CallNativeVoidMethod("clearMetadata", "(Ljava/lang/String;Ljava/lang/String;)V", new object[] { tab, key });
+        }
+
+        public void AddMetadata(string tab, string key, string value)
         {
             if (tab == null || key == null)
             {
@@ -543,6 +552,8 @@ namespace BugsnagUnity
             CallNativeVoidMethod("addMetadata", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V",
                 new object[] { tab, key, value });
         }
+
+       
 
         public void LeaveBreadcrumb(string name, string type, IDictionary<string, object> metadata)
         {

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -553,8 +553,6 @@ namespace BugsnagUnity
                 new object[] { tab, key, value });
         }
 
-       
-
         public void LeaveBreadcrumb(string name, string type, IDictionary<string, object> metadata)
         {
             if (!CanRunJNI())

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -278,34 +278,6 @@ namespace BugsnagUnity
             user.Id = Marshal.PtrToStringAuto(nativeUser.Id);
         }
 
-        public void SetMetadata(string section, Dictionary<string, object> metadataSection)
-        {
-            if (metadataSection != null)
-            {
-                using (var stream = new MemoryStream())
-                using (var reader = new StreamReader(stream))
-                using (var writer = new StreamWriter(stream, new UTF8Encoding(false)) { AutoFlush = false })
-                {
-                    SimpleJson.SerializeObject(metadataSection, writer);
-                    writer.Flush();
-                    stream.Position = 0;
-                    var jsonString = reader.ReadToEnd();
-                    NativeCode.bugsnag_setMetadata(section, jsonString);
-                }
-            }
-            else
-            {
-                NativeCode.bugsnag_removeMetadata(NativeConfiguration, section);
-            }
-        }
-
-        public void PopulateMetadata(Metadata metadata)
-        {           
-            var result =  NativeCode.bugsnag_retrieveMetaData();
-            var dictionary = ((JsonObject)SimpleJson.DeserializeObject(result)).GetDictionary();
-            metadata.MergeMetadata(dictionary);
-        }
-
         public void SetUser(User user)
         {
             NativeCode.bugsnag_setUser(user.Id, user.Name, user.Email);
@@ -403,5 +375,44 @@ namespace BugsnagUnity
             }
         }
 
+        public void ClearNativeMetadata(string section)
+        {
+            NativeCode.bugsnag_clearMetadata(section);
+        }
+
+        public void ClearNativeMetadata(string section, string key)
+        {
+            NativeCode.bugsnag_clearMetadataWithKey(section,key);
+        }
+
+        public void SetNativeMetadata(string section, IDictionary<string, object> data)
+        {
+            if (data != null)
+            {
+                using (var stream = new MemoryStream())
+                using (var reader = new StreamReader(stream))
+                using (var writer = new StreamWriter(stream, new UTF8Encoding(false)) { AutoFlush = false })
+                {
+                    SimpleJson.SerializeObject(data, writer);
+                    writer.Flush();
+                    stream.Position = 0;
+                    var jsonString = reader.ReadToEnd();
+                    NativeCode.bugsnag_setMetadata(section, jsonString);
+                }
+            }
+            else
+            {
+                NativeCode.bugsnag_removeMetadata(NativeConfiguration, section);
+            }
+        }
+
+        public IDictionary<string, object> GetNativeMetadata()
+        {
+            var result = NativeCode.bugsnag_retrieveMetaData();
+            var dictionary = ((JsonObject)SimpleJson.DeserializeObject(result)).GetDictionary();
+            return dictionary;
+        }
+
+      
     }
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -385,7 +385,7 @@ namespace BugsnagUnity
             NativeCode.bugsnag_clearMetadataWithKey(section,key);
         }
 
-        public void SetNativeMetadata(string section, IDictionary<string, object> data)
+        public void AddNativeMetadata(string section, IDictionary<string, object> data)
         {
             if (data != null)
             {

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -249,7 +249,11 @@ namespace BugsnagUnity
         [DllImport(Import)]
         internal static extern string bugsnag_getEventMetaData(IntPtr @event, string section);
 
+        [DllImport(Import)]
+        internal static extern void bugsnag_clearMetadata(string section);
 
+        [DllImport(Import)]
+        internal static extern void bugsnag_clearMetadataWithKey(string section, string key);
     }
 }
 

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -17,6 +17,8 @@ namespace BugsnagUnity
 
         private bool _hasReceivedLowMemoryWarning = false;
 
+        private Metadata _fallbackMetadata = new Metadata();
+
         public NativeClient(Configuration configuration)
         {
             Configuration = configuration;
@@ -57,15 +59,7 @@ namespace BugsnagUnity
         {
         }
 
-        public void PopulateMetadata(Metadata metadata)
-        {
-        }
-       
         public void PopulateUser(User user)
-        {
-        }
-
-        public void SetMetadata(string section, Dictionary<string, object> metadata)
         {
         }
 
@@ -121,19 +115,22 @@ namespace BugsnagUnity
 
         public void ClearNativeMetadata(string section)
         {
+            _fallbackMetadata.ClearMetadata(section);
         }
 
         public void ClearNativeMetadata(string section, string key)
         {
+            _fallbackMetadata.ClearMetadata(section, key);
         }
 
         public void SetNativeMetadata(string section, IDictionary<string, object> data)
         {
+            _fallbackMetadata.AddMetadata(section, data);
         }
 
         public IDictionary<string, object> GetNativeMetadata()
         {
-            return null;
+            return _fallbackMetadata.Payload;
         }
     }
 }

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -13,8 +13,6 @@ namespace BugsnagUnity
 
         public IDelivery Delivery { get; }
 
-        private Metadata _fallbackMetadata = new Metadata();
-
         private bool _launchMarkedAsCompleted = false;
 
         private bool _hasReceivedLowMemoryWarning = false;
@@ -61,7 +59,6 @@ namespace BugsnagUnity
 
         public void PopulateMetadata(Metadata metadata)
         {
-            metadata.MergeMetadata(_fallbackMetadata.Payload);
         }
        
         public void PopulateUser(User user)
@@ -70,7 +67,6 @@ namespace BugsnagUnity
 
         public void SetMetadata(string section, Dictionary<string, object> metadata)
         {
-            _fallbackMetadata.AddMetadata(section,metadata);
         }
 
         public void SetSession(Session session)
@@ -123,5 +119,21 @@ namespace BugsnagUnity
             return null;
         }
 
+        public void ClearNativeMetadata(string section)
+        {
+        }
+
+        public void ClearNativeMetadata(string section, string key)
+        {
+        }
+
+        public void SetNativeMetadata(string section, IDictionary<string, object> data)
+        {
+        }
+
+        public IDictionary<string, object> GetNativeMetadata()
+        {
+            return null;
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -123,7 +123,7 @@ namespace BugsnagUnity
             _fallbackMetadata.ClearMetadata(section, key);
         }
 
-        public void SetNativeMetadata(string section, IDictionary<string, object> data)
+        public void AddNativeMetadata(string section, IDictionary<string, object> data)
         {
             _fallbackMetadata.AddMetadata(section, data);
         }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -18,6 +18,8 @@ namespace BugsnagUnity
 
         private bool _hasReceivedLowMemoryWarning = false;
 
+        private Metadata _fallbackMetadata = new Metadata();
+
         public NativeClient(Configuration configuration)
         {
             Configuration = configuration;
@@ -170,19 +172,22 @@ namespace BugsnagUnity
 
         public void ClearNativeMetadata(string section)
         {
+            _fallbackMetadata.ClearMetadata(section);
         }
 
         public void ClearNativeMetadata(string section, string key)
         {
+            _fallbackMetadata.ClearMetadata(section, key);
         }
 
         public void SetNativeMetadata(string section, IDictionary<string, object> data)
         {
+            _fallbackMetadata.AddMetadata(section, data);
         }
 
         public IDictionary<string, object> GetNativeMetadata()
         {
-            return null;
+            return _fallbackMetadata.Payload;
         }
     }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -180,7 +180,7 @@ namespace BugsnagUnity
             _fallbackMetadata.ClearMetadata(section, key);
         }
 
-        public void SetNativeMetadata(string section, IDictionary<string, object> data)
+        public void AddNativeMetadata(string section, IDictionary<string, object> data)
         {
             _fallbackMetadata.AddMetadata(section, data);
         }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -18,9 +18,6 @@ namespace BugsnagUnity
 
         private bool _hasReceivedLowMemoryWarning = false;
 
-        private Metadata _fallbackMetadata = new Metadata();
-
-
         public NativeClient(Configuration configuration)
         {
             Configuration = configuration;
@@ -82,7 +79,6 @@ namespace BugsnagUnity
 
         public void PopulateMetadata(Metadata metadata)
         {
-            metadata.MergeMetadata(_fallbackMetadata.Payload);
         }
 
         public void PopulateUser(User user)
@@ -91,7 +87,6 @@ namespace BugsnagUnity
 
         public void SetMetadata(string section, Dictionary<string, object> metadata)
         {
-            _fallbackMetadata.AddMetadata(section, metadata);
         }
 
         public void SetSession(Session session)
@@ -169,6 +164,23 @@ namespace BugsnagUnity
         }
 
         public LastRunInfo GetLastRunInfo()
+        {
+            return null;
+        }
+
+        public void ClearNativeMetadata(string section)
+        {
+        }
+
+        public void ClearNativeMetadata(string section, string key)
+        {
+        }
+
+        public void SetNativeMetadata(string section, IDictionary<string, object> data)
+        {
+        }
+
+        public IDictionary<string, object> GetNativeMetadata()
         {
             return null;
         }

--- a/src/BugsnagUnity/Payload/Metadata.cs
+++ b/src/BugsnagUnity/Payload/Metadata.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using BugsnagUnity;
 using UnityEngine;
 
@@ -32,21 +33,21 @@ namespace BugsnagUnity.Payload
             }
             if (SectionExists(section))
             {
-
                 var existingSection = (IDictionary<string, object>)Get(section);
 
-                foreach (var entry in metadataSection)
+                foreach (var key in metadataSection.Keys.ToList())
                 {
-                    if (entry.Value == null)
+                    var value = metadataSection[key];
+                    if (value == null)
                     {
-                        if (existingSection.ContainsKey(entry.Key))
+                        if (existingSection.ContainsKey(key))
                         {
-                            existingSection.Remove(entry.Key);
+                            existingSection.Remove(key);
                         }
                     }
                     else
                     {
-                        existingSection[entry.Key] = entry.Value;
+                        existingSection[key] = value;
                     }
                 }
             }

--- a/src/BugsnagUnity/Payload/Metadata.cs
+++ b/src/BugsnagUnity/Payload/Metadata.cs
@@ -57,7 +57,7 @@ namespace BugsnagUnity.Payload
             }
             if (_nativeClient != null)
             {
-                _nativeClient.SetNativeMetadata(section,metadataSection);
+                _nativeClient.AddNativeMetadata(section,metadataSection);
             }
         }
 

--- a/src/BugsnagUnity/Payload/Metadata.cs
+++ b/src/BugsnagUnity/Payload/Metadata.cs
@@ -54,39 +54,23 @@ namespace BugsnagUnity.Payload
             {
                 Add(section,metadataSection);
             }
-
-            UpdateNativeMetadata(section);
+            if (_nativeClient != null)
+            {
+                _nativeClient.SetNativeMetadata(section,metadataSection);
+            }
         }
 
-        private void UpdateNativeMetadata(string section)
-        {
-
-            if (_nativeClient == null)
-            {
-                return;
-            }
-            var existingSection = (IDictionary<string, object>)Get(section);
-            var stringDict = new Dictionary<string, object>();
-            foreach (var pair in existingSection)
-            {
-                if (pair.Value != null)
-                {
-                    stringDict.Add(pair.Key, pair.Value);
-                }
-            }
-
-            _nativeClient.SetMetadata(section, stringDict);
-        }
+       
 
         public void ClearMetadata(string section)
         {
             if (SectionExists(section))
             {
                 Payload.Remove(section);
-                if (_nativeClient != null)
-                { 
-                    _nativeClient.SetMetadata(section, null);
-                }
+            }
+            if (_nativeClient != null)
+            {
+                _nativeClient.ClearNativeMetadata(section);
             }
         }
 
@@ -98,8 +82,11 @@ namespace BugsnagUnity.Payload
                 if (existingSection.ContainsKey(key))
                 {
                     existingSection.Remove(key);
-                    UpdateNativeMetadata(section);
                 }                
+            }
+            if (_nativeClient != null)
+            {
+                _nativeClient.ClearNativeMetadata(section,key);
             }
         }
 
@@ -123,8 +110,12 @@ namespace BugsnagUnity.Payload
             return null;
         }
 
-        internal void MergeMetadata(Dictionary<string, object> newMetadata)
+        internal void MergeMetadata(IDictionary<string, object> newMetadata)
         {
+            if (newMetadata == null)
+            {
+                return;
+            }
             foreach (var section in newMetadata)
             {
                 var sectionkey = section.Key;


### PR DESCRIPTION
## Goal

ClearMetadata was not working as intended and test covarage needed improving

## Changeset

- Added the following methods to the INativeClient interface: ClearNativeMetadata, SetNativeMetadata, GetNativeMetadata to simplify the code and make it easier to understand the relationship between Native and c# metadata.
- Added new tests for ClearMetadata

## Testing

- Added new tests for ClearMetadata
