### PR TITLE
fix(breadcrumbs): change use of ToUpper and ToLower to be Invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   * Calling `bugsnag_event_set_context` with NULL `context` correctly clears the event context again
     [bugsnag-android#1637](https://github.com/bugsnag/bugsnag-android/pull/1637)
 
+### Bug fixes
+
+* Fixed an issue where the use of ToUpper caused a crash on devices using the Turkish language
+  [#543](https://github.com/bugsnag/bugsnag-unity/pull/543)
+
 ## 6.3.0 (2022-03-23)
 
 ### Enhancements

--- a/src/BugsnagUnity/Native/Android/NativeBreadcrumb.cs
+++ b/src/BugsnagUnity/Native/Android/NativeBreadcrumb.cs
@@ -18,13 +18,13 @@ namespace BugsnagUnity
 
         private BreadcrumbType GetBreadcrumbType()
         {
-            var native = NativePointer.Call<AndroidJavaObject>("getType").Call<string>("toString").ToLower();
+            var native = NativePointer.Call<AndroidJavaObject>("getType").Call<string>("toString").ToLowerInvariant();
             return Breadcrumb.ParseBreadcrumbType(native);
         }
 
         private void SetBreadcrumbType(BreadcrumbType breadcrumbType)
         {
-            var nativeCrumb = new AndroidJavaClass("com.bugsnag.android.BreadcrumbType").GetStatic<AndroidJavaObject>(breadcrumbType.ToString().ToUpper());
+            var nativeCrumb = new AndroidJavaClass("com.bugsnag.android.BreadcrumbType").GetStatic<AndroidJavaObject>(breadcrumbType.ToString().ToUpperInvariant());
             NativePointer.Call("setType",nativeCrumb);
         }
     }

--- a/src/BugsnagUnity/Native/Android/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Android/NativeEvent.cs
@@ -32,7 +32,7 @@ namespace BugsnagUnity
 
         private Severity GetSeverity()
         {
-            var nativeSeverity = NativePointer.Call<AndroidJavaObject>("getSeverity").Call<string>("toString").ToLower();
+            var nativeSeverity = NativePointer.Call<AndroidJavaObject>("getSeverity").Call<string>("toString").ToLowerInvariant();
             if (nativeSeverity.Contains("error"))
             {
                 return Severity.Error;
@@ -46,7 +46,7 @@ namespace BugsnagUnity
 
         private void SetSeverity(Severity severity)
         {
-            var nativeSeverity = new AndroidJavaClass("com.bugsnag.android.Severity").GetStatic<AndroidJavaObject>(severity.ToString().ToUpper());
+            var nativeSeverity = new AndroidJavaClass("com.bugsnag.android.Severity").GetStatic<AndroidJavaObject>(severity.ToString().ToUpperInvariant());
             NativePointer.Call("setSeverity",nativeSeverity);
         }
 

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -323,7 +323,7 @@ namespace BugsnagUnity
                     AndroidJavaClass androidBreadcrumbEnumClass = new AndroidJavaClass("com.bugsnag.android.BreadcrumbType");
                     for (int i = 0; i < config.EnabledBreadcrumbTypes.Length; i++)
                     {
-                        var stringValue = Enum.GetName(typeof(BreadcrumbType), config.EnabledBreadcrumbTypes[i]).ToUpper();
+                        var stringValue = Enum.GetName(typeof(BreadcrumbType), config.EnabledBreadcrumbTypes[i]).ToUpperInvariant();
                         using (AndroidJavaObject crumbType = androidBreadcrumbEnumClass.CallStatic<AndroidJavaObject>("valueOf", stringValue))
                         {
                             enabledBreadcrumbs.Call<Boolean>("add", crumbType);

--- a/src/BugsnagUnity/Native/Cocoa/Breadcrumbs.cs
+++ b/src/BugsnagUnity/Native/Cocoa/Breadcrumbs.cs
@@ -39,12 +39,12 @@ namespace BugsnagUnity
                         writer.Flush();
                         stream.Position = 0;
                         var jsonString = reader.ReadToEnd();
-                        NativeCode.bugsnag_addBreadcrumb(breadcrumb.Message, breadcrumb.Type.ToString().ToLower(), jsonString);
+                        NativeCode.bugsnag_addBreadcrumb(breadcrumb.Message, breadcrumb.Type.ToString().ToLowerInvariant(), jsonString);
                     }                    
                 }
                 else
                 {
-                    NativeCode.bugsnag_addBreadcrumb(breadcrumb.Message, breadcrumb.Type.ToString().ToLower(), null);
+                    NativeCode.bugsnag_addBreadcrumb(breadcrumb.Message, breadcrumb.Type.ToString().ToLowerInvariant(), null);
                 }
             }
         }

--- a/src/BugsnagUnity/Native/Cocoa/NativeBreadcrumb.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeBreadcrumb.cs
@@ -47,7 +47,7 @@ namespace BugsnagUnity
 
         public BreadcrumbType Type {
             get => Breadcrumb.ParseBreadcrumbType( NativeCode.bugsnag_getBreadcrumbType(NativePointer) );
-            set => NativeCode.bugsnag_setBreadcrumbType(NativePointer, value.ToString().ToLower());
+            set => NativeCode.bugsnag_setBreadcrumbType(NativePointer, value.ToString().ToLowerInvariant());
         }
     }
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
@@ -37,7 +37,7 @@ namespace BugsnagUnity
 
         public List<IError> Errors => _errors;
 
-        public Severity Severity { get => GetSeverityFromEvent(); set => NativeCode.bugsnag_setEventSeverity(NativePointer, value.ToString().ToLower()); }
+        public Severity Severity { get => GetSeverityFromEvent(); set => NativeCode.bugsnag_setEventSeverity(NativePointer, value.ToString().ToLowerInvariant()); }
 
         private List<IThread> _threads = new List<IThread>();
 

--- a/src/BugsnagUnity/Payload/Breadcrumb.cs
+++ b/src/BugsnagUnity/Payload/Breadcrumb.cs
@@ -94,7 +94,7 @@ namespace BugsnagUnity.Payload
                 var stringValue = (string)Get(TYPE_KEY);
                 return ParseBreadcrumbType(stringValue);
             }
-            set { Add(TYPE_KEY, value.ToString().ToLower()); }
+            set { Add(TYPE_KEY, value.ToString().ToLowerInvariant()); }
         }
 
         public DateTimeOffset? Timestamp {

--- a/src/BugsnagUnity/PostProcessBuild.cs
+++ b/src/BugsnagUnity/PostProcessBuild.cs
@@ -27,7 +27,7 @@ namespace BugsnagUnity
 
         public static void Apply(LinkedList<string> lines)
         {
-            Apply(lines, Guid.NewGuid().ToString("N").Substring(0, 24).ToUpper());
+            Apply(lines, Guid.NewGuid().ToString("N").Substring(0, 24).ToUpperInvariant());
         }
 
         /// <summary>


### PR DESCRIPTION
## Goal

Using ToUpper or ToLower instead of their Invariant counterparts can cause issues if the users device is in a language with special characters, for example Turkish. This was causing crashes when breadcrumb names were converted to strings to be passed to the native android notifier for converting to enums.

## Changeset

Changed instances of ToUpper and ToLower to be Invariant when interacting with native layers.

## Testing

Full Ci Run tested and manually tested with turkish language on device.