### PR TITLE
Release v6.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug fixes
 
 * Fixed an issue where leaving a breadcrumb that contained metadata with a null value caused an exception
-  [#543](https://github.com/bugsnag/bugsnag-unity/pull/543)
+  [#561](https://github.com/bugsnag/bugsnag-unity/pull/561)
 
 ## 6.3.1 (2022-04-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 6.3.2 (2022-05-27)
+
+### Bug fixes
+
+* Fixed an issue where leaving a breadcrumb that contained metadata with a null value caused an exception
+  [#543](https://github.com/bugsnag/bugsnag-unity/pull/543)
+
 ## 6.3.1 (2022-04-06)
 
 ### Enhancements

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@ var target = Argument("target", "Default");
 var solution = File("./BugsnagUnity.sln");
 var configuration = Argument("configuration", "Release");
 var project = File("./src/BugsnagUnity/BugsnagUnity.csproj");
-var version = "6.3.1";
+var version = "6.3.2";
 
 Task("Restore-NuGet-Packages")
     .Does(() => NuGetRestore(solution));

--- a/features/android/android_breadcrumbs.feature
+++ b/features/android/android_breadcrumbs.feature
@@ -19,3 +19,10 @@ Feature: android breadcrumbs
         When I run the "throw Exception" mobile scenario
         Then I wait to receive an error
         And the event has a "state" breadcrumb named "Bugsnag loaded"
+
+    Scenario: Breadcrumb Null Metadata Value
+        When I run the "Breadcrumb Null Metadata Value" mobile scenario
+        Then I wait to receive an error
+        And the exception "message" equals "NullBreadcrumbMetadata"
+        And the event has a "state" breadcrumb named "testbreadcrumb"
+        And the event "breadcrumbs.1.metaData.KeyB" equals "null"

--- a/features/desktop/breadcrumbs.feature
+++ b/features/desktop/breadcrumbs.feature
@@ -92,4 +92,11 @@ Feature: Leaving breadcrumbs to attach to reports
         And the error payload field "events.0.breadcrumbs" is an array with 2 elements
         And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
         And the event "breadcrumbs.1.name" equals "Not Null"
+
+     Scenario: Breadcrumb Null Metadata Value
+        When I run the game in the "NullBreadcrumbMetadataValue" state
+        Then I wait to receive an error
+        And the exception "message" equals "NullBreadcrumbMetadata"
+        And the event has a "state" breadcrumb named "testbreadcrumb"
+        And the event "breadcrumbs.1.metaData.KeyB" is null
         

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -668,6 +668,9 @@ public class Main : MonoBehaviour
                 Bugsnag.LeaveBreadcrumb(null);
                 Bugsnag.LeaveBreadcrumb("Not Null");
                 throw new Exception("NullBreadcrumbMessage");
+            case "NullBreadcrumbMetadataValue":
+                NullBreadcrumbMetadataValue();
+                break;
             case "PersistSession":
             case "PersistSessionReport":
             case "(noop)":
@@ -675,6 +678,17 @@ public class Main : MonoBehaviour
             default:
                 throw new ArgumentException("Unable to run unexpected scenario: " + scenario);
         }
+    }
+
+    private void NullBreadcrumbMetadataValue()
+    {
+        var foo = new Dictionary<string, object>()
+        {
+            {"KeyA", "ValueA"},
+            {"KeyB", null},
+        };
+        Bugsnag.LeaveBreadcrumb("testbreadcrumb", foo, BreadcrumbType.State);
+        throw new Exception("NullBreadcrumbMetadata");
     }
 
     private IEnumerator NotifyPersistedEvents()

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -59,6 +59,8 @@ public class MobileScenarioRunner : MonoBehaviour {
         { "42", "Max Reported Threads" },
         { "43", "Persist" },
         { "44", "Persist Report" },
+        { "45", "Breadcrumb Null Metadata Value" },
+
 
 
         // Commands
@@ -413,6 +415,9 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         switch (scenarioName)
         {
+            case "Breadcrumb Null Metadata Value":
+                NullBreadcrumbMetadataValue();
+                break;
             case "Feature Flags After Init Clear All":
                 Bugsnag.AddFeatureFlag("testName1", "testVariant1");
                 Bugsnag.AddFeatureFlag("testName2", "testVariant2");
@@ -461,9 +466,9 @@ public class MobileScenarioRunner : MonoBehaviour {
                 break;
             case "Clear Metadata":
 
-                Bugsnag.AddMetadata("test","test1","test1");
+                Bugsnag.AddMetadata("test", "test1", "test1");
                 Bugsnag.AddMetadata("test", "test2", "test2");
-                Bugsnag.ClearMetadata("test","test2");
+                Bugsnag.ClearMetadata("test", "test2");
                 Bugsnag.AddMetadata("test3", "test3", "test3");
                 Bugsnag.AddMetadata("test4", "test4", "test4");
                 Bugsnag.ClearMetadata("test4");
@@ -471,7 +476,7 @@ public class MobileScenarioRunner : MonoBehaviour {
 
                 break;
             case "Inf Launch Duration":
-                Invoke("ThrowException",6);
+                Invoke("ThrowException", 6);
                 break;
             case "Ios Signal":
                 MobileNative.DoIosSignal();
@@ -551,7 +556,7 @@ public class MobileScenarioRunner : MonoBehaviour {
                 LeaveBreadcrumbString();
                 LeaveBreadcrumbTuple();
                 // Wait 6 seconds for launch timer to be over
-                Invoke("NotifyWithCallback" , 6);
+                Invoke("NotifyWithCallback", 6);
                 break;
             case "Change scene":
                 ChangeScene();
@@ -571,6 +576,19 @@ public class MobileScenarioRunner : MonoBehaviour {
             default:
                 throw new System.Exception("Unknown scenario: " + scenarioName);
         }
+
+
+    }
+
+    private void NullBreadcrumbMetadataValue()
+    {
+        var foo = new Dictionary<string, object>()
+        {
+            {"KeyA", "ValueA"},
+            {"KeyB", null},
+        };
+        Bugsnag.LeaveBreadcrumb("testbreadcrumb", foo, BreadcrumbType.State);
+        throw new Exception("NullBreadcrumbMetadata");
     }
 
     private void CheckLastRunInfo()

--- a/features/ios/ios_breadcrumbs.feature
+++ b/features/ios/ios_breadcrumbs.feature
@@ -18,3 +18,10 @@ Feature: ios breadcrumbs
         When I run the "throw Exception" mobile scenario
         Then I wait to receive an error
         And the event has a "state" breadcrumb named "Bugsnag loaded"
+
+    Scenario: Breadcrumb Null Metadata Value
+        When I run the "Breadcrumb Null Metadata Value" mobile scenario
+        Then I wait to receive an error
+        And the exception "message" equals "NullBreadcrumbMetadata"
+        And the event has a "state" breadcrumb named "testbreadcrumb"
+        And the event "breadcrumbs.1.metaData.KeyB" is null

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -74,6 +74,7 @@ def dial_number_for(name)
       "Max Reported Threads" => 42,
       "Persist" => 43,
       "Persist Report" => 44,
+      "Breadcrumb Null Metadata Value" => 45,
 
 
       # Commands

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -895,7 +895,7 @@ namespace BugsnagUnity
                 foreach (var entry in src)
                 {
                     using (AndroidJavaObject key = BuildJavaStringDisposable(entry.Key))
-                    using (AndroidJavaObject value = BuildJavaStringDisposable(entry.Value.ToString()))
+                    using (AndroidJavaObject value = BuildJavaStringDisposable(entry.Value == null ? "null" : entry.Value.ToString()))
                     {
                         map.Call<AndroidJavaObject>("put", key, value);
                     }


### PR DESCRIPTION
## Goal

Hotfix release to fix an issue where leaving a breadcrumb that contained metadata with a null value caused an exception.


## Changeset

Added a null check to android NativeInterface.BuildJavaMapDisposable(IDictionary<string, object> src)

## Testing

Added CI tests for leaving a breadcrumb with a null metadata value to all platforms