### PR TITLE
fix(CI): give requests more time to fix ordering issues

### DIFF
--- a/features/desktop/persistence.feature
+++ b/features/desktop/persistence.feature
@@ -92,8 +92,9 @@ Feature: Unity Persistence
         When I run the game in the "ClearBugsnagCache" state
         And I wait for 5 seconds
         And I run the game in the "MaxPersistEvents" state
-        And I wait for 5 seconds
+        And I wait for 12 seconds
         And I run the game in the "(noop)" state
+        And I wait for 5 seconds
         And I wait to receive 4 errors
         And the exception "message" equals "Event 1"
         And I discard the oldest error

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -144,6 +144,7 @@ public class Main : MonoBehaviour
                 config.AutoDetectErrors = true;
                 config.AutoTrackSessions = false;
                 config.Endpoints = new EndpointConfiguration("https://notify.def-not-bugsnag.com", "https://notify.def-not-bugsnag.com");
+                _closeTime = 12;
                 break;
             case "PersistEvent":
                 config.AutoDetectErrors = true;
@@ -669,7 +670,6 @@ public class Main : MonoBehaviour
                 break;
             default:
                 throw new ArgumentException("Unable to run unexpected scenario: " + scenario);
-                break;
         }
     }
 
@@ -678,7 +678,7 @@ public class Main : MonoBehaviour
         for (int i = 0; i < 5; i++)
         {
             Bugsnag.Notify(new Exception("Event " + i));
-            yield return new WaitForSeconds(0.75f);
+            yield return new WaitForSeconds(2f);
         }
     }
 


### PR DESCRIPTION
## Goal

The test features/desktop/persistence.feature:91 was flaky because it depends on requests completing in order, and some requests take longer than others, even when there is the same response.

## Changeset

- Added a 2 second wait between each request to allow the request to complete in the correct order.
- Added a 5 second wait before checking for the 4 expected requests to make sure that only 4 come through.