### PR TITLE
Reinstate timeout on all build steps

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,4 +1,3 @@
-timeout_in_minutes: 30
 agents:
   queue: opensource-arm-mac-cocoa-12
 
@@ -7,6 +6,7 @@ steps:
   # Build MacOS and WebGL test fixtures
   #
   - label: Build Unity 2018 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
     key: 'cocoa-webgl-2018-fixtures'
     depends_on: 'build-artifacts'
     env:
@@ -29,6 +29,7 @@ steps:
           limit: 1
 
   - label: Build Unity 2019 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
     key: 'cocoa-webgl-2019-fixtures'
     depends_on: 'build-artifacts'
     env:
@@ -51,6 +52,7 @@ steps:
           limit: 1
 
   - label: Build Unity 2021 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
     key: 'cocoa-webgl-2021-fixtures'
     depends_on: 'build-artifacts'
     env:
@@ -76,6 +78,7 @@ steps:
   # Run macOS desktop tests
   #
   - label: Run MacOS e2e tests for Unity 2018
+    timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2018-fixtures'
     env:
       UNITY_VERSION: "2018.4.36f1"
@@ -90,6 +93,7 @@ steps:
       - scripts/ci-run-macos-tests.sh
 
   - label: Run MacOS e2e tests for Unity 2019
+    timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2019-fixtures'
     env:
       UNITY_VERSION: "2019.4.35f1"
@@ -104,6 +108,7 @@ steps:
       - scripts/ci-run-macos-tests.sh
 
   - label: Run MacOS e2e tests for Unity 2021
+    timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2021-fixtures'
     env:
       UNITY_VERSION: "2021.2.11f1"
@@ -123,6 +128,7 @@ steps:
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
   #
   - label: Run WebGL e2e tests for Unity 2018
+    timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2018-fixtures'
     agents:
       queue: opensource-mac-cocoa-11
@@ -139,6 +145,7 @@ steps:
       - scripts/ci-run-webgl-tests.sh
 
   - label: Run WebGL e2e tests for Unity 2019
+    timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2019-fixtures'
     agents:
       queue: opensource-mac-cocoa-11
@@ -155,6 +162,7 @@ steps:
       - scripts/ci-run-webgl-tests.sh
 
   - label: Run WebGL e2e tests for Unity 2021
+    timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2021-fixtures'
     agents:
       queue: opensource-mac-cocoa-11
@@ -174,6 +182,7 @@ steps:
   # Build Android test fixtures
   #
   - label: ':android: Build Android test fixture for Unity 2018'
+    timeout_in_minutes: 30
     key: 'build-android-fixture-2018'
     depends_on: 'build-artifacts'
     env:
@@ -195,6 +204,7 @@ steps:
           limit: 1
 
   - label: ':android: Build Android test fixture for Unity 2019'
+    timeout_in_minutes: 30
     key: 'build-android-fixture-2019'
     depends_on: 'build-artifacts'
     env:
@@ -216,6 +226,7 @@ steps:
           limit: 1
 
   - label: ':android: Build Android test fixture for Unity 2021'
+    timeout_in_minutes: 30
     key: 'build-android-fixture-2021'
     depends_on: 'build-artifacts'
     env:
@@ -240,6 +251,7 @@ steps:
   # Run Android tests
   #
   - label: ':android: Run Android e2e tests for Unity 2018'
+    timeout_in_minutes: 30
     depends_on: 'build-android-fixture-2018'
     agents:
       queue: opensource
@@ -262,6 +274,7 @@ steps:
     concurrency_method: eager
 
   - label: ':android: Run Android e2e tests for Unity 2019'
+    timeout_in_minutes: 30
     depends_on: 'build-android-fixture-2019'
     agents:
       queue: opensource
@@ -285,6 +298,7 @@ steps:
 
   # TODO: PLAT-7967 Investigate failures specific to Unity 2021 on Android
   - label: ':android: Run Android e2e tests for Unity 2021'
