### PR TITLE
fix(ci): remove csharp layer cache inbetween scenarios

### DIFF
--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -577,6 +577,7 @@ public class MobileScenarioRunner : MonoBehaviour {
                 throw new Exception("Persisted Exception");
             case "Clear iOS Data":
                 MobileNative.ClearIOSData();
+                ClearPersistedData();
                 break;
             default:
                 throw new System.Exception("Unknown scenario: " + scenarioName);
@@ -584,6 +585,8 @@ public class MobileScenarioRunner : MonoBehaviour {
 
 
     }
+
+
 
     private void NullBreadcrumbMetadataValue()
     {
@@ -607,6 +610,14 @@ public class MobileScenarioRunner : MonoBehaviour {
             yield return new WaitForSeconds(1);
         }
         Bugsnag.StartSession();
+    }
+
+    private void ClearPersistedData()
+    {
+        if (Directory.Exists(Application.persistentDataPath + "/Bugsnag"))
+        {
+            Directory.Delete(Application.persistentDataPath + "/Bugsnag", true);
+        }
     }
 
     private void AddDebugMetadata()

--- a/features/ios/ios_persistence.feature
+++ b/features/ios/ios_persistence.feature
@@ -17,3 +17,5 @@ Feature: iOS event persistence tests
         And I discard the oldest error
 
         And the exception "message" equals "Persisted Exception"
+
+        And I wait for 2 seconds

--- a/features/ios/ios_persistence.feature
+++ b/features/ios/ios_persistence.feature
@@ -17,5 +17,3 @@ Feature: iOS event persistence tests
         And I discard the oldest error
 
         And the exception "message" equals "Persisted Exception"
-
-        And I wait for 2 seconds


### PR DESCRIPTION
## Goal

- CSharp layer cache data was not being removed before each scenario 

## Changeset

- Added method to clear Csharp layer data between scenarios 

## Testing

Covered by existing tests