### PR TITLE
Add EDM tests to Unity 2021

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -241,6 +241,28 @@ steps:
         - exit_status: "*"
           limit: 1
 
+  - label: ':android: Build Android EDM test fixture for Unity 2021'
+    timeout_in_minutes: 30
+    key: 'build-edm-fixture-2021'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2021.2.17f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/EDM_Fixture/edm_2021.2.17f1.apk
+          - features/scripts/mobile/buildEdmFixture.log
+          - features/scripts/mobile/edmImport.log
+          - features/scripts/mobile/enableEdm.log
+    commands:
+      - rake test:edm:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
   #
   # Run Android tests
   #
@@ -311,6 +333,31 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "features/android"
+    concurrency: 9
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+
+  - label: ':android: Run Android EDM e2e tests for Unity 2021'
+    timeout_in_minutes: 30
+    depends_on: 'build-edm-fixture-2021'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2021.2.17f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/EDM_Fixture/edm_2021.2.17f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.2.17f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_9_0"
+          - "features/edm"
     concurrency: 9
     concurrency_group: browserstack-app
     concurrency_method: eager


### PR DESCRIPTION
## Goal

Add EDM tests to Unity 2021 following the pattern of Unity 2020

## Design

Following the pattern of Unity 2020

## Changeset

Add EDM tests to Unity 2021

## Testing

Covered by full ci