### PR TITLE
task(featuresFlags): add feature flags to events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'xcpretty'
 gem 'xcodeproj'
 
 # Use official Maze Runner release
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.8.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.3'
 
 # Use a specific Maze Runner branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/features/android/android_feature_flags.feature
+++ b/features/android/android_feature_flags.feature
@@ -1,0 +1,44 @@
+Feature: Android Feature Flags
+
+    Background:
+        Given I wait for the mobile game to start
+
+     Scenario: Feature Flag in config
+        When I run the "Feature Flags In Config" mobile scenario
+        And I wait for 2 seconds
+        When I clear any error dialogue
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I wait to receive an error
+        
+        And the exception "errorClass" equals "java.lang.RuntimeException"
+
+        And the event "featureFlags.0.featureFlag" equals "testName2"
+        And the event "featureFlags.0.variant" equals "testVarient2"
+        And the event "featureFlags.1" is null
+
+    Scenario: Feature Flag after init
+        When I run the "Feature Flags After Init" mobile scenario
+        And I wait for 2 seconds
+        When I clear any error dialogue
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I wait to receive an error
+        
+        And the exception "errorClass" equals "java.lang.RuntimeException"
+
+        And the event "featureFlags.0.featureFlag" equals "testName2"
+        And the event "featureFlags.0.variant" equals "testVarient2"
+        And the event "featureFlags.1" is null
+
+   Scenario: Feature Flag After Init Clear All
+        When I run the "Feature Flags After Init Clear All" mobile scenario
+        And I wait for 2 seconds
+        When I clear any error dialogue
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I wait to receive an error
+        
+        And the exception "errorClass" equals "java.lang.RuntimeException"
+
+        And the event "featureFlags.0" is null

--- a/features/android/android_feature_flags.feature
+++ b/features/android/android_feature_flags.feature
@@ -28,7 +28,7 @@ Feature: Android Feature Flags
         And the exception "errorClass" equals "java.lang.RuntimeException"
 
         And the event "featureFlags.0.featureFlag" equals "testName2"
-        And the event "featureFlags.0.variant" equals "testVarient2"
+        And the event "featureFlags.0.variant" equals "testVariant2"
         And the event "featureFlags.1" is null
 
    Scenario: Feature Flag After Init Clear All

--- a/features/android/android_feature_flags.feature
+++ b/features/android/android_feature_flags.feature
@@ -14,7 +14,7 @@ Feature: Android Feature Flags
         And the exception "errorClass" equals "java.lang.RuntimeException"
 
         And the event "featureFlags.0.featureFlag" equals "testName2"
