### PR TITLE
Bump bugsnag-android dependency to v5.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Update bugsnag-android to v5.22.2
+  * Max reported threads can now be configured using manifest meta-data "com.bugsnag.android. MAX_REPORTED_THREADS"
+    [bugsnag-android#1655](https://github.com/bugsnag/bugsnag-android/pull/1655)
+  * Small improvement to startup performance (Bugsnag.start)
+    [bugsnag-android#1648](https://github.com/bugsnag/bugsnag-android/pull/1648)
+  * Fixed NDK stack-traces for libraries linked after `Bugsnag.start` was called
+    [bugsnag-android#1671](https://github.com/bugsnag/bugsnag-android/pull/1671)
+
 ## 6.3.1 (2022-04-06)
 
 ### Enhancements


### PR DESCRIPTION
Bumps the bugsnag-android dependency to v5.22.2.