### PR TITLE
CI Fix for webGL [full ci]

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -28,6 +28,6 @@ Task("Test")
   });
 
 Task("Default")
-  .IsDependentOn("Test");
+  .IsDependentOn("Build");
 
 RunTarget(target);

--- a/features/desktop/sessions.feature
+++ b/features/desktop/sessions.feature
@@ -67,17 +67,17 @@ Feature: Session Tracking
 
     @webgl_only
     Scenario: Receive a persisted session
-        When I run the game in the "PersistSession" state
-        And I wait for 10 seconds
+        When I run the game in the "PersistSessionWeb" state
+        And I wait to receive an error
+        And the error is valid for the error reporting API sent by the native Unity notifier
+        And the exception "message" equals "SessionCached"
         And I run the game in the "PersistSessionReport" state
         And I wait to receive 2 sessions
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
         And the session payload field "app.releaseStage" equals "First Session"
         And I discard the oldest session
         And the session payload field "app.releaseStage" equals "Second Session"
-        And I wait for 5 seconds
-
-
+        And I wait for 2 seconds
 
 
     @macos_only

--- a/features/desktop/sessions.feature
+++ b/features/desktop/sessions.feature
@@ -71,7 +71,11 @@ Feature: Session Tracking
         And I wait to receive an error
         And the error is valid for the error reporting API sent by the native Unity notifier
         And the exception "message" equals "SessionCached"
-        And I run the game in the "PersistSessionReport" state
+        And I discard the oldest error
+        And I run the game in the "PersistSessionReportWeb" state
+        And I wait to receive an error
+        And the error is valid for the error reporting API sent by the native Unity notifier
+        And the exception "message" equals "PersistSessionReportWeb"
         And I wait to receive 2 sessions
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
         And the session payload field "app.releaseStage" equals "First Session"

--- a/features/desktop/sessions.feature
+++ b/features/desktop/sessions.feature
@@ -73,7 +73,7 @@ Feature: Session Tracking
         And the exception "message" equals "SessionCached"
         And I wait for 10 seconds
 
-        And I run the game in the "PersistSessionReportWeb" state
+        And I run the game in the "PersistSessionReport" state
         And I wait to receive 2 sessions
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
         And the session payload field "app.releaseStage" equals "First Session"

--- a/features/desktop/sessions.feature
+++ b/features/desktop/sessions.feature
@@ -71,17 +71,15 @@ Feature: Session Tracking
         And I wait to receive an error
         And the error is valid for the error reporting API sent by the native Unity notifier
         And the exception "message" equals "SessionCached"
-        And I discard the oldest error
+        And I wait for 10 seconds
+
         And I run the game in the "PersistSessionReportWeb" state
-        And I wait to receive an error
-        And the error is valid for the error reporting API sent by the native Unity notifier
-        And the exception "message" equals "PersistSessionReportWeb"
         And I wait to receive 2 sessions
         Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
         And the session payload field "app.releaseStage" equals "First Session"
         And I discard the oldest session
         And the session payload field "app.releaseStage" equals "Second Session"