-        And the event "featureFlags.0.variant" equals "testVarient2"
+        And the event "featureFlags.0.variant" equals "testVariant2"
         And the event "featureFlags.1" is null
 
     Scenario: Feature Flag after init

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -371,8 +371,8 @@ public class Main : MonoBehaviour
         switch (scenario)
         {
             case "FeatureFlagsAfterInitClearAll":
-                Bugsnag.AddFeatureFlag("testName1", "testVarient1");
-                Bugsnag.AddFeatureFlag("testName2", "testVarient2");
+                Bugsnag.AddFeatureFlag("testName1", "testVariant1");
+                Bugsnag.AddFeatureFlag("testName2", "testVariant2");
                 Bugsnag.ClearFeatureFlags();
                 throw new Exception("FeatureFlags");
                 break;
@@ -382,8 +382,8 @@ public class Main : MonoBehaviour
             case "FeatureFlagsInConfig":
                 throw new Exception("FeatureFlags");
             case "FeatureFlagsAfterInit":
-                Bugsnag.AddFeatureFlag("testName1", "testVarient1");
-                Bugsnag.AddFeatureFlag("testName2", "testVarient2");
+                Bugsnag.AddFeatureFlag("testName1", "testVariant1");
+                Bugsnag.AddFeatureFlag("testName2", "testVariant2");
                 Bugsnag.ClearFeatureFlag("testName1");
                 throw new Exception("FeatureFlags");
             case "SetUserAfterInitCsharpError":

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -152,13 +152,13 @@ public class Main : MonoBehaviour
         switch (scenario)
         {
             case "FeatureFlagsConfigClearAll":
-                config.AddFeatureFlag("testName1", "testVarient1");
-                config.AddFeatureFlag("testName2", "testVarient2");
+                config.AddFeatureFlag("testName1", "testVariant1");
+                config.AddFeatureFlag("testName2", "testVariant2");
                 config.ClearFeatureFlags();
                 break;
             case "FeatureFlagsInConfig":
-                config.AddFeatureFlag("testName1", "testVarient1");
-                config.AddFeatureFlag("testName2", "testVarient2");
+                config.AddFeatureFlag("testName1", "testVariant1");
+                config.AddFeatureFlag("testName2", "testVariant2");
                 config.ClearFeatureFlag("testName1");
                 break;
             case "DisableErrorBreadcrumbs":

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -130,8 +130,6 @@ public class Main : MonoBehaviour
         config.DotnetScriptingRuntime = FindDotnetScriptingRuntime();
         config.DotnetApiCompatibility = FindDotnetApiCompatibility();
 
-
-        config.AddFeatureFlag("testName", "testVarient");
         // prepare scenario-specific config
         PrepareConfigForScenario(config, scenario);
         return config;
@@ -153,6 +151,16 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "FeatureFlagsConfigClearAll":
+                config.AddFeatureFlag("testName1", "testVarient1");
+                config.AddFeatureFlag("testName2", "testVarient2");
+                config.ClearFeatureFlags();
+                break;
+            case "FeatureFlagsInConfig":
+                config.AddFeatureFlag("testName1", "testVarient1");
+                config.AddFeatureFlag("testName2", "testVarient2");
+                config.ClearFeatureFlag("testName1");
+                break;
             case "DisableErrorBreadcrumbs":
                 config.EnabledBreadcrumbTypes = new BreadcrumbType[] { BreadcrumbType.Log };
                 break;
@@ -362,6 +370,22 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "FeatureFlagsAfterInitClearAll":
+                Bugsnag.AddFeatureFlag("testName1", "testVarient1");
+                Bugsnag.AddFeatureFlag("testName2", "testVarient2");
+                Bugsnag.ClearFeatureFlags();
+                throw new Exception("FeatureFlags");
+                break;
+            case "FeatureFlagsConfigClearAll":
+                throw new Exception("FeatureFlags");
+                break;
+            case "FeatureFlagsInConfig":
+                throw new Exception("FeatureFlags");
+            case "FeatureFlagsAfterInit":
+                Bugsnag.AddFeatureFlag("testName1", "testVarient1");
+                Bugsnag.AddFeatureFlag("testName2", "testVarient2");
+                Bugsnag.ClearFeatureFlag("testName1");
+                throw new Exception("FeatureFlags");
             case "SetUserAfterInitCsharpError":
                 Bugsnag.SetUser("1","2","3");
                 Bugsnag.Notify(new Exception("SetUserAfterInitCsharpError"));

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -130,6 +130,8 @@ public class Main : MonoBehaviour
         config.DotnetScriptingRuntime = FindDotnetScriptingRuntime();
         config.DotnetApiCompatibility = FindDotnetApiCompatibility();
 
+
+        config.AddFeatureFlag("testName", "testVarient");
         // prepare scenario-specific config
         PrepareConfigForScenario(config, scenario);
         return config;

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -239,6 +239,7 @@ public class MobileScenarioRunner : MonoBehaviour {
                 break;
 
             case "Session Callback":
+                config.AutoTrackSessions = true;
                 config.AddOnSession((session) => {
 
                     session.Id = "Custom Id";

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -51,6 +51,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         { "34", "Set User After Init Csharp Error" },
         { "35", "Set User After Init Native Error" },
         { "36", "Set User After Init NDK Error" },
+        { "37", "Feature Flags In Config" },
 
 
         // Commands
@@ -135,6 +136,11 @@ public class MobileScenarioRunner : MonoBehaviour {
 
         switch (scenarioName)
         {
+            case "Feature Flags In Config":
+                config.AddFeatureFlag("testName1","testVarient1");
+                config.AddFeatureFlag("testName2", "testVarient2");
+                config.ClearFeatureFlag("testName1");
+                break;
             case "Set User In Config Csharp error":
             case "Set User In Config Native Crash":
                 config.SetUser("1","2","3");
@@ -368,7 +374,13 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         switch (scenarioName)
         {
-
+            case "Feature Flags In Config":
+#if UNITY_ANDROID
+                MobileNative.TriggerBackgroundJavaCrash();
+#elif UNITY_IOS
+                NativeException();
+#endif
+                break;
             case "Set User After Init Csharp Error":
                 Bugsnag.SetUser("1", "2", "3");
                 Bugsnag.Notify(new Exception("SetUserAfterInitCsharpError"));

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -141,8 +141,8 @@ public class MobileScenarioRunner : MonoBehaviour {
         switch (scenarioName)
         {
             case "Feature Flags In Config":
-                config.AddFeatureFlag("testName1","testVarient1");
-                config.AddFeatureFlag("testName2", "testVarient2");
+                config.AddFeatureFlag("testName1","testVariant1");
+                config.AddFeatureFlag("testName2", "testVariant2");
                 config.ClearFeatureFlag("testName1");
                 break;
             case "Set User In Config Csharp error":

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -393,8 +393,8 @@ public class MobileScenarioRunner : MonoBehaviour {
 #endif
                 break;
             case "Feature Flags After Init":
-                Bugsnag.AddFeatureFlag("testName1", "testVarient1");
-                Bugsnag.AddFeatureFlag("testName2", "testVarient2");
+                Bugsnag.AddFeatureFlag("testName1", "testVariant1");
+                Bugsnag.AddFeatureFlag("testName2", "testVariant2");
                 Bugsnag.ClearFeatureFlag("testName1");
 #if UNITY_ANDROID
                 MobileNative.TriggerBackgroundJavaCrash();

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -80,6 +80,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         config.BundleVersion = "1.2.3";
         config.RedactedKeys = new string[] { "test", "password" };
         config.VersionCode = 123;
+        config.AutoTrackSessions = false;
         return config;
     }
 
@@ -323,6 +324,9 @@ public class MobileScenarioRunner : MonoBehaviour {
                 break;
             case "Custom App Type":
                 config.AppType = "test";
+                break;
+            case "Notify with callback":
+                config.AutoTrackSessions = true;
                 break;
             case "Native Event Callback":
                 config.AddOnSendError((@event) => {

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -383,8 +383,8 @@ public class MobileScenarioRunner : MonoBehaviour {
         switch (scenarioName)
         {
             case "Feature Flags After Init Clear All":
-                Bugsnag.AddFeatureFlag("testName1", "testVarient1");
-                Bugsnag.AddFeatureFlag("testName2", "testVarient2");
+                Bugsnag.AddFeatureFlag("testName1", "testVariant1");
+                Bugsnag.AddFeatureFlag("testName2", "testVariant2");
                 Bugsnag.ClearFeatureFlags();
 #if UNITY_ANDROID
                 MobileNative.TriggerBackgroundJavaCrash();

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -52,6 +52,9 @@ public class MobileScenarioRunner : MonoBehaviour {
         { "35", "Set User After Init Native Error" },
         { "36", "Set User After Init NDK Error" },
         { "37", "Feature Flags In Config" },
+        { "38", "Feature Flags After Init" },
+        { "39", "Feature Flags After Init Clear All" },
+
 
 
         // Commands
@@ -374,6 +377,26 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         switch (scenarioName)
         {
+            case "Feature Flags After Init Clear All":
+                Bugsnag.AddFeatureFlag("testName1", "testVarient1");
+                Bugsnag.AddFeatureFlag("testName2", "testVarient2");
+                Bugsnag.ClearFeatureFlags();
+#if UNITY_ANDROID
+                MobileNative.TriggerBackgroundJavaCrash();
+#elif UNITY_IOS
+                NativeException();
+#endif
+                break;
+            case "Feature Flags After Init":
+                Bugsnag.AddFeatureFlag("testName1", "testVarient1");
+                Bugsnag.AddFeatureFlag("testName2", "testVarient2");
+                Bugsnag.ClearFeatureFlag("testName1");
+#if UNITY_ANDROID
+                MobileNative.TriggerBackgroundJavaCrash();
+#elif UNITY_IOS
+                NativeException();
+#endif
+                break;
             case "Feature Flags In Config":
 #if UNITY_ANDROID
                 MobileNative.TriggerBackgroundJavaCrash();

--- a/features/ios/ios_feature_flags.feature
+++ b/features/ios/ios_feature_flags.feature
@@ -27,7 +27,7 @@ Feature: Feature Flags
         And the exception "errorClass" equals "St13runtime_error"
 
         And the event "featureFlags.0.featureFlag" equals "testName2"
-        And the event "featureFlags.0.variant" equals "testVarient2"
+        And the event "featureFlags.0.variant" equals "testVariant2"
         And the event "featureFlags.1" is null
 
    Scenario: Feature Flag After Init Clear All

--- a/features/ios/ios_feature_flags.feature
+++ b/features/ios/ios_feature_flags.feature
@@ -4,7 +4,7 @@ Feature: Feature Flags
         Given I wait for the mobile game to start
         And I clear all persistent data
 
-    Scenario: Event Callback
+    Scenario: Feature Flag in config
         When I run the "Feature Flags In Config" mobile scenario
         And I wait for 2 seconds
         And I relaunch the Unity mobile app
@@ -16,3 +16,28 @@ Feature: Feature Flags
         And the event "featureFlags.0.featureFlag" equals "testName2"
         And the event "featureFlags.0.variant" equals "testVarient2"
         And the event "featureFlags.1" is null
+
+    Scenario: Feature Flag after init
+        When I run the "Feature Flags After Init" mobile scenario
+        And I wait for 2 seconds
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I wait to receive an error
+        
+        And the exception "errorClass" equals "St13runtime_error"
+
+        And the event "featureFlags.0.featureFlag" equals "testName2"
+        And the event "featureFlags.0.variant" equals "testVarient2"
+        And the event "featureFlags.1" is null
+
+   Scenario: Feature Flag After Init Clear All
+        When I run the "Feature Flags After Init Clear All" mobile scenario
+        And I wait for 2 seconds
+
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I wait to receive an error
+        
+        And the exception "errorClass" equals "St13runtime_error"
+
+        And the event "featureFlags.0" is null

--- a/features/ios/ios_feature_flags.feature
+++ b/features/ios/ios_feature_flags.feature
@@ -14,7 +14,7 @@ Feature: Feature Flags
         And the exception "errorClass" equals "St13runtime_error"
 
         And the event "featureFlags.0.featureFlag" equals "testName2"
-        And the event "featureFlags.0.variant" equals "testVarient2"
+        And the event "featureFlags.0.variant" equals "testVariant2"
         And the event "featureFlags.1" is null
 
     Scenario: Feature Flag after init

--- a/features/ios/ios_feature_flags.feature
+++ b/features/ios/ios_feature_flags.feature
@@ -1,0 +1,18 @@
+Feature: Feature Flags
+
+    Background:
+        Given I wait for the mobile game to start
+        And I clear all persistent data
+
+    Scenario: Event Callback
+        When I run the "Feature Flags In Config" mobile scenario
+        And I wait for 2 seconds
+        And I relaunch the Unity mobile app
+        When I run the "Start SDK" mobile scenario
+        Then I wait to receive an error
+        
+        And the exception "errorClass" equals "St13runtime_error"
+
+        And the event "featureFlags.0.featureFlag" equals "testName2"
+        And the event "featureFlags.0.variant" equals "testVarient2"
+        And the event "featureFlags.1" is null

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -60,10 +60,8 @@ def dial_number_for(name)
       "Set User After Init Native Error" => 35,
       "Set User After Init NDK Error" => 36,
       "Feature Flags In Config" => 37,
-
-
-
-
+      "Feature Flags After Init" => 38,
+      "Feature Flags After Init Clear All" => 39,
 
       # Commands
       "Clear iOS Data" => 90

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -59,6 +59,7 @@ def dial_number_for(name)
       "Set User After Init Csharp Error" => 34,
       "Set User After Init Native Error" => 35,
       "Set User After Init NDK Error" => 36,
+      "Feature Flags In Config" => 37,
 
 
 

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -387,6 +387,27 @@ void bugsnag_setReleaseStage(const void *configuration, char *releaseStage) {
   ((__bridge BugsnagConfiguration *)configuration).releaseStage = ns_releaseStage;
 }
 
+void bugsnag_addFeatureFlagOnConfig(const void *configuration, char *name, char *varient) {
+    NSString *ns_name = name == NULL ? nil : [NSString stringWithUTF8String: name];
+    NSString *ns_varient = varient == NULL ? nil : [NSString stringWithUTF8String: varient];
+    [(__bridge BugsnagConfiguration *)configuration addFeatureFlagWithName:ns_name variant:ns_varient];
+}
+
+void bugsnag_addFeatureFlag(char *name, char *varient) {
+    NSString *ns_name = name == NULL ? nil : [NSString stringWithUTF8String: name];
+    NSString *ns_varient = varient == NULL ? nil : [NSString stringWithUTF8String: varient];
+    [Bugsnag addFeatureFlagWithName:ns_name variant:ns_varient];
+}
+
+void bugsnag_clearFeatureFlag(char *name) {
+    NSString *ns_name = name == NULL ? nil : [NSString stringWithUTF8String: name];
+    [Bugsnag clearFeatureFlagWithName:ns_name];
+}
+
+void bugsnag_clearFeatureFlags() {
+    [Bugsnag clearFeatureFlags];
+}
+
 NSMutableSet * getSetFromStringArray(const char *values[], int valuesCount)
 {
     NSMutableSet *theSet = [NSMutableSet new];

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -387,16 +387,16 @@ void bugsnag_setReleaseStage(const void *configuration, char *releaseStage) {
   ((__bridge BugsnagConfiguration *)configuration).releaseStage = ns_releaseStage;
 }
 
-void bugsnag_addFeatureFlagOnConfig(const void *configuration, char *name, char *varient) {
+void bugsnag_addFeatureFlagOnConfig(const void *configuration, char *name, char *variant) {
     NSString *ns_name = name == NULL ? nil : [NSString stringWithUTF8String: name];
-    NSString *ns_varient = varient == NULL ? nil : [NSString stringWithUTF8String: varient];
-    [(__bridge BugsnagConfiguration *)configuration addFeatureFlagWithName:ns_name variant:ns_varient];
+    NSString *ns_variant = variant == NULL ? nil : [NSString stringWithUTF8String: variant];
+    [(__bridge BugsnagConfiguration *)configuration addFeatureFlagWithName:ns_name variant:ns_variant];
 }
 
-void bugsnag_addFeatureFlag(char *name, char *varient) {
+void bugsnag_addFeatureFlag(char *name, char *variant) {
     NSString *ns_name = name == NULL ? nil : [NSString stringWithUTF8String: name];
-    NSString *ns_varient = varient == NULL ? nil : [NSString stringWithUTF8String: varient];
-    [Bugsnag addFeatureFlagWithName:ns_name variant:ns_varient];
+    NSString *ns_variant = variant == NULL ? nil : [NSString stringWithUTF8String: variant];
+    [Bugsnag addFeatureFlagWithName:ns_name variant:ns_variant];
 }
 
 void bugsnag_clearFeatureFlag(char *name) {

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -158,5 +158,13 @@ namespace BugsnagUnity
         /// </summary>
         public static object GetMetadata(string section, string key) => Client.GetMetadata(section, key);
 
+        public static void AddFeatureFlag(string name, string variant = null) => Client.AddFeatureFlag(name,variant);
+
+        public static void AddFeatureFlags(FeatureFlag[] featureFlags) => Client.AddFeatureFlags(featureFlags);
+
+        public static void ClearFeatureFlag(string name) => Client.ClearFeatureFlag(name);
+
+        public static void ClearFeatureFlags() => Client.ClearFeatureFlags();
+
     }
 }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -586,11 +586,16 @@ namespace BugsnagUnity
         public void AddFeatureFlag(string name, string variant = null)
         {
             _featureFlags.Add(new FeatureFlag(name, variant));
+            NativeClient.AddFeatureFlag(name, variant);
         }
 
         public void AddFeatureFlags(FeatureFlag[] featureFlags)
         {
             _featureFlags.AddRange(featureFlags);
+            foreach (var flag in featureFlags)
+            {
+                NativeClient.AddFeatureFlag(flag.Name, flag.Variant);
+            }
         }
 
         public void ClearFeatureFlag(string name)
@@ -602,11 +607,13 @@ namespace BugsnagUnity
                     _featureFlags.Remove(flag);
                 }
             }
+            NativeClient.ClearFeatureFlag(name);
         }
 
         public void ClearFeatureFlags()
         {
             _featureFlags.Clear();
+            NativeClient.ClearFeatureFlags();
         }
     }
 }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -369,7 +369,8 @@ namespace BugsnagUnity
               handledState,
               Breadcrumbs.Retrieve(),
               SessionTracking.CurrentSession,
-              Configuration.ApiKey);
+              Configuration.ApiKey,
+              NativeClient.GetFeatureFlags());
 
             //Check for adding project packages to an android java error event
             if (ShouldAddProjectPackagesToEvent(@event))
@@ -566,6 +567,13 @@ namespace BugsnagUnity
             _cachedUser = new User(id, email, name);
             NativeClient.SetUser(_cachedUser);
         }
-       
+
+        public void AddFeatureFlag(string name, string variant = null) => NativeClient.AddFeatureFlag(name, variant);
+
+        public void AddFeatureFlags(FeatureFlag[] featureFlags) => NativeClient.AddFeatureFlags(featureFlags);
+
+        public void ClearFeatureFlag(string name) => NativeClient.ClearFeatureFlag(name);
+
+        public void ClearFeatureFlags() => NativeClient.ClearFeatureFlags();
     }
 }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -600,13 +600,7 @@ namespace BugsnagUnity
 
         public void ClearFeatureFlag(string name)
         {
-            foreach (var flag in _featureFlags.ToArray())
-            {
-                if (flag.Name == name)
-                {
-                    _featureFlags.Remove(flag);
-                }
-            }
+            _featureFlags.RemoveAll(item => item.Name == name);
             NativeClient.ClearFeatureFlag(name);
         }
 

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -280,14 +280,7 @@ namespace BugsnagUnity
 
         public void ClearFeatureFlag(string name)
         {
-            var flagsClone = FeatureFlags.ToArray();
-            foreach (var flag in flagsClone)
-            {
-                if (flag.Name == name)
-                {
-                    FeatureFlags.Remove(flag);
-                }
-            }
+            FeatureFlags.RemoveAll(item => item.Name == name);
         }
 
         public void ClearFeatureFlags()

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace BugsnagUnity
 {
-    public class Configuration : IMetadataEditor
+    public class Configuration : IMetadataEditor, IFeatureFlagStore
     {
 
         public string AppType;
@@ -32,6 +32,8 @@ namespace BugsnagUnity
         private User _user = null;
 
         internal Metadata Metadata = new Metadata();
+
+        internal List<FeatureFlag> FeatureFlags = new List<FeatureFlag>();
 
         public bool KeyIsRedacted(string key)
         {
@@ -266,6 +268,32 @@ namespace BugsnagUnity
             return clone;
         }
 
+        public void AddFeatureFlag(string name, string variant = null)
+        {
+            FeatureFlags.Add(new FeatureFlag(name,variant));
+        }
+
+        public void AddFeatureFlags(FeatureFlag[] featureFlags)
+        {
+            FeatureFlags.AddRange(featureFlags);
+        }
+
+        public void ClearFeatureFlag(string name)
+        {
+            var flagsClone = FeatureFlags.ToArray();
+            foreach (var flag in flagsClone)
+            {
+                if (flag.Name == name)
+                {
+                    FeatureFlags.Remove(flag);
+                }
+            }
+        }
+
+        public void ClearFeatureFlags()
+        {
+            FeatureFlags.Clear();
+        }
     }
 
     [Serializable]

--- a/src/BugsnagUnity/IClient.cs
+++ b/src/BugsnagUnity/IClient.cs
@@ -5,7 +5,7 @@ using BugsnagUnity.Payload;
 namespace BugsnagUnity
 {
 
-    internal interface IClient : IMetadataEditor
+    internal interface IClient : IMetadataEditor, IFeatureFlagStore
     {
         Configuration Configuration { get; }
 

--- a/src/BugsnagUnity/IFeatureFlagStore.cs
+++ b/src/BugsnagUnity/IFeatureFlagStore.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using BugsnagUnity.Payload;
+
+namespace BugsnagUnity
+{
+    public interface IFeatureFlagStore
+    {
+        void AddFeatureFlag(string name, string variant = null);
+        void AddFeatureFlags(FeatureFlag[] featureFlags);
+        void ClearFeatureFlag(string name);
+        void ClearFeatureFlags();
+    }
+}

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -107,7 +107,5 @@ namespace BugsnagUnity
 
         IDictionary<string, object> GetNativeMetadata();
 
-        List<FeatureFlag> GetFeatureFlags();
-
     }
 }

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace BugsnagUnity
 {
-    interface INativeClient
+    interface INativeClient : IFeatureFlagStore
     {
         /// <summary>
         /// The native configuration
@@ -106,6 +106,8 @@ namespace BugsnagUnity
         void AddNativeMetadata(string section, IDictionary<string, object> data);
 
         IDictionary<string, object> GetNativeMetadata();
+
+        List<FeatureFlag> GetFeatureFlags();
 
     }
 }

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -14,8 +14,6 @@ namespace BugsnagUnity
 
         private NativeInterface NativeInterface;
 
-        private List<FeatureFlag> _featureFlags = new List<FeatureFlag>();
-
         public NativeClient(Configuration configuration)
         {
             NativeInterface = new NativeInterface(configuration);
@@ -137,15 +135,9 @@ namespace BugsnagUnity
             }
         }
 
-        public List<FeatureFlag> GetFeatureFlags()
-        {
-            return _featureFlags;
-        }
-
         public void AddFeatureFlag(string name, string variant = null)
         {
             NativeInterface.AddFeatureFlag(name, variant);
-            _featureFlags.Add(new FeatureFlag(name, variant));
         }
 
         public void AddFeatureFlags(FeatureFlag[] featureFlags)
@@ -153,26 +145,17 @@ namespace BugsnagUnity
             foreach (var flag in featureFlags)
             {
                 AddFeatureFlag(flag.Name, flag.Variant);
-                _featureFlags.Add(new FeatureFlag(flag.Name, flag.Variant));
             }
         }
 
         public void ClearFeatureFlag(string name)
         {
             NativeInterface.ClearFeatureFlag(name);
-            foreach (var flag in _featureFlags.ToArray())
-            {
-                if (flag.Name == name)
-                {
-                    _featureFlags.Remove(flag);
-                }
-            }
         }
 
         public void ClearFeatureFlags()
         {
             NativeInterface.ClearFeatureFlags();
-            _featureFlags.Clear();
         }
     }
 

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -134,6 +134,31 @@ namespace BugsnagUnity
                 NativeInterface.AddMetadata(section,pair.Key,pair.Value.ToString());
             }
         }
+
+        public List<FeatureFlag> GetFeatureFlags()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void AddFeatureFlag(string name, string variant = null)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void AddFeatureFlags(FeatureFlag[] featureFlags)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearFeatureFlag(string name)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearFeatureFlags()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 
 }

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -14,6 +14,8 @@ namespace BugsnagUnity
 
         private NativeInterface NativeInterface;
 
+        private List<FeatureFlag> _featureFlags = new List<FeatureFlag>();
+
         public NativeClient(Configuration configuration)
         {
             NativeInterface = new NativeInterface(configuration);
@@ -137,27 +139,40 @@ namespace BugsnagUnity
 
         public List<FeatureFlag> GetFeatureFlags()
         {
-            throw new System.NotImplementedException();
+            return _featureFlags;
         }
 
         public void AddFeatureFlag(string name, string variant = null)
         {
-            throw new System.NotImplementedException();
+            NativeInterface.AddFeatureFlag(name, variant);
+            _featureFlags.Add(new FeatureFlag(name, variant));
         }
 
         public void AddFeatureFlags(FeatureFlag[] featureFlags)
         {
-            throw new System.NotImplementedException();
+            foreach (var flag in featureFlags)
+            {
+                AddFeatureFlag(flag.Name, flag.Variant);
+                _featureFlags.Add(new FeatureFlag(flag.Name, flag.Variant));
+            }
         }
 
         public void ClearFeatureFlag(string name)
         {
-            throw new System.NotImplementedException();
+            NativeInterface.ClearFeatureFlag(name);
+            foreach (var flag in _featureFlags.ToArray())
+            {
+                if (flag.Name == name)
+                {
+                    _featureFlags.Remove(flag);
+                }
+            }
         }
 
         public void ClearFeatureFlags()
         {
-            throw new System.NotImplementedException();
+            NativeInterface.ClearFeatureFlags();
+            _featureFlags.Clear();
         }
     }
 

--- a/src/BugsnagUnity/Native/Android/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Android/NativeEvent.cs
@@ -149,24 +149,5 @@ namespace BugsnagUnity
             NativePointer.Call("setUser", id, email, name);
         }
 
-        public void AddFeatureFlag(string name, string variant = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void AddFeatureFlags(FeatureFlag[] featureFlags)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void ClearFeatureFlag(string name)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void ClearFeatureFlags()
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/BugsnagUnity/Native/Android/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Android/NativeEvent.cs
@@ -148,5 +148,25 @@ namespace BugsnagUnity
         {
             NativePointer.Call("setUser", id, email, name);
         }
+
+        public void AddFeatureFlag(string name, string variant = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddFeatureFlags(FeatureFlag[] featureFlags)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ClearFeatureFlag(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ClearFeatureFlags()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Android/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Android/NativeEvent.cs
@@ -148,6 +148,5 @@ namespace BugsnagUnity
         {
             NativePointer.Call("setUser", id, email, name);
         }
-
     }
 }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -1009,20 +1009,27 @@ namespace BugsnagUnity
 
         public void AddFeatureFlag(string name, string varient)
         {
-            AndroidJavaClass bugsnagClass = new AndroidJavaClass("com.bugsnag.android.Bugsnag");
-            bugsnagClass.CallStatic("addFeatureFlag",name,varient);
+            IntPtr bugsnagClient = CallNativeObjectMethodRef("getClient", "()Lcom/bugsnag/android/Client;", new object[] { });
+            var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "addFeatureFlag", "(Ljava/lang/String;Ljava/lang/String;)V");
+            object[] args = new object[] { name, varient };
+            jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(args);
+            AndroidJNI.CallVoidMethod(bugsnagClient, methodId, jargs);
         }
 
         public void ClearFeatureFlag(string name)
         {
-            AndroidJavaClass bugsnagClass = new AndroidJavaClass("com.bugsnag.android.Bugsnag");
-            bugsnagClass.CallStatic("clearFeatureFlag", name);
+            IntPtr bugsnagClient = CallNativeObjectMethodRef("getClient", "()Lcom/bugsnag/android/Client;", new object[] { });
+            var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "clearFeatureFlag", "(Ljava/lang/String;)V");
+            object[] args = new object[] { name };
+            jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(args);
+            AndroidJNI.CallVoidMethod(bugsnagClient, methodId, jargs);
         }
 
         public void ClearFeatureFlags()
         {
-            AndroidJavaClass bugsnagClass = new AndroidJavaClass("com.bugsnag.android.Bugsnag");
-            bugsnagClass.CallStatic("clearFeatureFlags");
+            IntPtr bugsnagClient = CallNativeObjectMethodRef("getClient", "()Lcom/bugsnag/android/Client;", new object[] { });
+            var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "clearFeatureFlags", "()V");
+            AndroidJNI.CallVoidMethod(bugsnagClient, methodId, null);
         }
 
     }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -26,6 +26,8 @@ namespace BugsnagUnity
         private IntPtr SetClass;
         private IntPtr StringClass;
         private IntPtr SessionClass;
