### PR TITLE
fix(metadata): add automatic Windows app type for WSAPlayer types

### DIFF
--- a/src/BugsnagUnity/Payload/App.cs
+++ b/src/BugsnagUnity/Payload/App.cs
@@ -109,6 +109,9 @@ namespace BugsnagUnity.Payload
                     return "MacOS";
                 case RuntimePlatform.WindowsPlayer:
                 case RuntimePlatform.WindowsEditor:
+                case RuntimePlatform.WSAPlayerARM:
+                case RuntimePlatform.WSAPlayerX64:
+                case RuntimePlatform.WSAPlayerX86:
                     return "Windows";
                 case RuntimePlatform.LinuxPlayer:
                 case RuntimePlatform.LinuxEditor:

--- a/unity/PackageProject/Assets/Bugsnag/Plugins/Windows/BugsnagUnity.Windows.dll.meta
+++ b/unity/PackageProject/Assets/Bugsnag/Plugins/Windows/BugsnagUnity.Windows.dll.meta
@@ -1,28 +1,39 @@
 fileFormatVersion: 2
 guid: 985672bb978624e548cfe578ccf27093
-timeCreated: 1536884316
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       '': Any
     second:
       enabled: 0
       settings:
+        Exclude Android: 1
         Exclude Editor: 1
         Exclude Linux: 1
         Exclude Linux64: 1
         Exclude LinuxUniversal: 1
         Exclude OSXUniversal: 1
+        Exclude WebGL: 1
         Exclude Win: 0
         Exclude Win64: 0
+        Exclude WindowsStoreApps: 0
   - first:
-      Any:
+      Android: Android
+    second:
+      enabled: 0
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
     second:
       enabled: 0
       settings: {}
@@ -57,7 +68,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: LinuxUniversal
     second:
@@ -90,9 +101,13 @@ PluginImporter:
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: AnyCPU
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   - first:
       iPhone: iOS
     second:
@@ -103,6 +118,6 @@ PluginImporter:
     second:
       enabled: 0
       settings: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Goal

add automatic Windows app type for Universal Windows Platform builds

NOTE: While looking into this i realised that our bugsnag.windows.dll unity meta file had the incorrect import settings, so i also fixed that. 

## Changeset

- Extended the App.GetAppType method to support WSAPlayer platforms
- Enabled UWP support in the meta file for the bugsnag.windows dll

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->