### PR TITLE
task(persistence): bring persistence up to spec

### DIFF
--- a/features/desktop/persistence.feature
+++ b/features/desktop/persistence.feature
@@ -88,4 +88,20 @@ Feature: Unity Persistence
         And the error payload field "events.0.device.id" equals the stored value "device_id"
         And the error payload field "events.0.user.id" equals the stored value "device_id"
 
+    Scenario: Max Persisted Events
+        When I run the game in the "ClearBugsnagCache" state
+        And I wait for 5 seconds
+        And I run the game in the "MaxPersistEvents" state
+        And I wait for 5 seconds
+        And I run the game in the "(noop)" state
+        And I wait to receive 4 errors
+        And the exception "message" equals "Event 1"
+        And I discard the oldest error
+        And the exception "message" equals "Event 2"
+        And I discard the oldest error
+        And the exception "message" equals "Event 3"
+        And I discard the oldest error
+        And the exception "message" equals "Event 4"
+
+
         

--- a/features/desktop/persistence.feature
+++ b/features/desktop/persistence.feature
@@ -38,11 +38,11 @@ Feature: Unity Persistence
         And I wait for 5 seconds
         And I run the game in the "PersistEventReport" state
         And I wait to receive 2 errors
-        And the event "context" equals "First Error"
-        And the exception "message" equals "First Event"
-        And I discard the oldest error
         And the event "context" equals "Second Error"
         And the exception "message" equals "Second Event"
+        And I discard the oldest error
+        And the event "context" equals "First Error"
+        And the exception "message" equals "First Event"
 
 
     Scenario: Receive a persisted event with on send callback
@@ -52,6 +52,7 @@ Feature: Unity Persistence
         And I wait for 5 seconds
         And I run the game in the "PersistEventReportCallback" state
         And I wait to receive 2 errors
+        And I discard the oldest error
         And the event "context" equals "First Error"
         And the exception "message" equals "First Event"
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -138,6 +138,13 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "MaxPersistEvents":
+                config.MaximumBreadcrumbs = 0;
+                config.MaxPersistedEvents = 4;
+                config.AutoDetectErrors = true;
+                config.AutoTrackSessions = false;
+                config.Endpoints = new EndpointConfiguration("https://notify.def-not-bugsnag.com", "https://notify.def-not-bugsnag.com");
+                break;
             case "PersistEvent":
                 config.AutoDetectErrors = true;
                 config.Endpoints = new EndpointConfiguration("https://notify.def-not-bugsnag.com", "https://notify.def-not-bugsnag.com");
@@ -424,6 +431,9 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "MaxPersistEvents":
+                StartCoroutine(NotifyPersistedEvents());
+                break;
             case "PersistDeviceId":
                 throw new Exception("PersistDeviceId");
             case "FeatureFlagsAfterInitClearAll":
@@ -660,6 +670,15 @@ public class Main : MonoBehaviour
             default:
                 throw new ArgumentException("Unable to run unexpected scenario: " + scenario);
                 break;
