### PR TITLE
Use Maze.check abstraction for making test assertions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -128,7 +128,8 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2020.3.23f1.apk"
         upload:
           - "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: maze-runner
         run: maze-runner
         command:
           - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.23f1.apk"

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
-gem "rake"
-gem "xcpretty"
-gem "xcodeproj"
+gem 'rake'
+gem 'xcpretty'
+gem 'xcodeproj'
 
 # Use official Maze Runner release
-gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: "v6.2.1"
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.8.0'
 
 # Use a specific Maze Runner branch
-#gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", branch: "tms/update-cucumber"
+#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'
 
 # Use a local copy of Maze Runner for development purposes
-#gem "bugsnag-maze-runner", path: "../maze-runner"
+#gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: e27004e424b165651f729a574ab21a277c75a355
-  tag: v6.2.1
+  revision: fe12189f83aad154f54221ee0fcd41b483d3c0d1
+  tag: v6.8.0
   specs:
-    bugsnag-maze-runner (6.2.1)
+    bugsnag-maze-runner (6.8.0)
       appium_lib (~> 11.2.0)
+      bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
-      minitest (~> 5.0)
       optimist (~> 3.0.1)
       os (~> 1.0.0)
       rake (~> 12.3.3)
       rubyzip (~> 2.3.2)
       selenium-webdriver (~> 3.11)
-      test-unit (~> 3.3.0)
+      test-unit (~> 3.5.2)
       webrick (~> 1.7.0)
 
 GEM
@@ -30,10 +30,13 @@ GEM
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     atomos (0.1.3)
+    bugsnag (6.24.1)
+      concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)
     claide (1.0.3)
     colored2 (3.1.2)