+    timeout_in_minutes: 30
     skip: Pending PLAT-7967
     depends_on: 'build-android-fixture-2021'
     agents:
@@ -311,6 +325,7 @@ steps:
   # Build iOS test fixtures
   #
   - label: ':ios: Generate Xcode project - Unity 2018'
+    timeout_in_minutes: 30
     key: 'generate-fixture-project-2018'
     depends_on: 'build-artifacts'
     env:
@@ -333,6 +348,7 @@ steps:
           limit: 1
 
   - label: ':ios: Build iOS test fixture for Unity 2018'
+    timeout_in_minutes: 30
     key: 'build-ios-fixture-2018'
     depends_on: 'generate-fixture-project-2018'
     env:
@@ -356,6 +372,7 @@ steps:
           limit: 1
 
   - label: ':ios: Generate Xcode project - Unity 2019'
+    timeout_in_minutes: 30
     key: 'generate-fixture-project-2019'
     depends_on: 'build-artifacts'
     env:
@@ -378,6 +395,7 @@ steps:
           limit: 1
 
   - label: ':ios: Build iOS test fixture for Unity 2019'
+    timeout_in_minutes: 30
     key: 'build-ios-fixture-2019'
     depends_on: 'generate-fixture-project-2019'
     env:
@@ -401,6 +419,7 @@ steps:
           limit: 1
 
   - label: ':ios: Generate Xcode project - Unity 2021'
+    timeout_in_minutes: 30
     key: 'generate-fixture-project-2021'
     depends_on: 'build-artifacts'
     env:
@@ -423,6 +442,7 @@ steps:
           limit: 1
 
   - label: ':ios: Build iOS test fixture for Unity 2021'
+    timeout_in_minutes: 30
     key: 'build-ios-fixture-2021'
     depends_on: 'generate-fixture-project-2021'
     env:
@@ -449,6 +469,7 @@ steps:
   # Run iOS tests
   #
   - label: ':ios: Run iOS e2e tests for Unity 2018'
+    timeout_in_minutes: 30
     depends_on: 'build-ios-fixture-2018'
     agents:
       queue: opensource
@@ -472,6 +493,7 @@ steps:
     concurrency_method: eager
 
   - label: ':ios: Run iOS e2e tests for Unity 2019'
+    timeout_in_minutes: 30
     depends_on: 'build-ios-fixture-2019'
     agents:
       queue: opensource
@@ -495,6 +517,7 @@ steps:
     concurrency_method: eager
 
   - label: ':ios: Run iOS e2e tests for Unity 2021'
+    timeout_in_minutes: 30
     depends_on: 'build-ios-fixture-2021'
     agents:
       queue: opensource
@@ -521,6 +544,7 @@ steps:
   # Build Windows test fixtures
   #
   - label: Build Unity 2018 Windows test fixture
+    timeout_in_minutes: 30
     key: 'windows-2018-fixture'
     depends_on: 'build-artifacts'
     agents:
@@ -540,6 +564,7 @@ steps:
           limit: 1
 
   - label: Build Unity 2019 Windows test fixture
+    timeout_in_minutes: 30
     key: 'windows-2019-fixture'
     depends_on: 'build-artifacts'
     agents:
@@ -559,6 +584,7 @@ steps:
           limit: 1
 
   - label: Build Unity 2021 Windows test fixture
+    timeout_in_minutes: 30
     key: 'windows-2021-fixture'
     depends_on: 'build-artifacts'
     agents:
@@ -581,6 +607,7 @@ steps:
   # Run Windows e2e tests
   #
   - label: Run Windows e2e tests for Unity 2018
+    timeout_in_minutes: 30
     depends_on: 'windows-2018-fixture'
     agents:
       queue: opensource-windows-unity
@@ -592,6 +619,7 @@ steps:
       - maze_output/**/*
 
   - label: Run Windows e2e tests for Unity 2019