+        private IntPtr ClientClass;
+
         // Cache of methods used:
         private IntPtr BreadcrumbGetMessage;
         private IntPtr BreadcrumbGetMetadata;
@@ -41,6 +43,12 @@ namespace BugsnagUnity
         private IntPtr ObjectGetClass;
         private IntPtr ObjectToString;
         private IntPtr ToIso8601;
+        private IntPtr AddFeatureFlagMethod;
+        private IntPtr ClearFeatureFlagMethod;
+        private IntPtr ClearFeatureFlagsMethod;
+
+
+
 
 
 
@@ -194,6 +202,10 @@ namespace BugsnagUnity
                 SessionClass = AndroidJNI.NewGlobalRef(sessionRef);
                 AndroidJNI.DeleteLocalRef(sessionRef);
 
+                IntPtr clientRef = AndroidJNI.FindClass("com/bugsnag/android/Client");
+                ClientClass = AndroidJNI.NewGlobalRef(clientRef);
+                AndroidJNI.DeleteLocalRef(clientRef);
+
                 BreadcrumbGetMetadata = AndroidJNI.GetMethodID(BreadcrumbClass, "getMetadata", "()Ljava/util/Map;");
                 BreadcrumbGetType = AndroidJNI.GetMethodID(BreadcrumbClass, "getType", "()Lcom/bugsnag/android/BreadcrumbType;");
                 BreadcrumbGetTimestamp = AndroidJNI.GetMethodID(BreadcrumbClass, "getStringTimestamp", "()Ljava/lang/String;");