+        }
+    }
+
+    private IEnumerator NotifyPersistedEvents()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            Bugsnag.Notify(new Exception("Event " + i));
+            yield return new WaitForSeconds(0.75f);
         }
     }
 

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -225,7 +225,7 @@ namespace BugsnagUnity
         /// <param name="logType"></param>
         void Notify(string condition, string stackTrace, LogType logType)
         {
-            if (!Configuration.EnabledErrorTypes.UnityLog)
+            if (!Configuration.EnabledErrorTypes.UnityLog || condition.Contains("Bugsnag Warning"))
             {
                 return;
             }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -225,7 +225,7 @@ namespace BugsnagUnity
         /// <param name="logType"></param>
         void Notify(string condition, string stackTrace, LogType logType)
         {
-            if (!Configuration.EnabledErrorTypes.UnityLog || condition.Contains("Bugsnag Warning"))
+            if (!Configuration.EnabledErrorTypes.UnityLog)
             {
                 return;
             }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -28,7 +28,7 @@ namespace BugsnagUnity
 
         private MaximumLogTypeCounter _logTypeCounter;
 
-        protected IDelivery Delivery => NativeClient.Delivery;
+        private Delivery _delivery;
 
         object CallbackLock { get; } = new object();
 
@@ -52,6 +52,7 @@ namespace BugsnagUnity
         public Client(INativeClient nativeClient)
         {
             NativeClient = nativeClient;
+            _delivery = new Delivery(nativeClient.Configuration);
             FileManager.InitFileManager(nativeClient.Configuration);
             MainThread = Thread.CurrentThread;
             SessionTracking = new SessionTracker(this);
@@ -66,7 +67,7 @@ namespace BugsnagUnity
             InitInitialSessionCheck();          
             CheckForMisconfiguredEndpointsWarning();
             AddBugsnagLoadedBreadcrumb();
-            Delivery.TrySendingCachedPayloads();
+            _delivery.TrySendingCachedPayloads();
         }
 
         private void InitFeatureFlags()
@@ -202,7 +203,7 @@ namespace BugsnagUnity
             {
                 return;
             }
-            Delivery.Send(payload);
+            _delivery.Send(payload);
         }
 
         void MultiThreadedNotify(string condition, string stackTrace, LogType logType)
@@ -428,32 +429,10 @@ namespace BugsnagUnity
                 // If the callback causes an exception, ignore it and execute the next one
             }
 
-
-            lock (CallbackLock)
-            {
-                foreach (var onSendErrorCallback in Configuration.GetOnSendErrorCallbacks())
-                {
-                    try
-                    {
-                        if (!onSendErrorCallback.Invoke(@event))
-                        {
-                            return;
-                        }
-                    }
-                    catch
-                    {
-                        // If the callback causes an exception, ignore it and execute the next one
-                    }
-                }
-            }
-
-            @event.RedactMetadata(Configuration);
-
             var report = new Report(Configuration, @event);
