### PR TITLE
Bump Unity test versions

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -811,12 +811,12 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2019.4.30f1"
+      UNITY_VERSION: "2019.4.32f1"
     command:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/Windows-2019.4.30f1.zip
+      - features/fixtures/maze_runner/build/Windows-2019.4.32f1.zip
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -877,7 +877,7 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2019.4.30f1"
+      UNITY_VERSION: "2019.4.32f1"
     command:
       - scripts/ci-run-windows-tests.bat
     artifact_paths:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -87,7 +87,7 @@ steps:
     agents:
       queue: opensource-mac-unity
     env:
-      UNITY_VERSION: "2021.2.3f1"
+      UNITY_VERSION: "2021.2.7f1"
     plugins:
       artifacts#v1.2.0:
         download:
@@ -97,8 +97,8 @@ steps:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2021.2.3f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2021.2.3f1.zip
+      - features/fixtures/maze_runner/build/MacOS-2021.2.7f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2021.2.7f1.zip
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -166,11 +166,11 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.15
     env:
-      UNITY_VERSION: "2021.2.3f1"
+      UNITY_VERSION: "2021.2.7f1"
     plugins:
       artifacts#v1.2.0:
         download:
-          - features/fixtures/maze_runner/build/MacOS-2021.2.3f1.zip
+          - features/fixtures/maze_runner/build/MacOS-2021.2.7f1.zip
         upload:
           - maze_output/*
           - Mazerunner.log
@@ -235,11 +235,11 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     env:
-      UNITY_VERSION: "2021.2.3f1"
+      UNITY_VERSION: "2021.2.7f1"
     plugins:
       artifacts#v1.2.0:
         download:
-          - features/fixtures/maze_runner/build/WebGL-2021.2.3f1.zip
+          - features/fixtures/maze_runner/build/WebGL-2021.2.7f1.zip
         upload:
           - maze_output/failed/**/*
     commands:
@@ -330,14 +330,14 @@ steps:
     agents:
       queue: opensource-mac-unity
     env:
-      UNITY_VERSION: "2021.2.3f1"
+      UNITY_VERSION: "2021.2.7f1"
     plugins:
       artifacts#v1.2.0:
         download:
           - Bugsnag.unitypackage
           - Bugsnag-with-android-64bit.unitypackage
         upload:
-          - features/fixtures/maze_runner/mazerunner_2021.2.3f1.apk
+          - features/fixtures/maze_runner/mazerunner_2021.2.7f1.apk
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
@@ -432,14 +432,14 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2021.2.3f1.apk"
+          - "features/fixtures/maze_runner/mazerunner_2021.2.7f1.apk"
         upload:
           - "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.3f1.apk"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.7f1.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "features/android"
@@ -616,7 +616,7 @@ steps:
     agents:
       queue: opensource-mac-unity
     env:
-      UNITY_VERSION: "2021.2.3f1"
+      UNITY_VERSION: "2021.2.7f1"
     plugins:
       artifacts#v1.2.0:
         download:
@@ -642,7 +642,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     env:
-      UNITY_VERSION: "2021.2.3f1"
+      UNITY_VERSION: "2021.2.7f1"
     plugins:
       artifacts#v1.2.0:
         download:
@@ -650,7 +650,7 @@ steps:
           - Bugsnag-with-android-64bit.unitypackage
           - project_2021.tgz
         upload:
-          - features/fixtures/maze_runner/mazerunner_2021.2.3f1.ipa
+          - features/fixtures/maze_runner/mazerunner_2021.2.7f1.ipa
           - features/fixtures/unity.log
     commands:
       - tar -zxf project_2021.tgz features/fixtures/maze_runner
@@ -745,14 +745,14 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2021.2.3f1.ipa"
+          - "features/fixtures/maze_runner/mazerunner_2021.2.7f1.ipa"
         upload:
           - "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.3f1.ipa"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.7f1.ipa"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
@@ -831,12 +831,12 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2021.2.3f1"
+      UNITY_VERSION: "2021.2.7f1"
     commands:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/Windows-2021.2.3f1.zip
+      - features/fixtures/maze_runner/build/Windows-2021.2.7f1.zip
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -889,7 +889,7 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2021.2.3f1"
+      UNITY_VERSION: "2021.2.7f1"
     command:
       - scripts/ci-run-windows-tests.bat
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -234,12 +234,12 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2020.3.17f1"
+      UNITY_VERSION: "2020.3.23f1"
     commands:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/Windows-2020.3.17f1.zip
+      - features/fixtures/maze_runner/build/Windows-2020.3.23f1.zip
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -256,7 +256,7 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2020.3.17f1"
+      UNITY_VERSION: "2020.3.23f1"
     command:
       - scripts/ci-run-windows-tests.bat
     artifact_paths:


### PR DESCRIPTION
## Goal

Bump Unity test version for 2021 across the board and 2019 on Windows, which had lagged behind a little.

## Testing

Covered by a full CI run.