@@ -204,6 +216,9 @@ namespace BugsnagUnity
                 MapEntryGetKey = AndroidJNI.GetMethodID(MapEntryClass, "getKey", "()Ljava/lang/Object;");
                 MapEntryGetValue = AndroidJNI.GetMethodID(MapEntryClass, "getValue", "()Ljava/lang/Object;");
                 MapEntrySet = AndroidJNI.GetMethodID(MapClass, "entrySet", "()Ljava/util/Set;");
+                AddFeatureFlagMethod = AndroidJNI.GetMethodID(ClientClass, "addFeatureFlag", "(Ljava/lang/String;Ljava/lang/String;)V");
+                ClearFeatureFlagMethod = AndroidJNI.GetMethodID(ClientClass, "clearFeatureFlag", "(Ljava/lang/String;)V");
+                ClearFeatureFlagsMethod = AndroidJNI.GetMethodID(ClientClass, "clearFeatureFlags", "()V");
 
                 IntPtr objectRef = AndroidJNI.FindClass("java/lang/Object");
                 ObjectToString = AndroidJNI.GetMethodID(objectRef, "toString", "()Ljava/lang/String;");
@@ -1012,26 +1027,23 @@ namespace BugsnagUnity
             return CallNativeObjectMethodRef("getClient", "()Lcom/bugsnag/android/Client;", new object[] { });
         }
 
