### PR TITLE
Bump Unity 2020 and 2021 test versions

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -74,6 +74,8 @@ steps:
   - label: Run MacOS e2e tests for Unity 2018
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2018-fixtures'
+    agents:
+      queue: macos-12-arm-unity
     env:
       UNITY_VERSION: "2018.4.36f1"
     plugins:
@@ -89,6 +91,8 @@ steps:
   - label: Run MacOS e2e tests for Unity 2019
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2019-fixtures'
+    agents:
+      queue: macos-12-arm-unity
     env:
       UNITY_VERSION: "2019.4.35f1"
     plugins:
@@ -104,6 +108,8 @@ steps:
   - label: Run MacOS e2e tests for Unity 2021
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2021-fixtures'
+    agents:
+      queue: macos-12-arm-unity
     env:
       UNITY_VERSION: "2021.2.17f1"
     plugins:
@@ -337,6 +343,8 @@ steps:
     timeout_in_minutes: 30
     key: 'build-ios-fixture-2018'
     depends_on: 'generate-fixture-project-2018'
+    agents:
+      queue: macos-12-arm-unity
     env:
       UNITY_VERSION: "2018.4.36f1"
     plugins:
@@ -380,6 +388,8 @@ steps:
     timeout_in_minutes: 30
     key: 'build-ios-fixture-2019'
     depends_on: 'generate-fixture-project-2019'
+    agents:
+      queue: macos-12-arm-unity
     env:
       UNITY_VERSION: "2019.4.35f1"
     plugins:
@@ -423,6 +433,8 @@ steps:
     timeout_in_minutes: 30
     key: 'build-ios-fixture-2021'
     depends_on: 'generate-fixture-project-2021'
+    agents:
+      queue: macos-12-arm-unity
     env:
       UNITY_VERSION: "2021.2.17f1"
     plugins:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -52,7 +52,7 @@ steps:
     key: 'cocoa-webgl-2021-fixtures'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2021.2.11f1"
+      UNITY_VERSION: "2021.2.17f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -61,8 +61,8 @@ steps:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2021.2.11f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2021.2.11f1.zip
+      - features/fixtures/maze_runner/build/MacOS-2021.2.17f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2021.2.17f1.zip
     retry:
       automatic:
         - exit_status: "*"
@@ -105,11 +105,11 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2021-fixtures'
     env:
-      UNITY_VERSION: "2021.2.11f1"
+      UNITY_VERSION: "2021.2.17f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - features/fixtures/maze_runner/build/MacOS-2021.2.11f1.zip
+          - features/fixtures/maze_runner/build/MacOS-2021.2.17f1.zip
         upload:
           - maze_output/**/*
           - Mazerunner.log
@@ -161,11 +161,11 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     env:
-      UNITY_VERSION: "2021.2.11f1"
+      UNITY_VERSION: "2021.2.17f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - features/fixtures/maze_runner/build/WebGL-2021.2.11f1.zip
+          - features/fixtures/maze_runner/build/WebGL-2021.2.17f1.zip
         upload:
           - maze_output/**/*
     # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
@@ -220,13 +220,13 @@ steps:
     key: 'build-android-fixture-2021'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2021.2.11f1"
+      UNITY_VERSION: "2021.2.17f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
-          - features/fixtures/maze_runner/mazerunner_2021.2.11f1.apk
+          - features/fixtures/maze_runner/mazerunner_2021.2.17f1.apk
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
@@ -294,14 +294,14 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2021.2.11f1.apk"
+          - "features/fixtures/maze_runner/mazerunner_2021.2.17f1.apk"
         upload:
           - "maze_output/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.11f1.apk"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.17f1.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "features/android"
@@ -403,7 +403,7 @@ steps:
     key: 'generate-fixture-project-2021'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2021.2.11f1"
+      UNITY_VERSION: "2021.2.17f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -424,14 +424,14 @@ steps:
     key: 'build-ios-fixture-2021'
     depends_on: 'generate-fixture-project-2021'
     env:
-      UNITY_VERSION: "2021.2.11f1"
+      UNITY_VERSION: "2021.2.17f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
           - project_2021.tgz
         upload:
-          - features/fixtures/maze_runner/mazerunner_2021.2.11f1.ipa
+          - features/fixtures/maze_runner/mazerunner_2021.2.17f1.ipa
           - features/fixtures/unity.log
     commands:
       - tar -zxf project_2021.tgz features/fixtures/maze_runner
@@ -500,14 +500,14 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2021.2.11f1.ipa"
+          - "features/fixtures/maze_runner/mazerunner_2021.2.17f1.ipa"
         upload:
           - "maze_output/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.11f1.ipa"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.17f1.ipa"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
@@ -562,12 +562,12 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2021.2.11f1"
+      UNITY_VERSION: "2021.2.17f1"
     commands:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/Windows-2021.2.11f1.zip
+      - features/fixtures/maze_runner/build/Windows-2021.2.17f1.zip
     retry:
       automatic:
         - exit_status: "*"
@@ -608,7 +608,7 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2021.2.11f1"
+      UNITY_VERSION: "2021.2.17f1"
       WSLENV: "UNITY_VERSION"
     command:
       - scripts/ci-run-windows-tests.bat

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,6 +51,8 @@ steps:
   - label: Run MacOS e2e tests for Unity 2020
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2020-fixtures'
+    agents:
+      queue: macos-12-arm-unity
     env:
       UNITY_VERSION: "2020.3.32f1"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
     key: 'cocoa-webgl-2020-fixtures'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -38,8 +38,8 @@ steps:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2020.3.28f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2020.3.28f1.zip
+      - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
     retry:
       automatic:
         - exit_status: "*"
@@ -52,11 +52,11 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2020-fixtures'
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - features/fixtures/maze_runner/build/MacOS-2020.3.28f1.zip
+          - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
         upload:
           - maze_output/**/*
           - Mazerunner.log
@@ -74,11 +74,11 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - features/fixtures/maze_runner/build/WebGL-2020.3.28f1.zip
+          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
         upload:
           - maze_output/**/*
     # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
@@ -93,13 +93,13 @@ steps:
     key: 'build-android-fixture-2020'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.28f1.apk
+          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
@@ -113,13 +113,13 @@ steps:
     key: 'build-edm-fixture-2020'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
-          - features/fixtures/EDM_Fixture/edm_2020.3.28f1.apk
+          - features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk
           - features/scripts/mobile/buildEdmFixture.log
           - features/scripts/mobile/edmImport.log
           - features/scripts/mobile/enableEdm.log
@@ -139,18 +139,18 @@ steps:
     agents:
       queue: opensource
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.28f1.apk"
+          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
         upload:
           - "maze_output/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.28f1.apk"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "features/android"
@@ -164,18 +164,18 @@ steps:
     agents:
       queue: opensource
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/EDM_Fixture/edm_2020.3.28f1.apk"
+          - "features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
         upload:
           - "maze_output/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.28f1.apk"
+          - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "features/edm"
@@ -191,7 +191,7 @@ steps:
     key: 'generate-fixture-project-2020'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -212,14 +212,14 @@ steps:
     key: 'build-ios-fixture-2020'
     depends_on: 'generate-fixture-project-2020'
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
           - project_2020.tgz
         upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.28f1.ipa
+          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa
           - features/fixtures/unity.log
     commands:
       - tar -zxf project_2020.tgz features/fixtures/maze_runner
@@ -240,14 +240,14 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.28f1.ipa"
+          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
         upload:
           - "maze_output/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.28f1.ipa"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
@@ -266,12 +266,12 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
     commands:
       - scripts/ci-build-windows-package.bat
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/Windows-2020.3.28f1.zip
+      - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
     retry:
       automatic:
         - exit_status: "*"
@@ -286,7 +286,7 @@ steps:
     agents:
       queue: opensource-windows-unity
     env:
-      UNITY_VERSION: "2020.3.28f1"
+      UNITY_VERSION: "2020.3.32f1"
       WSLENV: "UNITY_VERSION"
     command:
       - scripts/ci-run-windows-tests.bat


### PR DESCRIPTION
## Goal

Bump Unity 2020 and 2021 test versions.

## Changeset

For test steps that only need a mac to run (and not Unity installed) I have adjusted the queue to be the more general one.

## Testing

Covered by a full CI run.