-
             if (!report.Ignored)
             {
-                FileManager.AddPendingEvent(report);
+                FileManager.AddPendingPayload(report);
                 Send(report);
                 if (Configuration.IsBreadcrumbTypeEnabled(BreadcrumbType.Error))
                 {
@@ -488,6 +467,7 @@ namespace BugsnagUnity
         {
             if (inFocus)
             {
+                _delivery.TrySendingCachedPayloads();
                 _foregroundStopwatch.Start();
                 lock (autoSessionLock)
                 {
@@ -497,7 +477,6 @@ namespace BugsnagUnity
                         if (IsUsingFallback())
                         {
                             SessionTracking.StartSession();
-                            Delivery.TrySendingCachedPayloads();
                         }
                         else
                         {

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -67,7 +67,7 @@ namespace BugsnagUnity
             InitInitialSessionCheck();          
             CheckForMisconfiguredEndpointsWarning();
             AddBugsnagLoadedBreadcrumb();
-            _delivery.TrySendingCachedPayloads();
+            _delivery.StartDeliveringCachedPayloads();
         }
 
         private void InitFeatureFlags()
@@ -203,7 +203,7 @@ namespace BugsnagUnity
             {
                 return;
             }
-            _delivery.Send(payload);
+            _delivery.Deliver(payload);
         }
 
         void MultiThreadedNotify(string condition, string stackTrace, LogType logType)
@@ -467,7 +467,6 @@ namespace BugsnagUnity
         {
             if (inFocus)
             {
-                _delivery.TrySendingCachedPayloads();
                 _foregroundStopwatch.Start();
                 lock (autoSessionLock)
                 {
@@ -489,6 +488,7 @@ namespace BugsnagUnity
                     }
                     _backgroundStopwatch.Reset();
                 }
+                _delivery.StartDeliveringCachedPayloads();
             }
             else
             {

--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -13,7 +13,6 @@ namespace BugsnagUnity
     class Delivery
     {
 
-        private GameObject _dispatcherObject;
         private Configuration _configuration;
         private object _callbackLock { get; } = new object();
 
@@ -25,7 +24,6 @@ namespace BugsnagUnity
         internal Delivery(Configuration configuration)
         {
             _configuration = configuration;
-            CreateDispatchBehaviour();
         }
 
         // Run any on send error callbacks if it's an event, serialise the payload and add it to the sending queue
@@ -56,11 +54,6 @@ namespace BugsnagUnity
                 }
                 report.Event.RedactMetadata(_configuration);
                 report.ApplyEventPayload();
-            }
-
-            if (_dispatcherObject == null)
-            {
-                CreateDispatchBehaviour();
             }
             try
             {
@@ -128,10 +121,6 @@ namespace BugsnagUnity
             try
             {
                 _finishedCacheDeliveries.Clear();
-                if (_dispatcherObject == null)
-                {
-                    CreateDispatchBehaviour();
-                }
                 MainThreadDispatchBehaviour.Instance().Enqueue(DeliverCachedPayloads());
             }
             catch
@@ -152,13 +141,7 @@ namespace BugsnagUnity
                 }
             }
             _cacheDeliveryInProcess = false;
-        }
-
-        private void CreateDispatchBehaviour()
-        {
-            _dispatcherObject = new GameObject("Bugsnag main thread dispatcher");
-            _dispatcherObject.AddComponent<MainThreadDispatchBehaviour>();
-        }
+        }     
 
         private bool CachedPayloadProcessed(string id)
         {

--- a/src/BugsnagUnity/FileManager.cs
+++ b/src/BugsnagUnity/FileManager.cs
@@ -152,7 +152,7 @@ namespace BugsnagUnity
             }
             var path = _sessionsDirectory + "/" + pendingSession.PayloadId + SESSION_FILE_PREFIX;
             WritePayloadToDisk(pendingSession.Json, path);
-            CheckForMaxCachedSessions();
+            CheckForMaxCachedPayloads(_cachedSessions, _configuration.MaxPersistedSessions);
         }
 
         internal static void CacheEvent(string reportId)
@@ -165,26 +165,14 @@ namespace BugsnagUnity
             var path = _eventsDirectory + "/" + eventReport.PayloadId + EVENT_FILE_PREFIX;
             WritePayloadToDisk(eventReport.Json, path);
             RemovePendingPayload(reportId);
-            CheckForMaxCachedEvents();          
+            CheckForMaxCachedPayloads(_cachedEvents, _configuration.MaxPersistedEvents);
         }
 
-        private static void CheckForMaxCachedEvents()
+        private static void CheckForMaxCachedPayloads(string[] payloads, int maxPayloads)
         {
-            var filesCount = _cachedEvents.Length;
-            while (filesCount > _configuration.MaxPersistedEvents)
+            if (payloads.Length > maxPayloads)
             {
-                RemoveOldestFiles(_cachedEvents, filesCount - _configuration.MaxPersistedEvents);
-                filesCount = _cachedEvents.Length;
-            }
-        }
-
-        private static void CheckForMaxCachedSessions()
-        {
-            var filesCount = _cachedSessions.Length;
-            while(filesCount > _configuration.MaxPersistedSessions)
-            {
-                RemoveOldestFiles(_cachedSessions, filesCount - _configuration.MaxPersistedSessions);
-                filesCount = _cachedSessions.Length;
+                RemoveOldestFiles(payloads, payloads.Length - maxPayloads);
             }
         }
 