-        public void AddFeatureFlag(string name, string varient)
+        public void AddFeatureFlag(string name, string variant)
         {
-            var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "addFeatureFlag", "(Ljava/lang/String;Ljava/lang/String;)V");
-            object[] args = new object[] { name, varient };
+            object[] args = new object[] { name, variant };
             jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(args);
-            AndroidJNI.CallVoidMethod(GetClientRef(), methodId, jargs);
+            AndroidJNI.CallVoidMethod(GetClientRef(), AddFeatureFlagMethod, jargs);
         }
 
         public void ClearFeatureFlag(string name)
         {
-            var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "clearFeatureFlag", "(Ljava/lang/String;)V");
             object[] args = new object[] { name };
             jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(args);
-            AndroidJNI.CallVoidMethod(GetClientRef(), methodId, jargs);
+            AndroidJNI.CallVoidMethod(GetClientRef(), ClearFeatureFlagMethod, jargs);
         }
 
         public void ClearFeatureFlags()
         {
-            var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "clearFeatureFlags", "()V");
-            AndroidJNI.CallVoidMethod(GetClientRef(), methodId, null);
+            AndroidJNI.CallVoidMethod(GetClientRef(), ClearFeatureFlagsMethod, null);
         }
 
     }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -1009,6 +1009,8 @@ namespace BugsnagUnity
 
         public void AddFeatureFlag(string name, string varient)
         {
+            //object[] args = new object[] { name, varient };
+            //CallNativeVoidMethod("addFeatureFlag", "(Ljava/lang/String;Ljava/lang/String;)V", args);// CallNativeVoidMethod("addFeatureFlag", "(Ljava/lang/String;Ljava/lang/String;)V",)
             IntPtr bugsnagClient = CallNativeObjectMethodRef("getClient", "()Lcom/bugsnag/android/Client;", new object[] { });
             var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "addFeatureFlag", "(Ljava/lang/String;Ljava/lang/String;)V");
             object[] args = new object[] { name, varient };

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -1007,31 +1007,31 @@ namespace BugsnagUnity
             return lastRunInfo;
         }
 
