### PR TITLE
fix(ci): fix flake in mobile persistence tests [full ci]

### DIFF
--- a/features/android/android_persistence.feature
+++ b/features/android/android_persistence.feature
@@ -5,7 +5,7 @@ Feature: Android event persistence tests
 
     Scenario: Get Persisted event
         When I run the "Persist" mobile scenario
-        And I wait for 4 seconds
+        Then I wait to receive a session
         When I clear any error dialogue
         And I relaunch the Unity mobile app
         When I run the "throw Exception" mobile scenario

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -147,7 +147,8 @@ public class MobileScenarioRunner : MonoBehaviour {
             case "Persist":
                 config.EnabledErrorTypes.OOMs = false;
                 config.AutoDetectErrors = true;
-                config.Endpoints = new EndpointConfiguration("https://notify.def-not-bugsnag.com", "https://notify.def-not-bugsnag.com");
+                config.AutoTrackSessions = false;
+                config.Endpoints = new EndpointConfiguration("https://notify.def-not-bugsnag.com", "http://bs-local.com:9339/sessions");
                 break;
             case "Persist Report":
                 config.EnabledErrorTypes.OOMs = false;
@@ -512,7 +513,10 @@ public class MobileScenarioRunner : MonoBehaviour {
                 MobileNative.TriggerBackgroundJavaCrash();
                 break;
             case "throw Exception":
+                ThrowException();
+                break;
             case "Persist Report":
+                AddDebugMetadata();
                 ThrowException();
                 break;
             case "throw Exception with breadcrumbs":
@@ -564,6 +568,7 @@ public class MobileScenarioRunner : MonoBehaviour {
                 ThrowException();
                 break;
             case "Persist":
+                StartCoroutine(CheckEventIsPersisted());
                 throw new Exception("Persisted Exception");
             case "Clear iOS Data":
                 MobileNative.ClearIOSData();
@@ -571,6 +576,33 @@ public class MobileScenarioRunner : MonoBehaviour {
             default:
                 throw new System.Exception("Unknown scenario: " + scenarioName);
         }
+    }
+
+    private IEnumerator CheckEventIsPersisted()
+    {
+        if (!Directory.Exists(Application.persistentDataPath + "/Bugsnag/Events"))
+        {
+            yield return new WaitForSeconds(1);
+        }
+        if (Directory.GetFiles(Application.persistentDataPath + "/Bugsnag/Events", "*.event").Length == 0)
+        {
+            yield return new WaitForSeconds(1);
+        }
+        Bugsnag.StartSession();
+    }
+
+    private void AddDebugMetadata()
+    {
+        var metadata = new Dictionary<string, object>();
+        if (Directory.Exists(Application.persistentDataPath + "/Bugsnag/Events"))
+        {
+            metadata.Add("Events directory exsitsts with file count", Directory.GetFiles(Application.persistentDataPath + "/Bugsnag/Events", "*.event").Length);
+        }
+        else
+        {
+            metadata.Add("Events Dir Does Not Exist!","wtf");
+        }
+        Bugsnag.AddMetadata("debug", metadata);
     }
 
     private void CheckLastRunInfo()

--- a/features/ios/ios_persistence.feature
+++ b/features/ios/ios_persistence.feature
@@ -6,7 +6,7 @@ Feature: iOS event persistence tests
 
     Scenario: Get Persisted event
         When I run the "Persist" mobile scenario
-        And I wait for 4 seconds
+        Then I wait to receive a session
         And I close and relaunch the Unity mobile app
         When I run the "Persist Report" mobile scenario
         Then I wait to receive 2 errors


### PR DESCRIPTION
## Goal

I changed the mobile persistence test to wait for a session that is only sent when caching the error has happened. This removes the race condition and also any need to use sleep.

## Testing

Ran CI locally