--- a/src/BugsnagUnity/FileManager.cs
+++ b/src/BugsnagUnity/FileManager.cs
@@ -10,8 +10,6 @@ namespace BugsnagUnity
     public class FileManager
     {
 
-        private const int MAX_CACHED_DAYS = 60;
-
         private static List<PendingPayload> _pendingPayloads = new List<PendingPayload>();
 
         private static Configuration _configuration;
@@ -100,27 +98,6 @@ namespace BugsnagUnity
         {
             _configuration = configuration;
             CheckForDirectoryCreation();
-            RemoveExpiredPayloads();
-        }
-
-        private static void RemoveExpiredPayloads()
-        {
-            try
-            {
-                var files = _cachedEvents.ToList();
-                files.AddRange(_cachedSessions);
-                foreach (var file in files)
-                {
-                    var creationTime = File.GetCreationTimeUtc(file);
-                    if ((DateTime.UtcNow - creationTime).TotalDays > MAX_CACHED_DAYS)
-                    {
-                        Debug.LogWarning("Bugsnag Warning: Discarding historic event from " + creationTime.ToLongDateString() + " after failed delivery");
-                        File.Delete(file);
-                    }
-                }
-            }
-            catch { }
-           
         }
 
         internal static void AddPendingPayload(IPayload payload)

--- a/src/BugsnagUnity/FileManager.cs
+++ b/src/BugsnagUnity/FileManager.cs
@@ -10,6 +10,8 @@ namespace BugsnagUnity
     public class FileManager
     {
 
+        private const int MAX_CACHED_DAYS = 60;
+
         private static List<PendingPayload> _pendingPayloads = new List<PendingPayload>();
 
         private static Configuration _configuration;
@@ -98,6 +100,27 @@ namespace BugsnagUnity
         {
             _configuration = configuration;
             CheckForDirectoryCreation();
+            RemoveExpiredPayloads();
+        }
+
+        private static void RemoveExpiredPayloads()
+        {
+            try
+            {
+                var files = _cachedEvents.ToList();
+                files.AddRange(_cachedSessions);
+                foreach (var file in files)
+                {
+                    var creationTime = File.GetCreationTimeUtc(file);
+                    if ((DateTime.UtcNow - creationTime).TotalDays > MAX_CACHED_DAYS)
+                    {
+                        Debug.LogWarning("Bugsnag Warning: Discarding historic event from " + creationTime.ToLongDateString() + " after failed delivery");
+                        File.Delete(file);
+                    }
+                }
+            }
+            catch { }
+           
         }
 
         internal static void AddPendingPayload(IPayload payload)

--- a/src/BugsnagUnity/FileManager.cs
+++ b/src/BugsnagUnity/FileManager.cs
@@ -10,6 +10,10 @@ namespace BugsnagUnity
     public class FileManager
     {
 
+        private const string SESSION_FILE_PREFIX = ".session";
+        private const string EVENT_FILE_PREFIX = ".event";
+
+
         private static List<PendingPayload> _pendingPayloads = new List<PendingPayload>();
 
         private static Configuration _configuration;
@@ -29,9 +33,9 @@ namespace BugsnagUnity
             get { return _cacheDirectory + "/Events"; }
         }
 
-        private static string[] _cachedSessions => Directory.GetFiles(_sessionsDirectory, "*.session");
+        private static string[] _cachedSessions => Directory.GetFiles(_sessionsDirectory, "*" + SESSION_FILE_PREFIX);
 
-        private static string[] _cachedEvents => Directory.GetFiles(_eventsDirectory, "*.event");
+        private static string[] _cachedEvents => Directory.GetFiles(_eventsDirectory, "*" + EVENT_FILE_PREFIX);
 
         private static string _deviceIdFile = _cacheDirectory + "/deviceId.txt";
 
@@ -146,7 +150,7 @@ namespace BugsnagUnity
             {
                 return;
             }
-            var path = _sessionsDirectory + "/" + pendingSession.PayloadId + ".session";
+            var path = _sessionsDirectory + "/" + pendingSession.PayloadId + SESSION_FILE_PREFIX;
             WritePayloadToDisk(pendingSession.Json, path);
             CheckForMaxCachedSessions();
         }
@@ -158,7 +162,7 @@ namespace BugsnagUnity
             {
                 return;
             }
-            var path = _eventsDirectory + "/" + eventReport.PayloadId + ".event";
+            var path = _eventsDirectory + "/" + eventReport.PayloadId + EVENT_FILE_PREFIX;
             WritePayloadToDisk(eventReport.Json, path);
             RemovePendingPayload(reportId);
             CheckForMaxCachedEvents();          
@@ -246,13 +250,13 @@ namespace BugsnagUnity
         {
             if (File.Exists(path))
             {
-                if (path.Contains("session"))
+                if (path.EndsWith(SESSION_FILE_PREFIX))
                 {
                     var json = File.ReadAllText(path);
                     var sessionReportFromCachedPayload = new SessionReport(_configuration, ((JsonObject)SimpleJson.DeserializeObject(json)).GetDictionary());
                     return sessionReportFromCachedPayload;
                 }
-                if (path.Contains("event"))
+                else if (path.EndsWith(EVENT_FILE_PREFIX))
                 {
                     var json = File.ReadAllText(path);
                     var eventReportFromCachedPayload = new Report(_configuration, ((JsonObject)SimpleJson.DeserializeObject(json)).GetDictionary());

--- a/src/BugsnagUnity/FileManager.cs
+++ b/src/BugsnagUnity/FileManager.cs
@@ -231,7 +231,7 @@ namespace BugsnagUnity
             var cachedPayloadPaths = new List<string>();
             cachedPayloadPaths.AddRange(_cachedSessions);
             cachedPayloadPaths.AddRange(_cachedEvents);
-            return cachedPayloadPaths.ToArray();
+            return cachedPayloadPaths.OrderBy(file => File.GetCreationTimeUtc(file)).ToArray();
         }
 
         internal static IPayload GetPayloadFromCachePath(string path)

--- a/src/BugsnagUnity/FileManager.cs
+++ b/src/BugsnagUnity/FileManager.cs
@@ -234,25 +234,32 @@ namespace BugsnagUnity
             }
         }
 
-        internal static List<IPayload> GetCachedPayloads()
+        internal static string[] GetCachedPayloadPaths()
         {
-            var cachedPayloads = new List<IPayload>();
+            var cachedPayloadPaths = new List<string>();
+            cachedPayloadPaths.AddRange(_cachedSessions);
+            cachedPayloadPaths.AddRange(_cachedEvents);
+            return cachedPayloadPaths.ToArray();
+        }
 
-            foreach (var cachedSessionPath in _cachedSessions)
+        internal static IPayload GetPayloadFromCachePath(string path)
+        {
+            if (File.Exists(path))
             {
-                var json = File.ReadAllText(cachedSessionPath);
-                var sessionReportFromCachedPayload = new SessionReport(_configuration, ((JsonObject)SimpleJson.DeserializeObject(json)).GetDictionary());
-                cachedPayloads.Add(sessionReportFromCachedPayload);
+                if (path.Contains("session"))
+                {
+                    var json = File.ReadAllText(path);
+                    var sessionReportFromCachedPayload = new SessionReport(_configuration, ((JsonObject)SimpleJson.DeserializeObject(json)).GetDictionary());
+                    return sessionReportFromCachedPayload;
+                }
+                if (path.Contains("event"))
+                {
+                    var json = File.ReadAllText(path);
+                    var eventReportFromCachedPayload = new Report(_configuration, ((JsonObject)SimpleJson.DeserializeObject(json)).GetDictionary());
+                    return eventReportFromCachedPayload;
+                }
             }
-
-            var cachedEvents = _cachedEvents.ToList();
-            foreach (var cachedEventPath in cachedEvents)
-            {
-                var json = File.ReadAllText(cachedEventPath);
-                var eventReportFromCachedPayload = new Report(_configuration, ((JsonObject)SimpleJson.DeserializeObject(json)).GetDictionary());
-                cachedPayloads.Add(eventReportFromCachedPayload);
-            }
-            return cachedPayloads;
+            return null;
         }
 
         private static void WritePayloadToDisk(string jsonData, string path)

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -19,11 +19,6 @@ namespace BugsnagUnity
         IBreadcrumbs Breadcrumbs { get; }
 
         /// <summary>
-        /// The native delivery method
-        /// </summary>
-        IDelivery Delivery { get; }
-
-        /// <summary>
         /// Populates the native app information
         /// </summary>
         /// <returns></returns>

--- a/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
+++ b/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
@@ -81,30 +81,19 @@ namespace BugsnagUnity
             action.Invoke();
         }
 
