### PR TITLE
fix(launchduration): fix for fallback launch duration not being correct

### DIFF
--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -176,7 +176,7 @@ Feature: Reporting unhandled events
         When I run the game in the "InfLaunchDuration" state
         And I wait to receive an error
         Then the error is valid for the error reporting API sent by the Unity notifier
-        And the exception "message" equals "InfLaunch"
+        And the exception "message" equals "Launch"
        
         #app metadata
         And the event "app.isLaunching" is true
@@ -196,7 +196,7 @@ Feature: Reporting unhandled events
         When I run the game in the "InfLaunchDuration" state
         And I wait to receive an error
         Then the error is valid for the error reporting API sent by the Unity notifier
-        And the exception "message" equals "InfLaunch"
+        And the exception "message" equals "Launch"
        
         #app metadata
         And the event "app.isLaunching" equals "true"
@@ -210,4 +210,44 @@ Feature: Reporting unhandled events
        
         #app metadata
         And the event "app.isLaunching" equals "false"
+
+    @macos_only
+    Scenario: Setting long launch time
+        When I run the game in the "LongLaunchDuration" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "message" equals "Launch"
+       
+        #app metadata
+        And the event "app.isLaunching" equals "true"
+
+    @macos_only
+    Scenario: Setting long launch time
+        When I run the game in the "ShortLaunchDuration" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "message" equals "Launch"
+       
+        #app metadata
+        And the event "app.isLaunching" equals "false"
+
+    @windows_only
+    Scenario: Setting long launch time
+        When I run the game in the "LongLaunchDuration" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "message" equals "Launch"
+       
+        #app metadata
+        And the event "app.isLaunching" is true
+
+    @windows_only
+    Scenario: Setting long launch time
+        When I run the game in the "ShortLaunchDuration" state
+        And I wait to receive an error
+        Then the error is valid for the error reporting API sent by the Unity notifier
+        And the exception "message" equals "Launch"
+       
+        #app metadata
+        And the event "app.isLaunching" is false
 

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -222,7 +222,7 @@ Feature: Reporting unhandled events
         And the event "app.isLaunching" equals "true"
 
     @macos_only
-    Scenario: Setting long launch time
+    Scenario: Setting short launch time
         When I run the game in the "ShortLaunchDuration" state
         And I wait to receive an error
         Then the error is valid for the error reporting API sent by the Unity notifier
@@ -240,14 +240,4 @@ Feature: Reporting unhandled events
        
         #app metadata
         And the event "app.isLaunching" is true
-
-    @windows_only
-    Scenario: Setting long launch time
-        When I run the game in the "ShortLaunchDuration" state
-        And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the Unity notifier
-        And the exception "message" equals "Launch"
-       
-        #app metadata
-        And the event "app.isLaunching" is false
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -156,6 +156,14 @@ public class Main : MonoBehaviour
                 config.LaunchDurationMillis = 0;
                 _closeTime = 8;
                 break;
+            case "LongLaunchDuration":
+                config.LaunchDurationMillis = 10000;
+                _closeTime = 12;
+                break;
+            case "ShortLaunchDuration":
+                config.LaunchDurationMillis = 1000;
+                _closeTime = 10;
+                break;
             case "DisabledReleaseStage":
                 config.EnabledReleaseStages = new string[] { "test" };
                 config.ReleaseStage = "somevalue";
@@ -345,12 +353,16 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "LongLaunchDuration":
+            case "ShortLaunchDuration":
+                Invoke("LaunchException", 6);
+                break;
             case "InfLaunchDurationMark":
                 Bugsnag.MarkLaunchCompleted();
                 throw new Exception("InfLaunchDurationMark");
                 break;
             case "InfLaunchDuration":
-                Invoke("InfLaunchException",6);
+                Invoke("LaunchException",6);
                 break;
             case "EventCallbacks":
                 DoNotify();
@@ -719,9 +731,9 @@ public class Main : MonoBehaviour
         Debug.LogException(new System.Exception("auth failed!"));
     }
 
-    void InfLaunchException()
+    void LaunchException()
     {
-        throw new Exception("InfLaunch");
+        throw new Exception("Launch");
     }
 
     void DoUnhandledException(long counter)

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -46,7 +46,7 @@ namespace BugsnagUnity
             }
             else
             {
-                isLaunching = app.DurationInForeground?.Milliseconds < Configuration.LaunchDurationMillis;
+                isLaunching = app.DurationInForeground?.TotalMilliseconds < Configuration.LaunchDurationMillis;
             }
             app.IsLaunching = isLaunching;
         }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -47,7 +47,7 @@ namespace BugsnagUnity
             }
             else
             {
-                isLaunching = app.DurationInForeground?.Milliseconds < Configuration.LaunchDurationMillis;
+                isLaunching = app.DurationInForeground?.TotalMilliseconds < Configuration.LaunchDurationMillis;
             }
             app.IsLaunching = isLaunching;
         }


### PR DESCRIPTION
## Goal

Launch duration was compairing milliseconds instead of TotoalMilliseconds!

## Testing

Added fallback, windows and macos tests