### PR TITLE
fix(CI): fix for typo in persistence test 

### DIFF
--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -580,11 +580,11 @@ public class MobileScenarioRunner : MonoBehaviour {
 
     private IEnumerator CheckEventIsPersisted()
     {
-        if (!Directory.Exists(Application.persistentDataPath + "/Bugsnag/Events"))
+        while (!Directory.Exists(Application.persistentDataPath + "/Bugsnag/Events"))
         {
             yield return new WaitForSeconds(1);
         }
-        if (Directory.GetFiles(Application.persistentDataPath + "/Bugsnag/Events", "*.event").Length == 0)
+        while (Directory.GetFiles(Application.persistentDataPath + "/Bugsnag/Events", "*.event").Length == 0)
         {
             yield return new WaitForSeconds(1);
         }


### PR DESCRIPTION
## Goal

Fix for a typo in the logic to trigger the next phase of the test and gard against a race condition

## Testing

ran 30 times locally