+        private IntPtr GetClientRef()
+        {
+            return CallNativeObjectMethodRef("getClient", "()Lcom/bugsnag/android/Client;", new object[] { });
+        }
+
         public void AddFeatureFlag(string name, string varient)
         {
-            //object[] args = new object[] { name, varient };
-            //CallNativeVoidMethod("addFeatureFlag", "(Ljava/lang/String;Ljava/lang/String;)V", args);// CallNativeVoidMethod("addFeatureFlag", "(Ljava/lang/String;Ljava/lang/String;)V",)
-            IntPtr bugsnagClient = CallNativeObjectMethodRef("getClient", "()Lcom/bugsnag/android/Client;", new object[] { });
             var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "addFeatureFlag", "(Ljava/lang/String;Ljava/lang/String;)V");
             object[] args = new object[] { name, varient };
             jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(args);
-            AndroidJNI.CallVoidMethod(bugsnagClient, methodId, jargs);
+            AndroidJNI.CallVoidMethod(GetClientRef(), methodId, jargs);
         }
 
         public void ClearFeatureFlag(string name)
         {
-            IntPtr bugsnagClient = CallNativeObjectMethodRef("getClient", "()Lcom/bugsnag/android/Client;", new object[] { });
             var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "clearFeatureFlag", "(Ljava/lang/String;)V");
             object[] args = new object[] { name };
             jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(args);
-            AndroidJNI.CallVoidMethod(bugsnagClient, methodId, jargs);
+            AndroidJNI.CallVoidMethod(GetClientRef(), methodId, jargs);
         }
 
         public void ClearFeatureFlags()
         {
-            IntPtr bugsnagClient = CallNativeObjectMethodRef("getClient", "()Lcom/bugsnag/android/Client;", new object[] { });
             var methodId = AndroidJNI.GetMethodID(AndroidJNI.FindClass("com/bugsnag/android/Client"), "clearFeatureFlags", "()V");
-            AndroidJNI.CallVoidMethod(bugsnagClient, methodId, null);
+            AndroidJNI.CallVoidMethod(GetClientRef(), methodId, null);
         }
 
     }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -315,6 +315,15 @@ namespace BugsnagUnity
                 }
             }
 
+            // set feature flags
+            if (config.FeatureFlags != null && config.FeatureFlags.Count > 0)
+            {
+                foreach (var flag in config.FeatureFlags)
+                {
+                    obj.Call("addFeatureFlag",flag.Name,flag.Variant);
+                }
+            }
+
             // set sendThreads
             AndroidJavaClass androidThreadSendPolicyClass = new AndroidJavaClass("com.bugsnag.android.ThreadSendPolicy");
             using (AndroidJavaObject policy = androidThreadSendPolicyClass.CallStatic<AndroidJavaObject>("valueOf", GetAndroidFormatThreadSendName(config.SendThreads)))
@@ -996,6 +1005,24 @@ namespace BugsnagUnity
                 CrashedDuringLaunch = crashedDuringLaunch
             };
             return lastRunInfo;
+        }
+
+        public void AddFeatureFlag(string name, string varient)
+        {
+            AndroidJavaClass bugsnagClass = new AndroidJavaClass("com.bugsnag.android.Bugsnag");
+            bugsnagClass.CallStatic("addFeatureFlag",name,varient);
+        }
+
+        public void ClearFeatureFlag(string name)
+        {
+            AndroidJavaClass bugsnagClass = new AndroidJavaClass("com.bugsnag.android.Bugsnag");
+            bugsnagClass.CallStatic("clearFeatureFlag", name);
+        }
+
+        public void ClearFeatureFlags()
+        {
+            AndroidJavaClass bugsnagClass = new AndroidJavaClass("com.bugsnag.android.Bugsnag");
+            bugsnagClass.CallStatic("clearFeatureFlags");
         }
 
     }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -415,6 +415,29 @@ namespace BugsnagUnity
             return dictionary;
         }
 
