### PR TITLE
Bump Maze Runner Version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'xcpretty'
 gem 'xcodeproj'
 
 # Use official Maze Runner release
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.3'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.4'
 
 # Use a specific Maze Runner branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: fe12189f83aad154f54221ee0fcd41b483d3c0d1
-  tag: v6.8.0
+  revision: 971b390f5617825c18186a35f3f66ffdfcddd315
+  tag: v6.9.4
   specs:
-    bugsnag-maze-runner (6.8.0)
+    bugsnag-maze-runner (6.9.4)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -20,7 +20,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.4)
+    CFPropertyList (3.0.5)
       rexml
     appium_lib (11.2.0)
       appium_lib_core (~> 4.1)
@@ -30,11 +30,11 @@ GEM
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     atomos (0.1.3)
-    bugsnag (6.24.1)
+    bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)
-    claide (1.0.3)
+    claide (1.1.0)
     colored2 (3.1.2)
     concurrent-ruby (1.1.9)
     cucumber (7.1.0)
@@ -50,10 +50,10 @@ GEM
       mime-types (~> 3.3, >= 3.3.1)
       multi_test (~> 0.1, >= 0.1.2)
       sys-uname (~> 1.2, >= 1.2.2)
-    cucumber-core (10.1.0)
+    cucumber-core (10.1.1)
       cucumber-gherkin (~> 22.0, >= 22.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
-      cucumber-tag-expressions (~> 4.0, >= 4.0.2)
+      cucumber-tag-expressions (~> 4.1, >= 4.1.0)
     cucumber-create-meta (6.0.4)
       cucumber-messages (~> 17.1, >= 17.1.1)
       sys-uname (~> 1.2, >= 1.2.2)
@@ -65,23 +65,22 @@ GEM
       cucumber-messages (~> 17.1, >= 17.1.0)
     cucumber-messages (17.1.1)
     cucumber-tag-expressions (4.1.0)
-    cucumber-wire (6.2.0)
+    cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-      cucumber-messages (~> 17.1, >= 17.1.1)
     curb (0.9.11)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     eventmachine (1.2.7)
     faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.15.4)
+    ffi (1.15.5)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.1115)
+    mime-types-data (3.2022.0105)
     multi_test (0.1.2)
     nanaimo (0.3.0)
-    nokogiri (1.12.5-x86_64-darwin)
+    nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -115,6 +114,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   bugsnag-maze-runner!
@@ -123,4 +123,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   2.2.20
+   2.3.8


### PR DESCRIPTION
## Goal

Bump Maze Runner to the latest version to add colour to the Windows E2E test output.

Before:
<img width="1090" alt="Screenshot 2022-03-17 at 08 17 56" src="https://user-images.githubusercontent.com/46817760/158766436-ab934d0c-3dfa-4e00-a184-05e2ceb53a7f.png">

After:
<img width="1089" alt="Screenshot 2022-03-17 at 08 18 29" src="https://user-images.githubusercontent.com/46817760/158766449-ae92899c-d45d-4106-a842-0c6d02118a1b.png">

## Changeset

Bump the version of Maze Runner from `6.9.3` to `6.9.4` in the Gemfile and `bundle update` has been run to update the lock file.

## Testing

Full CI has been run 