+    timeout_in_minutes: 30
     depends_on: 'windows-2019-fixture'
     agents:
       queue: opensource-windows-unity
@@ -603,6 +631,7 @@ steps:
       - maze_output/**/*
 
   - label: Run Windows e2e tests for Unity 2021
+    timeout_in_minutes: 30
     depends_on: 'windows-2021-fixture'
     agents:
       queue: opensource-windows-unity

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,3 @@
-timeout_in_minutes: 30
 agents:
   queue: opensource-arm-mac-cocoa-12
 
@@ -8,6 +7,7 @@ steps:
   # Build notifier.  We run tests for all Unity versions with the 2018 artifacts, as that is what we ship.
   #
   - label: Build notifier artifacts
+    timeout_in_minutes: 30
     key: 'build-artifacts'
     env:
       UNITY_VERSION: "2018.4.36f1"
@@ -21,6 +21,7 @@ steps:
   # Build MacOS and WebGL test fixtures
   #
   - label: Build Unity 2020 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
     key: 'cocoa-webgl-2020-fixtures'
     depends_on: 'build-artifacts'
     env:
@@ -45,6 +46,7 @@ steps:
   # Run desktop tests
   #
   - label: Run MacOS e2e tests for Unity 2020
+    timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2020-fixtures'
     env:
       UNITY_VERSION: "2020.3.28f1"
@@ -64,6 +66,7 @@ steps:
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
   #
   - label: Run WebGL e2e tests for Unity 2020
+    timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2020-fixtures'
     agents:
       queue: opensource-mac-cocoa-11
@@ -83,6 +86,7 @@ steps:
   # Build Android test fixtures
   #
   - label: ':android: Build Android test fixture for Unity 2020'
+    timeout_in_minutes: 30
     key: 'build-android-fixture-2020'
     depends_on: 'build-artifacts'
     env:
@@ -107,6 +111,7 @@ steps:
   # Run Android tests
   #
   - label: ':android: Run Android e2e tests for Unity 2020'
+    timeout_in_minutes: 30
     depends_on: 'build-android-fixture-2020'
     agents:
       queue: opensource
@@ -134,6 +139,7 @@ steps:
   # Build iOS test fixtures
   #
   - label: ':ios: Generate Xcode project - Unity 2020'
+    timeout_in_minutes: 30
     key: 'generate-fixture-project-2020'
     depends_on: 'build-artifacts'
     env:
@@ -156,6 +162,7 @@ steps:
           limit: 1
 
   - label: ':ios: Build iOS test fixture for Unity 2020'
+    timeout_in_minutes: 30
     key: 'build-ios-fixture-2020'
     depends_on: 'generate-fixture-project-2020'
     env:
@@ -182,6 +189,7 @@ steps:
   # Run iOS tests
   #
   - label: ':ios: Run iOS e2e tests for Unity 2020'
+    timeout_in_minutes: 30
     depends_on: 'build-ios-fixture-2020'
     agents:
       queue: opensource
@@ -208,6 +216,7 @@ steps:
   # Build Windows test fixture
   #
   - label: Build Unity 2020 Windows test fixture
+    timeout_in_minutes: 30
     key: 'windows-2020-fixture'
     depends_on: 'build-artifacts'
     agents:
@@ -230,6 +239,7 @@ steps:
   # Run Windows e2e tests
   #
   - label: Run Windows e2e tests for Unity 2020
+    timeout_in_minutes: 30
     depends_on: 'windows-2020-fixture'
     agents:
       queue: opensource-windows-unity
@@ -244,5 +254,6 @@ steps:
   # Conditionally trigger full pipeline
   #
   - label: 'Conditionally trigger full set of tests'
+    timeout_in_minutes: 30
     command: sh -c .buildkite/pipeline_trigger.sh
 


### PR DESCRIPTION
## Goal

Reinstate `timeout_in_minutes`, which doesn't take affect when given as a step default - allowing steps to potentially run for days.

## Testing

Covered by CI.