-      
+        public List<FeatureFlag> GetFeatureFlags()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddFeatureFlag(string name, string variant = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddFeatureFlags(FeatureFlag[] featureFlags)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ClearFeatureFlag(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ClearFeatureFlags()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -17,8 +17,6 @@ namespace BugsnagUnity
         IntPtr NativeConfiguration { get; }
         private static NativeClient _instance;
 
-        private List<FeatureFlag> _featureFlags = new List<FeatureFlag>();
-
         public NativeClient(Configuration configuration)
         {
             _instance = this;
@@ -90,7 +88,6 @@ namespace BugsnagUnity
             {
                 NativeCode.bugsnag_addFeatureFlagOnConfig(obj, flag.Name, flag.Variant);
             }
-            _featureFlags = config.FeatureFlags;
         }
 
         [MonoPInvokeCallback(typeof(Func<IntPtr, bool>))]
@@ -431,15 +428,9 @@ namespace BugsnagUnity
             return dictionary;
         }
 
-        public List<FeatureFlag> GetFeatureFlags()
-        {
-            return _featureFlags;
-        }
-
         public void AddFeatureFlag(string name, string variant = null)
         {
             NativeCode.bugsnag_addFeatureFlag(name, variant);
-            _featureFlags.Add(new FeatureFlag(name, variant));
         }
 
         public void AddFeatureFlags(FeatureFlag[] featureFlags)
@@ -447,26 +438,17 @@ namespace BugsnagUnity
             foreach (var flag in featureFlags)
             {
                 AddFeatureFlag(flag.Name, flag.Variant);
-                _featureFlags.Add(new FeatureFlag(flag.Name, flag.Variant));
             }
         }
 
         public void ClearFeatureFlag(string name)
         {
             NativeCode.bugsnag_clearFeatureFlag(name);
-            foreach (var flag in _featureFlags.ToArray())
-            {
-                if (flag.Name == name)
-                {
-                    _featureFlags.Remove(flag);
-                }
-            }
         }
 
         public void ClearFeatureFlags()
         {
             NativeCode.bugsnag_clearFeatureFlags();
-            _featureFlags.Clear();
         }
     }
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -54,10 +54,10 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setReleaseStage(IntPtr configuration, string releaseStage);
 
         [DllImport(Import)]
-        internal static extern void bugsnag_addFeatureFlagOnConfig(IntPtr configuration, string name, string varient);
+        internal static extern void bugsnag_addFeatureFlagOnConfig(IntPtr configuration, string name, string variant);
 
         [DllImport(Import)]
-        internal static extern void bugsnag_addFeatureFlag(string name, string varient);
+        internal static extern void bugsnag_addFeatureFlag(string name, string variant);
 
         [DllImport(Import)]
         internal static extern void bugsnag_clearFeatureFlag(string name);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -54,6 +54,18 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setReleaseStage(IntPtr configuration, string releaseStage);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_addFeatureFlagOnConfig(IntPtr configuration, string name, string varient);
+
+        [DllImport(Import)]
+        internal static extern void bugsnag_addFeatureFlag(string name, string varient);
+
+        [DllImport(Import)]
+        internal static extern void bugsnag_clearFeatureFlag(string name);
+
+        [DllImport(Import)]
+        internal static extern void bugsnag_clearFeatureFlags();
+
+        [DllImport(Import)]
         internal static extern void bugsnag_setAutoNotifyConfig(IntPtr configuration, bool autoNotify);
 
         [DllImport(Import)]

--- a/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
@@ -179,25 +179,6 @@ namespace BugsnagUnity
             var dictionary = ((JsonObject)SimpleJson.DeserializeObject(result)).GetDictionary();
             return dictionary;
         }
-
-        public void AddFeatureFlag(string name, string variant = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void AddFeatureFlags(FeatureFlag[] featureFlags)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void ClearFeatureFlag(string name)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void ClearFeatureFlags()
-        {
-            throw new NotImplementedException();
-        }
+       
     }
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
@@ -180,8 +180,24 @@ namespace BugsnagUnity
             return dictionary;
         }
 
-       
+        public void AddFeatureFlag(string name, string variant = null)
+        {
+            throw new NotImplementedException();
+        }
 
+        public void AddFeatureFlags(FeatureFlag[] featureFlags)
+        {
+            throw new NotImplementedException();
+        }
 
+        public void ClearFeatureFlag(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ClearFeatureFlags()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -148,8 +148,7 @@ namespace BugsnagUnity
 
         public void ClearFeatureFlag(string name)
         {
-            var flagsClone = _featureFlags.ToArray();
-            foreach (var flag in flagsClone)
+            foreach (var flag in _featureFlags.ToArray())
             {
                 if (flag.Name == name)
                 {
@@ -163,7 +162,11 @@ namespace BugsnagUnity
             _featureFlags.Clear();
         }
 
-        public List<FeatureFlag> GetFeatureFlags() => _featureFlags;
+        public List<FeatureFlag> GetFeatureFlags()
+        {
+            return _featureFlags;
+        }
+       
 
     }
 }

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace BugsnagUnity
 {
-    class NativeClient : INativeClient
+    class NativeClient : INativeClient, IFeatureFlagStore
     {
         public Configuration Configuration { get; }
 
@@ -19,12 +19,15 @@ namespace BugsnagUnity
 
         private Metadata _fallbackMetadata = new Metadata();
 
+        private List<FeatureFlag> _featureFlags = new List<FeatureFlag>();
+
         public NativeClient(Configuration configuration)
         {
             Configuration = configuration;
             Breadcrumbs = new Breadcrumbs(configuration);
             Delivery = new Delivery();
             Application.lowMemory += () => { _hasReceivedLowMemoryWarning = true; };
+            AddFeatureFlags(configuration.FeatureFlags.ToArray());
         }
 
         public void PopulateApp(App app)
@@ -132,5 +135,35 @@ namespace BugsnagUnity
         {
             return _fallbackMetadata.Payload;
         }
+
+        public void AddFeatureFlag(string name, string variant = null)
+        {
+            _featureFlags.Add(new FeatureFlag(name, variant));
+        }
+
+        public void AddFeatureFlags(FeatureFlag[] featureFlags)
+        {
+            _featureFlags.AddRange(featureFlags);
+        }
+
+        public void ClearFeatureFlag(string name)
+        {
+            var flagsClone = _featureFlags.ToArray();
+            foreach (var flag in flagsClone)
+            {
+                if (flag.Name == name)
+                {
+                    _featureFlags.Remove(flag);
+                }
+            }
+        }
+
+        public void ClearFeatureFlags()
+        {
+            _featureFlags.Clear();
+        }
+
+        public List<FeatureFlag> GetFeatureFlags() => _featureFlags;
+
     }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -207,8 +207,7 @@ namespace BugsnagUnity
 
         public void ClearFeatureFlag(string name)
         {
-            var flagsClone = _featureFlags.ToArray();
-            foreach (var flag in flagsClone)
+            foreach (var flag in _featureFlags.ToArray())
             {
                 if (flag.Name == name)
                 {

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -20,17 +20,12 @@ namespace BugsnagUnity
 
         private Metadata _fallbackMetadata = new Metadata();
 
-        private List<FeatureFlag> _featureFlags = new List<FeatureFlag>();
-
-
         public NativeClient(Configuration configuration)
         {
             Configuration = configuration;
             Breadcrumbs = new Breadcrumbs(configuration);
             Delivery = new Delivery();
             Application.lowMemory += () => { _hasReceivedLowMemoryWarning = true; };
-            AddFeatureFlags(configuration.FeatureFlags.ToArray());
-
         }
 
         public void PopulateApp(App app)
@@ -197,30 +192,19 @@ namespace BugsnagUnity
 
         public void AddFeatureFlag(string name, string variant = null)
         {
-            _featureFlags.Add(new FeatureFlag(name, variant));
         }
 
         public void AddFeatureFlags(FeatureFlag[] featureFlags)
         {
-            _featureFlags.AddRange(featureFlags);
         }
 
         public void ClearFeatureFlag(string name)
         {
-            foreach (var flag in _featureFlags.ToArray())
-            {
-                if (flag.Name == name)
-                {
-                    _featureFlags.Remove(flag);
-                }
-            }
         }
 
         public void ClearFeatureFlags()
         {
-            _featureFlags.Clear();
         }
 
-        public List<FeatureFlag> GetFeatureFlags() => _featureFlags;
     }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -20,12 +20,17 @@ namespace BugsnagUnity
 
         private Metadata _fallbackMetadata = new Metadata();
 
+        private List<FeatureFlag> _featureFlags = new List<FeatureFlag>();
+
+
         public NativeClient(Configuration configuration)
         {
             Configuration = configuration;
             Breadcrumbs = new Breadcrumbs(configuration);
             Delivery = new Delivery();
             Application.lowMemory += () => { _hasReceivedLowMemoryWarning = true; };
+            AddFeatureFlags(configuration.FeatureFlags.ToArray());
+
         }
 
         public void PopulateApp(App app)
@@ -189,5 +194,34 @@ namespace BugsnagUnity
         {
             return _fallbackMetadata.Payload;
         }
+
+        public void AddFeatureFlag(string name, string variant = null)
+        {
+            _featureFlags.Add(new FeatureFlag(name, variant));
+        }
+
+        public void AddFeatureFlags(FeatureFlag[] featureFlags)
+        {
+            _featureFlags.AddRange(featureFlags);
+        }
+
+        public void ClearFeatureFlag(string name)
+        {
+            var flagsClone = _featureFlags.ToArray();
+            foreach (var flag in flagsClone)
+            {
+                if (flag.Name == name)
+                {
+                    _featureFlags.Remove(flag);
+                }
+            }
+        }
+
+        public void ClearFeatureFlags()
+        {
+            _featureFlags.Clear();
+        }
+
+        public List<FeatureFlag> GetFeatureFlags() => _featureFlags;
     }
 }

--- a/src/BugsnagUnity/Payload/Event.cs
+++ b/src/BugsnagUnity/Payload/Event.cs
@@ -207,12 +207,15 @@ namespace BugsnagUnity.Payload
                 breadcrumbPayloads.Add(crumb.Payload);
             }
             Add("breadcrumbs", breadcrumbPayloads.ToArray());
-            var featureFlagPayloads = new List<Dictionary<string, object>>();
-            foreach (var item in _featureFlags)
+            if (_featureFlags != null && _featureFlags.Count > 0)
             {
-                featureFlagPayloads.Add(item.Payload);
+                var featureFlagPayloads = new List<Dictionary<string, object>>();
+                foreach (var item in _featureFlags)
+                {
+                    featureFlagPayloads.Add(item.Payload);
+                }
+                Add("featureFlags", featureFlagPayloads.ToArray());
             }
-            Add("featureFlags", featureFlagPayloads.ToArray());
             if (Session != null)
             {
                 Add("session", Session.Payload);

--- a/src/BugsnagUnity/Payload/Event.cs
+++ b/src/BugsnagUnity/Payload/Event.cs
@@ -46,7 +46,7 @@ namespace BugsnagUnity.Payload
                 }
                 Session = session;
             }
