### PR TITLE
fix(sessions): remove 1 frame wait before sending initial session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Increased thread saftey of the metadata dictionary in Bugsnag.LeaveBreadcrumb
   [#564](https://github.com/bugsnag/bugsnag-unity/pull/564)
 
+* Fixed an issue where events occuring directly after Bugsnag init had no session information attached.
+  [#571](https://github.com/bugsnag/bugsnag-unity/pull/571)
+
 
 ## 7.0.0 (2022-05-30)
 

--- a/features/android/android_csharp_errors.feature
+++ b/features/android/android_csharp_errors.feature
@@ -163,6 +163,7 @@ Feature: Android smoke tests for C# errors
         And the error payload field "events.0.device.runtimeVersions.osBuild" is not null
         And the error payload field "events.0.device.runtimeVersions.unity" is not null
 
+
      Scenario: Mark Launch Complete
         When I run the "Mark Launch Complete" mobile scenario
         Then I wait to receive an error
@@ -184,4 +185,9 @@ Feature: Android smoke tests for C# errors
         And the event "app.isLaunching" equals "true"
 
 
+    Scenario: Uncaught C# exception directly after start contains session
+        When I run the "Launch Exception Session" mobile scenario
+        Then I wait to receive an error
+
+        And the event "session" is not null
 

--- a/features/desktop/persistence.feature
+++ b/features/desktop/persistence.feature
@@ -7,13 +7,9 @@ Feature: Unity Persistence
     And I run the game in the "PersistSessionReport" state
     And I wait to receive 2 sessions
     Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
-    And the session payload field "app.releaseStage" equals the platform-dependent string:
-      | macos   | Second Session |
-      | windows | First Session  |
+    And the session payload field "app.releaseStage" equals "Second Session"
     And I discard the oldest session
-    And the session payload field "app.releaseStage" equals the platform-dependent string:
-      | macos   | First Session  |
-      | windows | Second Session |
+    And the session payload field "app.releaseStage" equals "First Session"
     And I run the game in the "ClearBugsnagCache" state
     And I wait for 5 seconds
 

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -26,6 +26,13 @@ Feature: Reporting unhandled events
       | Main.RunScenario(System.String scenario) | Main.RunScenario(string scenario)               |                                         |
       | Main.Start()                             |                                                 |                                         |
 
+  Scenario: Session is present in exception called directly after start
+    When I run the game in the "ExceptionWithSessionAfterStart" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "ExceptionWithSessionAfterStart"
+    And the event "session" is not null
+
   @windows_only
   Scenario: Windows device and app data
     When I run the game in the "UncaughtException" state

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -26,6 +26,7 @@ Feature: Reporting unhandled events
       | Main.RunScenario(System.String scenario) | Main.RunScenario(string scenario)               |                                         |
       | Main.Start()                             |                                                 |                                         |
 
+  @windows_only
   Scenario: Session is present in exception called directly after start
     When I run the game in the "ExceptionWithSessionAfterStart" state
     And I wait to receive an error

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -138,6 +138,10 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "ExceptionWithSessionAfterStart":
+                config.AutoTrackSessions = true;
+                config.Endpoints = new EndpointConfiguration("https://webhook.site/4345f13f-49ad-49d5-b8cb-da8d29acb329", "https://webhook.site/4345f13f-49ad-49d5-b8cb-da8d29acb329");
+                break;
             case "MaxPersistEvents":
                 config.MaximumBreadcrumbs = 0;
                 config.MaxPersistedEvents = 4;
@@ -432,6 +436,8 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "ExceptionWithSessionAfterStart":
+                throw new Exception("ExceptionWithSessionAfterStart");
             case "MaxPersistEvents":
                 StartCoroutine(NotifyPersistedEvents());
                 break;

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -140,7 +140,6 @@ public class Main : MonoBehaviour
         {
             case "ExceptionWithSessionAfterStart":
                 config.AutoTrackSessions = true;
-                config.Endpoints = new EndpointConfiguration("https://webhook.site/4345f13f-49ad-49d5-b8cb-da8d29acb329", "https://webhook.site/4345f13f-49ad-49d5-b8cb-da8d29acb329");
                 break;
             case "MaxPersistEvents":
                 config.MaximumBreadcrumbs = 0;

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -60,7 +60,7 @@ public class MobileScenarioRunner : MonoBehaviour {
         { "43", "Persist" },
         { "44", "Persist Report" },
         { "45", "Breadcrumb Null Metadata Value" },
-
+        { "46", "Launch Exception Session" },
 
 
         // Commands
@@ -146,6 +146,9 @@ public class MobileScenarioRunner : MonoBehaviour {
 
         switch (scenarioName)
         {
+            case "Launch Exception Session":
+                config.AutoTrackSessions = true;
+                break;
             case "Persist":
                 config.EnabledErrorTypes.OOMs = false;
                 config.AutoDetectErrors = true;
@@ -416,6 +419,8 @@ public class MobileScenarioRunner : MonoBehaviour {
     {
         switch (scenarioName)
         {
+            case "Launch Exception Session":
+                throw new Exception("Session");
             case "Breadcrumb Null Metadata Value":
                 NullBreadcrumbMetadataValue();
                 break;

--- a/features/ios/ios_csharp_errors.feature
+++ b/features/ios/ios_csharp_errors.feature
@@ -90,3 +90,9 @@ Feature: iOS smoke tests for C# errors
         And the exception "message" equals "You threw an exception!"
         And the event "app.isLaunching" equals "false"
 
+     Scenario: Uncaught C# exception directly after start contains session
+        When I run the "Launch Exception Session" mobile scenario
+        Then I wait to receive an error
+
+        And the event "session" is not null
+

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -75,7 +75,7 @@ def dial_number_for(name)
       "Persist" => 43,
       "Persist Report" => 44,
       "Breadcrumb Null Metadata Value" => 45,
-
+      "Launch Exception Session" => 46,
 
       # Commands
       "Clear iOS Data" => 90

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -125,7 +125,7 @@ namespace BugsnagUnity
                 SetupAdvancedExceptionInterceptor();
             }
             InitTimingTracker();
-            InitInitialSessionCheck();          
+            StartInitialSession();          
             CheckForMisconfiguredEndpointsWarning();
             AddBugsnagLoadedBreadcrumb();
             _delivery.StartDeliveringCachedPayloads();
@@ -155,18 +155,11 @@ namespace BugsnagUnity
             }
         }
 
-        private void InitInitialSessionCheck()
+        private void StartInitialSession()
         {
-            // Run initial session check in next frame to allow potential configuration
-            // changes to be completed first.
-            try
+            if (IsUsingFallback() && Configuration.AutoTrackSessions && SessionTracking.CurrentSession == null)
             {
-                var asyncHandler = MainThreadDispatchBehaviour.Instance();
-                asyncHandler.Enqueue(RunInitialSessionCheck());
-            }
-            catch (System.Exception ex)
-            {
-                // Async behavior is not available in a test environment
+                SessionTracking.StartSession();
             }
         }
 
@@ -590,18 +583,6 @@ namespace BugsnagUnity
             return Configuration.ReleaseStage == null
                 || Configuration.EnabledReleaseStages == null
                 || Configuration.EnabledReleaseStages.Contains(Configuration.ReleaseStage);
-        }
-
-        /// <summary>
-        /// Check next frame if a new session should be captured
-        /// </summary>
-        private IEnumerator<UnityEngine.AsyncOperation> RunInitialSessionCheck()
-        {
-            yield return null;
-            if (IsUsingFallback() && Configuration.AutoTrackSessions && SessionTracking.CurrentSession == null)
-            {
-                SessionTracking.StartSession();
-            }
         }
 
         public void SetContext(string context)


### PR DESCRIPTION
## Goal

Due to legacy code, events occuring after but during the same frame as Bugsnag.Start have no session data.

## Design

If autodetectsessions is enabled, the fallback will now create the initial session in the same frame as init.

## Changeset

- Removed 1 frame wait in fallback

## Testing

Added CI tests for iOS, Cocoa and Windows. MacOS does not work yet and will be worked on by the cocoa team at a later date