### PR TITLE
Skip Android e2e tests on Unity 2021 pending further investigation

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -307,7 +307,9 @@ steps:
     concurrency_group: browserstack-app
     concurrency_method: eager
 
+  # TODO: PLAT-7967 Investigate failures specific to Unity 2021 on Android
   - label: ':android: Run Android e2e tests for Unity 2021'
+    skip: Pending PLAT-7967
     depends_on: 'build-android-fixture-2021'
     timeout_in_minutes: 30
     agents:


### PR DESCRIPTION
## Goal

Skip Android e2e tests on Unity 2021 pending further investigation.