+    concurrent-ruby (1.1.9)
     cucumber (7.1.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -51,7 +54,7 @@ GEM
       cucumber-gherkin (~> 22.0, >= 22.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
       cucumber-tag-expressions (~> 4.0, >= 4.0.2)
-    cucumber-create-meta (6.0.2)
+    cucumber-create-meta (6.0.4)
       cucumber-messages (~> 17.1, >= 17.1.1)
       sys-uname (~> 1.2, >= 1.2.2)
     cucumber-cucumber-expressions (14.0.0)
@@ -73,10 +76,9 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.15.4)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
-    minitest (5.14.4)
+    mime-types-data (3.2021.1115)
     multi_test (0.1.2)
     nanaimo (0.3.0)
     nokogiri (1.12.5-x86_64-darwin)
@@ -94,7 +96,7 @@ GEM
       rubyzip (>= 1.2.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
-    test-unit (3.3.9)
+    test-unit (3.5.3)
       power_assert
     tomlrb (1.3.0)
     webrick (1.7.0)

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -4,7 +4,7 @@ require 'cgi'
 # Mobile steps
 #
 
-When("I wait for the mobile game to start") do
+When('I wait for the mobile game to start') do
   # Wait for a fixed time period
   # TODO: PLAT-6655 Remove the Unity splash screen so we don't have to wait so long
   sleep 3
@@ -22,39 +22,35 @@ end
 
 def dial_number_for(name)
   lookup = {
-      # Scenarios
-      "throw Exception" => 1,
-      "Log error" => 2,
-      "Native exception" => 3,
-      "Log caught exception" => 4,
-      "NDK signal" => 5,
-      "Notify caught exception" => 6,
-      "Notify with callback" => 7,
-      "Change scene" => 8,
-      "Disable Breadcrumbs" => 9,
-      "Start SDK" => 10,
-      "Max Breadcrumbs" => 11,
-      "Disable Native Errors" => 12,
-      "throw Exception with breadcrumbs" => 13,
-      "Start SDK no errors" => 14,
-      "Discard Error Class" => 15,
-      "Java Background Crash" => 16,
-      "Custom App Type" => 17,
-      "Android Persistence Directory" => 18,
-      "Disabled Release Stage" => 19,
-      "Enabled Release Stage" => 20,
-      "Java Background Crash No Threads" => 21,
-      "iOS Native Error" => 22,
-      "iOS Native Error No Threads" => 23,
-      "Mark Launch Complete" => 24,
-      "Check Last Run Info" => 25,
+    # Scenarios
+    'throw Exception' => 1,
+    'Log error' => 2,
+    'Native exception' => 3,
+    'Log caught exception' => 4,
+    'NDK signal' => 5,
+    'Notify caught exception' => 6,
+    'Notify with callback' => 7,
+    'Change scene' => 8,
+    'Disable Breadcrumbs' => 9,
+    'Start SDK' => 10,
+    'Max Breadcrumbs' => 11,
+    'Disable Native Errors' => 12,
+    'throw Exception with breadcrumbs' => 13,
+    'Start SDK no errors' => 14,
+    'Discard Error Class' => 15,
+    'Java Background Crash' => 16,
+    'Custom App Type' => 17,
+    'Android Persistence Directory' => 18,
+    'Disabled Release Stage' => 19,
+    'Enabled Release Stage' => 20,
+    'Java Background Crash No Threads' => 21,
+    'iOS Native Error' => 22,
+    'iOS Native Error No Threads' => 23,
+    'Mark Launch Complete' => 24,
+    'Check Last Run Info' => 25,
 
-
-
-
-
-      # Commands
-      "Clear iOS Data" => 90
+    # Commands
+    'Clear iOS Data' => 90
   }
   number = lookup[name]
   $logger.debug "Command/scenario '#{name}' has dial-in code #{number}"
@@ -65,27 +61,27 @@ def dial_number_for(name)
   sleep 1
 end
 
-When("I run the {string} command") do |command|
+When('I run the {string} command') do |command|
   dial_number_for command
-  step("I press Run Command")
+  step('I press Run Command')
 end
 
-When("I run the {string} mobile scenario") do |scenario|
+When('I run the {string} mobile scenario') do |scenario|
   dial_number_for scenario
-  step("I press Run Scenario")
+  step('I press Run Scenario')
 end
 
-When("I dial {int}") do |number|
+When('I dial {int}') do |number|
   $logger.debug "Dialling #{number}"
   press_at 40 + (number * 80)
   sleep 1
 end
 
-When("I press Run Scenario") do
+When('I press Run Scenario') do
   press_at 840
 end
 
-When("I press Run Command") do
+When('I press Run Command') do
   press_at 920
 end
 
@@ -112,10 +108,11 @@ end
 #
 # Desktop steps
 #
-When("I run the game in the {string} state") do |state|
+When('I run the game in the {string} state') do |state|
   endpoint = "http://localhost:#{Maze.config.port}"
 
-  if Maze.config.os == 'macos'
+  case Maze.config.os
+  when 'macos'
     Maze::Runner.environment['BUGSNAG_SCENARIO'] = state
     Maze::Runner.environment['BUGSNAG_APIKEY'] = $api_key
     Maze::Runner.environment['MAZE_ENDPOINT'] = endpoint
@@ -124,7 +121,7 @@ When("I run the game in the {string} state") do |state|
     command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args -batchmode -nographics"
     Maze::Runner.run_command(command)
 
-  elsif Maze.config.os == 'windows'
+  when 'windows'
     command = "#{Maze.config.app} -batchmode -nographics"
     env = {
         'BUGSNAG_SCENARIO' => state,
@@ -164,88 +161,90 @@ def check_error_reporting_api(notifier_name)
   )
 end
 
-Then("the error is valid for the error reporting API sent by the native Unity notifier") do
+Then('the error is valid for the error reporting API sent by the native Unity notifier') do
   # This step currently only applies to native errors on macOS macOS
   check_error_reporting_api 'Unity Bugsnag Notifier'
 end
 
-Then("the error is valid for the error reporting API sent by the Unity notifier") do
+Then('the error is valid for the error reporting API sent by the Unity notifier') do
 
-  if Maze.config.farm == :bs
+  os = if Maze.config.farm == :bs
     # Mobile - could be ios or android
-    os = Maze.config.capabilities['os']
+    Maze.config.capabilities['os']
   else
     # Could be windows or macos
-    os = Maze.config.os
+    Maze.config.os
   end
 
-  if os == 'ios'
-    notifier_name = 'Unity Bugsnag Notifier'
-  elsif os == 'android'
-    notifier_name = 'Android Bugsnag Notifier'
-  else
-    notifier_name = 'Unity Bugsnag Notifier'
-  end
+  notifier_name = case os
+                  when 'ios'
+                    'Unity Bugsnag Notifier'
+                  when 'android'
+                    'Android Bugsnag Notifier'
+                  else
+                    'Unity Bugsnag Notifier'
+                  end
 
   check_error_reporting_api notifier_name
 end
 
-Then("the first significant stack frame methods and files should match:") do |expected_values|
-  stacktrace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.exceptions.0.stacktrace")
+Then('the first significant stack frame methods and files should match:') do |expected_values|
+  stacktrace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.exceptions.0.stacktrace')
   expected_frame_values = expected_values.raw
   expected_index = 0
 
-  flunk("The stacktrace is empty") if stacktrace.length == 0
-  flunk("The stacktrace is not long enough") if stacktrace.length < expected_frame_values.length
+  flunk('The stacktrace is empty') if stacktrace.length == 0
+  flunk('The stacktrace is not long enough') if stacktrace.length < expected_frame_values.length
 
   stacktrace.each_with_index do |item, index|
     next if expected_index >= expected_frame_values.length
+
     expected_frames = expected_frame_values[expected_index]
 
     method = item['method']
     next if method.start_with? 'UnityEngine' or method.start_with? 'BugsnagUnity'
 
     frame_matches = expected_frames.any? { |frame| frame == method }
-    assert(frame_matches, "None of the given methods match the frame #{method}")
+    Maze.check.true(frame_matches, "None of the given methods match the frame #{method}")
     expected_index += 1
   end
 end
 
-Then("the current error request events match one of:") do |table|
+Then('the current error request events match one of:') do |table|
   events = Maze::Server.errors.all.map do |error|
-    Maze::Helper.read_key_path(error[:body], "events")
+    Maze::Helper.read_key_path(error[:body], 'events')
   end.flatten
   table.hashes.each do |values|
-    assert_not_nil(events.detect do |event|
-      handled_count = Maze::Helper.read_key_path(event, "session.events.handled")
-      unhandled_count = Maze::Helper.read_key_path(event, "session.events.unhandled")
-      message = Maze::Helper.read_key_path(event, "exceptions.0.message")
-      handled_count == values["handled"].to_i &&
-        unhandled_count == values["unhandled"].to_i &&
-        message == values["message"]
+    Maze.check.not_nil(events.detect do |event|
+      handled_count = Maze::Helper.read_key_path(event, 'session.events.handled')
+      unhandled_count = Maze::Helper.read_key_path(event, 'session.events.unhandled')
+      message = Maze::Helper.read_key_path(event, 'exceptions.0.message')
+      handled_count == values['handled'].to_i &&
+        unhandled_count == values['unhandled'].to_i &&
+        message == values['message']
     end, "No event matches the following values: #{values}")
   end
 end
 
-Then("the event {string} matches one of:") do |path, table|
+Then('the event {string} matches one of:') do |path, table|
   payload_value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{path}")
   valid_values = table.raw.flat_map { |e| e }
-  assert(valid_values.any? { |frame| frame == payload_value }, "Value #{payload_value} did not match any of the expected values")
+  Maze.check.true(valid_values.any? { |frame| frame == payload_value }, "Value #{payload_value} did not match any of the expected values")
 end
 
-Then("custom metadata is included in the event") do
-  steps %Q{
+Then('custom metadata is included in the event') do
+  steps %Q(
     Then the event "metaData.app.buildno" equals "0.1"
     And the event "metaData.app.cache" is null
     And the event "metaData.init" is null
     And the event "metaData.custom.letter" equals "QX"
     And the event "metaData.custom.better" equals "400"
     And the event "metaData.custom.setter" equals "more stuff"
-  }
+  )
 end
 
 # TODO See PLAT-7058
-Then("the event {string} is present from Unity 2018") do |field|
+Then('the event {string} is present from Unity 2018') do |field|
   if ENV['UNITY_VERSION']
     unity_version = ENV['UNITY_VERSION'][0..4].to_i
     if unity_version < 2018


### PR DESCRIPTION
## Goal

Use the `Maze.check` abstraction just added to Maze Runner rather than `assert` functions from the global Ruby namespace (which can be problematic and makes it harder to alter the behaviour of checks if we so wish).

## Changeset

Also corrected a number of Rubocop style violations as part of this change.

## Testing

Covered by a basic CI run.