### PR TITLE
Increase timeout for macOS e2e tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -72,7 +72,7 @@ steps:
   # Run macOS desktop tests
   #
   - label: Run MacOS e2e tests for Unity 2018
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     depends_on: 'cocoa-webgl-2018-fixtures'
     agents:
       queue: macos-12-arm-unity
@@ -89,7 +89,7 @@ steps:
       - scripts/ci-run-macos-tests.sh
 
   - label: Run MacOS e2e tests for Unity 2019
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     depends_on: 'cocoa-webgl-2019-fixtures'
     agents:
       queue: macos-12-arm-unity
@@ -106,7 +106,7 @@ steps:
       - scripts/ci-run-macos-tests.sh
 
   - label: Run MacOS e2e tests for Unity 2021
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     depends_on: 'cocoa-webgl-2021-fixtures'
     agents:
       queue: macos-12-arm-unity

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,7 @@ steps:
   # Run desktop tests
   #
   - label: Run MacOS e2e tests for Unity 2020
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     depends_on: 'cocoa-webgl-2020-fixtures'
     agents:
       queue: macos-12-arm-unity


### PR DESCRIPTION
## Goal

Stop e2e tests failing unnecessarily through timeouts.

## Design

These test normally take 25-30 minutes to run, so a timeout of 30 is just too restrictive.

## Testing

Covered by CI.