### PR TITLE
Build and test EDM

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,6 +108,28 @@ steps:
         - exit_status: "*"
           limit: 1
 
+  - label: ':android: Build Android EDM test fixture for Unity 2020'
+    timeout_in_minutes: 30
+    key: 'build-edm-fixture-2020'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2020.3.28f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/EDM_Fixture/edm_2020.3.28f1.apk
+          - features/scripts/mobile/buildEdmFixture.log
+          - features/scripts/mobile/edmImport.log
+          - features/scripts/mobile/enableEdm.log
+    commands:
+      - rake test:edm:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
   #
   # Run Android tests
   #
@@ -132,6 +154,31 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "features/android"
+    concurrency: 9
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+
+  - label: ':android: Run Android EDM e2e tests for Unity 2020'
+    timeout_in_minutes: 30
+    depends_on: 'build-edm-fixture-2020'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2020.3.28f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/EDM_Fixture/edm_2020.3.28f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.28f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_9_0"
+          - "features/edm"
     concurrency: 9
     concurrency_group: browserstack-app
     concurrency_method: eager

--- a/Rakefile
+++ b/Rakefile
@@ -397,7 +397,21 @@ namespace :test do
       # Build the Android APK
       script = File.join("features", "scripts", "mobile", "build_android.sh")
       unless system env, script
-        raise 'APK build failed'
+        raise 'Android APK build failed'
+      end
+    end
+  end
+
+  namespace :edm do
+    task :build do
+      # Check that a Unity version has been selected and the path exists before calling the build script
+      unity_path, unity = get_required_unity_paths
+
+      # Build the Android APK
+      env = { "UNITY_PATH" => File.dirname(unity) }
+      script = File.join("features", "scripts", "mobile", "build_edm.sh")
+      unless system env, script
+        raise 'EDM APK build failed'
       end
     end
   end

--- a/features/edm/edm.feature
+++ b/features/edm/edm.feature
@@ -8,7 +8,4 @@ Feature: Android EDM smoke test
 
         # Exception details
         And the error payload field "events" is an array with 1 elements
-        And the exception "message" equals "edm"
-
-
-
+        And the exception "message" equals "EDM"


### PR DESCRIPTION
## Goal

Run tests on Android build with EDM.

## Design

Follows the existing pattern for building and running tests on Android, using a special script for building with EDM.

## Changeset

New pipeline steps and Rake target.

## Testing

Covered by a basic CI run.