### PR TITLE
task(context): stop sending scene name as context and send as metadata instead

### DIFF
--- a/features/desktop/context.feature
+++ b/features/desktop/context.feature
@@ -2,7 +2,8 @@ Feature: Checking the context of requests
 
 
  Scenario: Manually setting the context and then loading a scene
-        When I run the game in the "CheckForManualContextAfterSceneLoad" state
-        And I wait to receive an error
-        Then the error is valid for the error reporting API sent by the Unity notifier
-        And the event "context" equals "Manually-Set"
+       When I run the game in the "CheckForManualContextAfterSceneLoad" state
+       And I wait to receive an error
+       Then the error is valid for the error reporting API sent by the Unity notifier
+       And the event "context" equals "Manually-Set"
+       And the event "metaData.app.lastLoadedUnityScene" equals "OtherScene"


### PR DESCRIPTION
## Goal

stop sending scene name as context and send as metadata instead

## Changeset

Added the data to metadata when a scene load is detected

## Testing

Added a check to an existing test