-        And I wait for 2 seconds
+        And I wait for 10 seconds
 
 
     @macos_only

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -160,6 +160,7 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "PersistSessionWeb":
             case "PersistSession":
                 config.AddOnSession((session)=> {
                     session.App.ReleaseStage = "First Session";

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -162,8 +162,6 @@ public class Main : MonoBehaviour
         {
             case "PersistSessionWeb":
             case "PersistSession":
-                config.AddMetadata("wtf", "dataPath", Application.persistentDataPath);
-                config.AddMetadata("wtf", "url", Application.absoluteURL);
                 config.AddOnSession((session)=> {
                     session.App.ReleaseStage = "First Session";
                     return true;
@@ -173,11 +171,6 @@ public class Main : MonoBehaviour
                 break;
 
             case "PersistSessionReportWeb":
-                var sessionsDir = Application.persistentDataPath + "/Bugsnag" + "/Sessions";
-                var cachedSessions = Directory.GetFiles(sessionsDir, "*.session");
-                config.AddMetadata("wtf", "dataPath", Application.persistentDataPath);
-                config.AddMetadata("wtf","numCached",cachedSessions.Length);
-                config.AddMetadata("wtf","url", Application.absoluteURL);
                 config.AddOnSession((session) => {
                     session.App.ReleaseStage = "Second Session";
                     return true;
@@ -652,7 +645,6 @@ public class Main : MonoBehaviour
                 StartCoroutine(SendSessionCachedMessage());
                 break;
             case "PersistSessionReportWeb":
-                throw new Exception("PersistSessionReportWeb");
             case "PersistSession":
             case "PersistSessionReport":
             case "(noop)":
@@ -665,13 +657,17 @@ public class Main : MonoBehaviour
 
     private IEnumerator SendSessionCachedMessage()
     {
+        Debug.Log("MAZE_RUNNER: polling for cached session");
         var sessionsDir = Application.persistentDataPath + "/Bugsnag" + "/Sessions";
         var cachedSessions = Directory.GetFiles(sessionsDir, "*.session");
         while (cachedSessions.Length < 1)
         {
+            Debug.Log("MAZE_RUNNER: polling for cached session");
             yield return new WaitForSeconds(1);
             cachedSessions = Directory.GetFiles(sessionsDir, "*.session");
         }
+        Debug.Log("MAZE_RUNNER: cached session found, sending exception to start next stage of test");
+
         throw new Exception("SessionCached");
     }
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -636,6 +636,7 @@ public class Main : MonoBehaviour
             case "PersistSessionWeb":
                 StartCoroutine(SendSessionCachedMessage());
                 break;
+
             case "PersistSession":
             case "PersistSessionReport":
             case "(noop)":

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -162,11 +162,24 @@ public class Main : MonoBehaviour
         {
             case "PersistSessionWeb":
             case "PersistSession":
+                config.AddMetadata("wtf", "url", Application.absoluteURL);
                 config.AddOnSession((session)=> {
                     session.App.ReleaseStage = "First Session";
                     return true;
                 });
                 config.Endpoints = new EndpointConfiguration(_correctEndpoint + "/notify", "https://notify.bugsdnag.com");
+                config.AutoTrackSessions = true;
+                break;
+
+            case "PersistSessionReportWeb":
+                var sessionsDir = Application.persistentDataPath + "/Bugsnag" + "/Sessions";
+                var cachedSessions = Directory.GetFiles(sessionsDir, "*.session");
+                config.AddMetadata("wtf","numCached",cachedSessions.Length);
+                config.AddMetadata("wtf","url", Application.absoluteURL);
+                config.AddOnSession((session) => {
+                    session.App.ReleaseStage = "Second Session";
+                    return true;
+                });
                 config.AutoTrackSessions = true;
                 break;
             case "PersistSessionReport":
@@ -636,6 +649,8 @@ public class Main : MonoBehaviour
             case "PersistSessionWeb":
                 StartCoroutine(SendSessionCachedMessage());
                 break;
+            case "PersistSessionReportWeb":
+                throw new Exception("PersistSessionReportWeb");
             case "PersistSession":
             case "PersistSessionReport":
             case "(noop)":

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -162,6 +162,7 @@ public class Main : MonoBehaviour
         {
             case "PersistSessionWeb":
             case "PersistSession":
+                config.AddMetadata("wtf", "dataPath", Application.persistentDataPath);
                 config.AddMetadata("wtf", "url", Application.absoluteURL);
                 config.AddOnSession((session)=> {
                     session.App.ReleaseStage = "First Session";
@@ -174,6 +175,7 @@ public class Main : MonoBehaviour
             case "PersistSessionReportWeb":
                 var sessionsDir = Application.persistentDataPath + "/Bugsnag" + "/Sessions";
                 var cachedSessions = Directory.GetFiles(sessionsDir, "*.session");
+                config.AddMetadata("wtf", "dataPath", Application.persistentDataPath);
                 config.AddMetadata("wtf","numCached",cachedSessions.Length);
                 config.AddMetadata("wtf","url", Application.absoluteURL);
                 config.AddOnSession((session) => {

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -169,14 +169,6 @@ public class Main : MonoBehaviour
                 config.Endpoints = new EndpointConfiguration(_correctEndpoint + "/notify", "https://notify.bugsdnag.com");
                 config.AutoTrackSessions = true;
                 break;
-
-            case "PersistSessionReportWeb":
-                config.AddOnSession((session) => {
-                    session.App.ReleaseStage = "Second Session";
-                    return true;
-                });
-                config.AutoTrackSessions = true;
-                break;
             case "PersistSessionReport":
                 config.AddOnSession((session) => {
                     session.App.ReleaseStage = "Second Session";
@@ -644,7 +636,6 @@ public class Main : MonoBehaviour
             case "PersistSessionWeb":
                 StartCoroutine(SendSessionCachedMessage());
                 break;
-            case "PersistSessionReportWeb":
             case "PersistSession":
             case "PersistSessionReport":
             case "(noop)":

--- a/src/BugsnagUnity/FileManager.cs
+++ b/src/BugsnagUnity/FileManager.cs
@@ -28,12 +28,16 @@ namespace BugsnagUnity
 
         internal static void InitFileManager(Configuration configuration)
         {
+            Debug.Log("Initialising the Cache Manager");
             _configuration = configuration;
             CheckForDirectoryCreation();
+            Debug.Log("there are currently " + _cachedSessions.Length + " sessions saved in the cache");
+
         }
 
         internal static void AddPendingSession(SessionReport sessionReport)
         {
+            Debug.Log("Added a session to the list of pending session payloads with the id: " + sessionReport.Id);
             _pendingSessions.Add(sessionReport);
         }
 
@@ -51,6 +55,8 @@ namespace BugsnagUnity
 
         internal static void SendPayloadFailed(IPayload payload)
         {
+            Debug.Log("sending a session with the id" + payload.Id + " failed, writing the session to disk now");
+
             if (!PayloadAlreadyCached(payload.Id))
             {
                 switch (payload.PayloadType)
@@ -147,6 +153,8 @@ namespace BugsnagUnity
 
         internal static void RemovedCachedSession(string id)
         {
+
+            Debug.Log("Removing session file from the cache, session id: " + id);
             foreach (var cachedSessionPath in _cachedSessions)
             {
                 if (cachedSessionPath.Contains(id))
@@ -158,6 +166,7 @@ namespace BugsnagUnity
 
         private static void RemovePendingSession(string id)
         {
+            Debug.Log("Removing session from the list of pending session requests, session id: " + id);
             _pendingSessions.RemoveAll(item => item.Id == id);
         }
 
@@ -176,21 +185,38 @@ namespace BugsnagUnity
 
         private static void WriteToDisk(string json, string path)
         {
+            Debug.Log("Writing a session to disk with the content: " + json);
             CheckForDirectoryCreation();
             File.WriteAllText(path, json);
+            Debug.Log("session was written to disk at the location: " + path);
+
         }
 
         private static void CheckForDirectoryCreation()
         {
+
+            Debug.Log("Checking if the Bugsnag session cache already exists");
+
+
             try
             {
                 if (!Directory.Exists(CacheDirectory))
                 {
+                    Debug.Log("The Root Cache Directory does not exist, creating it here: " + CacheDirectory);
                     Directory.CreateDirectory(CacheDirectory);
+                }
+                else
+                {
+                    Debug.Log("The Root Cache Directory already exists here: " + CacheDirectory);
                 }
                 if (!Directory.Exists(SessionsDirectory))
                 {
+                    Debug.Log("The session Cache Directory does not exist, creating it here: " + SessionsDirectory);
                     Directory.CreateDirectory(SessionsDirectory);
+                }
+                else
+                {
+                    Debug.Log("The session Cache Directory already exists here: " + SessionsDirectory);
                 }
             }
             catch

--- a/src/BugsnagUnity/IDelivery.cs
+++ b/src/BugsnagUnity/IDelivery.cs
@@ -119,6 +119,10 @@ namespace BugsnagUnity
                 if (req.responseCode >= 200 && req.responseCode < 300)
                 {
                     // success!
+                    if (payload.PayloadType == PayloadType.Session)
+                    {
+                        Debug.Log("Session successfully sent with the id: " + payload.Id);
+                    }
                     FileManager.PayloadSendSuccess(payload);
                 }
                 else if (req.responseCode >= 500)
@@ -129,6 +133,10 @@ namespace BugsnagUnity
                 }
                 else
                 {
+                    if (payload.PayloadType == PayloadType.Session)
+                    {
+                        Debug.Log("sending session failed with the id: " + payload.Id);
+                    }
                     // sending failed, cache payload to disk
                     FileManager.SendPayloadFailed(payload);
                 }

--- a/src/BugsnagUnity/IDelivery.cs
+++ b/src/BugsnagUnity/IDelivery.cs
@@ -120,7 +120,6 @@ namespace BugsnagUnity
                 {
                     // success!
                     FileManager.PayloadSendSuccess(payload);
-                    TrySendingCachedPayloads();
                 }
                 else if (req.responseCode >= 500)
                 {

--- a/src/BugsnagUnity/IDelivery.cs
+++ b/src/BugsnagUnity/IDelivery.cs
@@ -120,6 +120,7 @@ namespace BugsnagUnity
                 {
                     // success!
                     FileManager.PayloadSendSuccess(payload);
+                    TrySendingCachedPayloads();
                 }
                 else if (req.responseCode >= 500)
                 {

--- a/src/BugsnagUnity/SessionTracker.cs
+++ b/src/BugsnagUnity/SessionTracker.cs
@@ -1,5 +1,6 @@
 ﻿using BugsnagUnity.Payload;
 using System.Runtime.CompilerServices;
+using UnityEngine;
 
 [assembly: InternalsVisibleTo("BugsnagUnity.Tests")]
 
@@ -101,6 +102,7 @@ namespace BugsnagUnity
             if (Client.Configuration.Endpoints.IsValid)
             {
                 var payload = new SessionReport(Client.Configuration, app, device, Client.GetUser().Clone(), session);
+                Debug.Log("Created a session payload with the id: " + payload.Id);
                 FileManager.AddPendingSession(payload);               
                 Client.Send(payload);
             }


### PR DESCRIPTION
Fixed the WebGL session persistence test by replacing the race condition with an exception triggered when the session is correctly cached.