### PR TITLE
Exit build script immediately on error

### DIFF
--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash -e
 
 if [ -z "$UNITY_VERSION" ]; then
   echo "UNITY_VERSION must be set, to e.g. 2018.4.36f1"


### PR DESCRIPTION
## Goal

Exit script immediately on error.

## Design

Without this the build script can silently fail, leading to confusing failures in later steps.  Failing the step also means that it can take advantage of retrying the build (which isn't allowed on test steps).

## Testing

Covered by CI.