### PR TITLE
task(device): persist device id in fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Enhancements
 
-* Added event and session persistence for Windows and WebGL builds [#512](https://github.com/bugsnag/bugsnag-unity/pull/512) [#509](https://github.com/bugsnag/bugsnag-unity/pull/509)
+* Added event, session and device id persistence for Windows and WebGL builds [#512](https://github.com/bugsnag/bugsnag-unity/pull/512) [#509](https://github.com/bugsnag/bugsnag-unity/pull/509) [#514](https://github.com/bugsnag/bugsnag-unity/pull/514)
+
 
 ## 6.1.0 (2022-02-08)
 

--- a/features/desktop/persistence.feature
+++ b/features/desktop/persistence.feature
@@ -64,5 +64,17 @@ Feature: Unity Persistence
         And the event "metaData.Persist Section.Persist Key" equals "Persist Value"
         And I wait for 5 seconds
 
+    Scenario: Persist Device Id
+        When I run the game in the "PersistDeviceId" state
+        And I wait to receive an error
+        And the exception "message" equals "PersistDeviceId"
+        And the error payload field "events.0.device.id" is stored as the value "device_id"
+        And the error payload field "events.0.user.id" equals the stored value "device_id"
+        And I discard the oldest error
+        And I run the game in the "PersistDeviceId" state
+        And I wait to receive an error
+        And the exception "message" equals "PersistDeviceId"   
+        And the error payload field "events.0.device.id" equals the stored value "device_id"
+        And the error payload field "events.0.user.id" equals the stored value "device_id"
 
         

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -443,6 +443,8 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "PersistDeviceId":
+                throw new Exception("PersistDeviceId");
             case "FeatureFlagsAfterInitClearAll":
                 Bugsnag.AddFeatureFlag("testName1", "testVariant1");
                 Bugsnag.AddFeatureFlag("testName2", "testVariant1");

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -137,7 +137,7 @@ namespace BugsnagUnity
             else
             {
                 // otherwise create one
-                _cachedUser = new User { Id = SystemInfo.deviceUniqueIdentifier };
+                _cachedUser = new User { Id = FileManager.GetDeviceId() };
                 // see if a native user is avaliable
                 NativeClient.PopulateUser(_cachedUser);
             }

--- a/src/BugsnagUnity/FileManager.cs
+++ b/src/BugsnagUnity/FileManager.cs
@@ -35,6 +35,49 @@ namespace BugsnagUnity
 
         private static string[] _cachedEvents => Directory.GetFiles(_eventsDirectory, "*.event");
 
+        private static string _deviceIdFile = _cacheDirectory + "/deviceId.txt";
+
+        [Serializable]
+        private class DeviceIdModel
+        {
+            public string DeviceId;
+        }
+
+        internal static string GetDeviceId()
+        {
+            try
+            {
+                var deviceId = string.Empty;
+                if (File.Exists(_deviceIdFile))
+                {
+
+                    var deviceIdStore = JsonUtility.FromJson<DeviceIdModel>(File.ReadAllText(_deviceIdFile));
+                    deviceId = deviceIdStore.DeviceId;
+                }
+                if (string.IsNullOrEmpty(deviceId) && _configuration.GenerateAnonymousId)
+                {
+                    deviceId = Guid.NewGuid().ToString();
+                    StoreDeviceId(deviceId);
+                }
+                return deviceId;
+            }
+            catch
+            {
+                // not possible in unit tests
+                return string.Empty;
+            }
+           
+        }
+
+        private static void StoreDeviceId(string deviceId)
+        {
+            var model = new DeviceIdModel()
+            {
+                DeviceId = deviceId
+            };
+            var json = JsonUtility.ToJson(model);
+            File.WriteAllText(_deviceIdFile, json);
+        }
 
         internal static void InitFileManager(Configuration configuration)
         {

--- a/src/BugsnagUnity/Payload/Device.cs
+++ b/src/BugsnagUnity/Payload/Device.cs
@@ -27,9 +27,6 @@ namespace BugsnagUnity.Payload
         private const string TOTAL_MEMORY_KEY = "totalMemory";
         private const string USER_AGENT_KEY = "userAgent";
 
-        //Player prefs id for Bugsnag generated device id
-        private const string GENERATED_ID_KEY = "GENERATED_ID_KEY";
-
 
         public string? BrowserName
         {
@@ -126,21 +123,11 @@ namespace BugsnagUnity.Payload
             Locale = CultureInfo.CurrentCulture.ToString();
             AddOsInfo();
             AddRuntimeVersions(configuration);
-            if (configuration.GenerateAnonymousId)
-            {
-                Id = GetGeneratedDeviceId();
-            }
+            Id = FileManager.GetDeviceId();
             Model = SystemInfo.deviceModel;
         }
 
-        private string GetGeneratedDeviceId()
-        {
-            if (!PlayerPrefs.HasKey(GENERATED_ID_KEY))
-            {
-                PlayerPrefs.SetString(GENERATED_ID_KEY, Guid.NewGuid().ToString());
-            }
-            return PlayerPrefs.GetString(GENERATED_ID_KEY);
-        }
+      
 
         private void AddOsInfo()
         {

--- a/tests/UnityEngine/JsonUtility.cs
+++ b/tests/UnityEngine/JsonUtility.cs
@@ -1,0 +1,19 @@
+﻿using System;
+namespace UnityEngine
+{
+    public class JsonUtility
+    {
+        public JsonUtility()
+        {
+        }
+        public static T FromJson<T>(string json) {
+            var t = new object();
+            return (T)t;
+        }
+        public static string ToJson(object obj) {
+            return string.Empty;
+        }
+
+
+    }
+}


### PR DESCRIPTION
## Goal

User Stability requires a persistent device.id between app launches. 

## Changeset

Added device id utillity methods to the FileManager class

## Testing

Added CI tests for mac windows and webgl