### PR TITLE
Bump bugsnag-android to v5.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TBD
 
+### Dependency updates
+
+* Update bugsnag-android from v5.22.4 to [v5.23.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5230-2022-06-20)
+
 ### Bug fixes
 
 * Increased thread saftey of the metadata dictionary in Bugsnag.LeaveBreadcrumb


### PR DESCRIPTION
## Goal

Bump bugsnag-android dependency to v5.23.0

Note - this includes a new configuration option that needs to be added to the Unity codebase.

### Enhancements

* Added configuration option to control whether internal errors are sent to Bugsnag
  [#1701](https://github.com/bugsnag/bugsnag-android/pull/1701)

### Bug fixes

* Fixed Bugsnag interactions with the Google ANR handler on newer versions of Android
  [#1699](https://github.com/bugsnag/bugsnag-android/pull/1699)
* Overwriting & clearing event metadata in the NDK plugin will no longer leave phantom values
  [#1700](https://github.com/bugsnag/bugsnag-android/pull/1700)