### PR TITLE
Ensure notifier builds on Windows

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
   #
   # Build notifier.  We run tests for all Unity versions with the 2018 artifacts, as that is what we ship.
   #
-  - label: Build notifier artifacts
+  - label: Build released notifier artifact
     timeout_in_minutes: 30
     key: 'build-artifacts'
     env:
@@ -16,6 +16,19 @@ steps:
       - bundle exec rake plugin:export
     artifact_paths:
       - Bugsnag.unitypackage
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: Ensure notifier builds on Windows (for development)
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource-windows-unity
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+    command:
+      - scripts/ci-build-windows-plugin.bat
     retry:
       automatic:
         - exit_status: "*"

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,13 @@ gem 'rake'
 gem 'xcpretty'
 gem 'xcodeproj'
 
-# Use official Maze Runner release
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.4'
+unless Gem.win_platform?
+  # Use official Maze Runner release
+  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.4'
 
-# Use a specific Maze Runner branch
-#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'
+  # Use a specific Maze Runner branch
+  #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'
 
-# Use a local copy of Maze Runner for development purposes
-#gem 'bugsnag-maze-runner', path: '../maze-runner'
+  # Use a local copy of Maze Runner for development purposes
+  #gem 'bugsnag-maze-runner', path: '../maze-runner'
+end

--- a/scripts/ci-build-windows-plugin.bat
+++ b/scripts/ci-build-windows-plugin.bat
@@ -1,0 +1,2 @@
+call bundle install
+call bundle exec rake plugin:export

--- a/tests/UnityEngine/MonoBehaviour.cs
+++ b/tests/UnityEngine/MonoBehaviour.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace UnityEngine
 {
-    public class MonoBehaviour
+    public class MonoBehaviour : Component
     {
     }
 }


### PR DESCRIPTION
## Goal

Ensure the notifier builds on Windows.

## Design

We ship the macOS build Unity package, but it's also useful to be able to build the notifier on Windows for development purposes.  This change adds that build to the CI pipeline, ensuring that it is not accidentally broken.

## Changeset

Just one tweak to one of the dummy classes was needed so that unit tests passed.  

Maze Runner installation is skipped on vanilla Windows as the required native extensions are not available.  When we need Maze Runner we use `wsl` and in that environment `Gem.win_platform?` is false.

## Testing

Covered by a basic CI run.