-
-        private static MainThreadDispatchBehaviour _instance = null;
-
-        public static bool Exists()
-        {
-            return _instance != null;
-        }
+        private static MainThreadDispatchBehaviour _instance;
 
         public static MainThreadDispatchBehaviour Instance()
         {
-            if (!Exists())
-            {
-                throw new Exception("MainThreadDispatchBehaviour could not find the MainThreadDispatchBehaviour object.");
-            }
             return _instance;
         }
-
 
         void Awake()
         {
             if (_instance == null)
             {
                 _instance = this;
-                DontDestroyOnLoad(this.gameObject);
+                DontDestroyOnLoad(gameObject);
             }
         }
 

--- a/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
+++ b/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
@@ -85,6 +85,10 @@ namespace BugsnagUnity
 
         public static MainThreadDispatchBehaviour Instance()
         {
+            if (_instance == null)
+            {
+                _instance = new GameObject("Bugsnag main thread dispatcher").AddComponent<MainThreadDispatchBehaviour>();
+            }
             return _instance;
         }
 

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -10,15 +10,12 @@ namespace BugsnagUnity
 
         public IBreadcrumbs Breadcrumbs { get; }
 
-        public IDelivery Delivery { get; }
-
         private NativeInterface NativeInterface;
 
         public NativeClient(Configuration configuration)
         {
             NativeInterface = new NativeInterface(configuration);
             Configuration = configuration;
-            Delivery = new Delivery();
             Breadcrumbs = new Breadcrumbs(NativeInterface);
             if (configuration.AutoTrackSessions)
             {

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -12,7 +12,6 @@ namespace BugsnagUnity
     {
         public Configuration Configuration { get; }
         public IBreadcrumbs Breadcrumbs { get; }
-        public IDelivery Delivery { get; }
         private static Session _nativeSession;
         IntPtr NativeConfiguration { get; }
         private static NativeClient _instance;
@@ -23,7 +22,6 @@ namespace BugsnagUnity
             Configuration = configuration;
             NativeConfiguration = CreateNativeConfig(configuration);
             NativeCode.bugsnag_startBugsnagWithConfiguration(NativeConfiguration, NotifierInfo.NotifierVersion);
-            Delivery = new Delivery();
             Breadcrumbs = new Breadcrumbs();
         }
 

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -11,8 +11,6 @@ namespace BugsnagUnity
 
         public IBreadcrumbs Breadcrumbs { get; }
 
-        public IDelivery Delivery { get; }
-
         private bool _launchMarkedAsCompleted = false;
 
         private bool _hasReceivedLowMemoryWarning = false;
@@ -25,7 +23,6 @@ namespace BugsnagUnity
         {
             Configuration = configuration;
             Breadcrumbs = new Breadcrumbs(configuration);
-            Delivery = new Delivery();
             Application.lowMemory += () => { _hasReceivedLowMemoryWarning = true; };
             AddFeatureFlags(configuration.FeatureFlags.ToArray());
         }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -12,8 +12,6 @@ namespace BugsnagUnity
 
         public IBreadcrumbs Breadcrumbs { get; }
 
-        public IDelivery Delivery { get; }
-
         private bool _launchMarkedAsCompleted = false;
 
         private bool _hasReceivedLowMemoryWarning = false;
@@ -24,7 +22,6 @@ namespace BugsnagUnity
         {
             Configuration = configuration;
             Breadcrumbs = new Breadcrumbs(configuration);
-            Delivery = new Delivery();
             Application.lowMemory += () => { _hasReceivedLowMemoryWarning = true; };
         }
 

--- a/src/BugsnagUnity/Payload/IPayload.cs
+++ b/src/BugsnagUnity/Payload/IPayload.cs
@@ -14,6 +14,8 @@ namespace BugsnagUnity.Payload
         string Id { get; set; }
 
         PayloadType PayloadType { get; }
+
+        Dictionary<string, object> GetSerialisablePayload();
     }
 
     public enum PayloadType

--- a/src/BugsnagUnity/Payload/Report.cs
+++ b/src/BugsnagUnity/Payload/Report.cs
@@ -29,7 +29,6 @@ namespace BugsnagUnity.Payload
             Event = @event;
             this.AddToPayload("apiKey", @event.ApiKey);
             this.AddToPayload("notifier", NotifierInfo.Instance);
-            this.AddToPayload("events", new[] { Event.GetEventPayload() });
         }
 
         internal Report(Configuration configuration, Dictionary<string, object> data)