-            AddFeatureFlags(featureFlags.ToArray());
+            _featureFlags = featureFlags;
         }
 
         internal void AddAndroidProjectPackagesToEvent(string[] packages)
@@ -219,33 +219,6 @@ namespace BugsnagUnity.Payload
             }
 
             return Payload;
-        }
-
-        public void AddFeatureFlag(string name, string variant = null)
-        {
-            _featureFlags.Add(new FeatureFlag(name, variant));
-        }
-
-        public void AddFeatureFlags(FeatureFlag[] featureFlags)
-        {
-            _featureFlags.AddRange(featureFlags);
-        }
-
-        public void ClearFeatureFlag(string name)
-        {
-            var flagsClone = _featureFlags.ToArray();
-            foreach (var flag in flagsClone)
-            {
-                if (flag.Name == name)
-                {
-                    _featureFlags.Remove(flag);
-                }
-            }
-        }
-
-        public void ClearFeatureFlags()
-        {
-            _featureFlags.Clear();
         }
     }
 }

--- a/src/BugsnagUnity/Payload/FeatureFlag.cs
+++ b/src/BugsnagUnity/Payload/FeatureFlag.cs
@@ -10,8 +10,8 @@ namespace BugsnagUnity.Payload
         }
         public string Name
         {
-            get => (string)Get("name");
-            set => Add("name", value);
+            get => (string)Get("featureFlag");
+            set => Add("featureFlag", value);
         }
         public string Variant
         {

--- a/src/BugsnagUnity/Payload/FeatureFlag.cs
+++ b/src/BugsnagUnity/Payload/FeatureFlag.cs
@@ -1,0 +1,22 @@
+﻿using System;
+namespace BugsnagUnity.Payload
+{
+    public class FeatureFlag : PayloadContainer
+    {
+        public FeatureFlag(string name, string variant)
+        {
+            Name = name;
+            Variant = variant;
+        }
+        public string Name
+        {
+            get => (string)Get("name");
+            set => Add("name", value);
+        }
+        public string Variant
+        {
+            get => (string)Get("variant");
+            set => Add("variant", value);
+        }
+    }
+}

--- a/src/BugsnagUnity/Payload/IEvent.cs
+++ b/src/BugsnagUnity/Payload/IEvent.cs
@@ -5,7 +5,7 @@ using BugsnagUnity.Payload;
 
 namespace BugsnagUnity
 {
-    public interface IEvent: IMetadataEditor, IUserEditor, IFeatureFlagStore
+    public interface IEvent: IMetadataEditor, IUserEditor
     {
         string ApiKey { get; set; }
 

--- a/src/BugsnagUnity/Payload/IEvent.cs
+++ b/src/BugsnagUnity/Payload/IEvent.cs
@@ -5,7 +5,7 @@ using BugsnagUnity.Payload;
 
 namespace BugsnagUnity
 {
-    public interface IEvent: IMetadataEditor, IUserEditor
+    public interface IEvent: IMetadataEditor, IUserEditor, IFeatureFlagStore
     {
         string ApiKey { get; set; }
 


### PR DESCRIPTION
## Goal

This is Part 1 of the Unity feature flags task.

This PR adds feature flag opperations to the Configuration and Client (fallback and native)

Part 2 will add the opperations to callbacks.

## Design

Feature flags are stored in the Client. When start is called, any flags set in the config will be transfered to the client.

Any feature flag operation on the client is also passed through to the native client so that they are in sync and native errors report the correct flags. 

## Changeset

- Created the serialisable payload class "FeatureFlag"
- Created the interface "IFeatureFlagStore".
- Implemented that interface in the "Configuration", "Client" and "NativeClient" classes

## Testing

Added Full CI tests for Fallback, Cocoa and Android