@@ -46,7 +45,7 @@ namespace BugsnagUnity.Payload
             Event = new Event(data);
         }
 
-        internal Dictionary<string, object> GetSerialisableEventReport()
+        public Dictionary<string, object> GetSerialisablePayload()
         {
             var serialisableReport = new Dictionary<string, object>();
             serialisableReport["id"] = Id;

--- a/src/BugsnagUnity/Payload/SessionReport.cs
+++ b/src/BugsnagUnity/Payload/SessionReport.cs
@@ -48,7 +48,7 @@ namespace BugsnagUnity.Payload
             Id = cachedReport["id"].ToString();
         }
 
-        public Dictionary<string, object> GetSerialisableSessionReport()
+        public Dictionary<string, object> GetSerialisablePayload()
         {
             var serialisableSessionReport = new Dictionary<string, object>
                 {

--- a/src/BugsnagUnity/SessionTracker.cs
+++ b/src/BugsnagUnity/SessionTracker.cs
@@ -101,7 +101,7 @@ namespace BugsnagUnity
             if (Client.Configuration.Endpoints.IsValid)
             {
                 var payload = new SessionReport(Client.Configuration, app, device, Client.GetUser().Clone(), session);
-                FileManager.AddPendingSession(payload);               
+                FileManager.AddPendingPayload(payload);               
                 Client.Send(payload);
             }
             else

--- a/tests/UnityEngine/Object.cs
+++ b/tests/UnityEngine/Object.cs
@@ -1,0 +1,15 @@
+﻿using System;
+namespace UnityEngine
+{
+    public class Object
+    {
+        public Object()
+        {
+        }
+
+        public static bool op_Equality(UnityEngine.Object a, UnityEngine.Object b)
+        {
+            return a == b;
+        }
+    }
+}

--- a/tests/UnityEngine/WaitForSeconds.cs
+++ b/tests/UnityEngine/WaitForSeconds.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace UnityEngine
+{
+    public class WaitForSeconds
+    {
+        public WaitForSeconds(float time)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Goal

- Remove legacy delivery queue
- Modifications to the event in OnSend should not be persisted
- Process the cached events in the background, one by one

## Changeset

- Removed the IDelivery interface and it's inclusion and initialisation in the NativeInterface class as it was unnecessary. 
- Replaced it with a simpler Delivery class that is initialised in the Client.
- Move the processing of OnSendError callbacks to the Delivery class so that they run after the event payload has been stored for potential caching.
- Removed the delayed retry of payload sending as this is now handled by caching and retrying later.
- Simplified the Filemanager class to allow for generic serialisation of pending requests before they go through callbacks.
- Process the cached events in the background, one by one using a coroutine

## Testing

Changes covered by existing tests.