### PR TITLE
task(config): add telemetry config option to set value for android and cocoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TBD
 
+### Enhancements
+
+* Add `Configuration.Telemetry` config option to set the [native Android option](https://docs.bugsnag.com/platforms/android/configuration-options/#telemetry) and the [native Cocoa option](https://docs.bugsnag.com/platforms/ios/configuration-options/#telemetry) [#576](https://github.com/bugsnag/bugsnag-unity/pull/576)
+
 ### Dependency updates
 
 * Update bugsnag-android from v5.22.4 to [v5.23.1](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5231-2022-06-23)

--- a/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
+++ b/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
@@ -174,6 +174,7 @@ namespace BugsnagUnity.Editor
             EditorGUILayout.PropertyField(so.FindProperty("SecondsPerUniqueLog"));
             EditorGUILayout.PropertyField(so.FindProperty("SendLaunchCrashesSynchronously"));
             EditorGUILayout.PropertyField(so.FindProperty("SendThreads"));
+            EditorGUILayout.PropertyField(so.FindProperty("Telemetry"));
             EditorGUIUtility.labelWidth = originalWidth;
             EditorGUI.indentLevel--;
 

--- a/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
+++ b/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
@@ -38,6 +38,7 @@ namespace BugsnagUnity
         public bool ReportExceptionLogsAsHandled = true;
         public bool SendLaunchCrashesSynchronously = true;
         public double SecondsPerUniqueLog = 5;
+        public List<TelemetryType> Telemetry = new List<TelemetryType> { TelemetryType.InternalErrors };
         public int VersionCode;
         public static Configuration LoadConfiguration()
         {
@@ -102,6 +103,7 @@ namespace BugsnagUnity
             config.ReportExceptionLogsAsHandled = ReportExceptionLogsAsHandled;
             config.SendLaunchCrashesSynchronously = SendLaunchCrashesSynchronously;
             config.SecondsPerUniqueLog = TimeSpan.FromSeconds(SecondsPerUniqueLog);
+            config.Telemetry = Telemetry;
             config.VersionCode = VersionCode;
             return config;
         }

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -546,7 +546,7 @@ void bugsnag_setEnabledTelemetryTypes(const void *configuration, const char *typ
         return;
     }
 
-    ((__bridge BugsnagConfiguration *)configuration).telemetry &= ~BSGTelemetryInternalErrors;
+    ((__bridge BugsnagConfiguration *)configuration).telemetry = 0;
     for (int i = 0; i < count; i++) {
         const char *enabledType = types[i];
         if (enabledType != nil) {

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -19,6 +19,18 @@
         const char *user_email;
     };
 
+void bugsnag_startBugsnagWithConfiguration(const void *configuration, char *notifierVersion) {
+  if (notifierVersion) {
+    ((__bridge BugsnagConfiguration *)configuration).notifier =
+      [[BugsnagNotifier alloc] initWithName:@"Unity Bugsnag Notifier"
+                                    version:@(notifierVersion)
+                                        url:@"https://github.com/bugsnag/bugsnag-unity"
+                               dependencies:@[[[BugsnagNotifier alloc] init]]];
+  }
+  [Bugsnag startWithConfiguration: (__bridge BugsnagConfiguration *)configuration];
+  // Memory introspection is unused in a C/C++ context
+}
+
 const char * getMetadataJson(NSDictionary* dictionary){
 
     if (!dictionary) {
@@ -528,6 +540,25 @@ void bugsnag_setEnabledBreadcrumbTypes(const void *configuration, const char *ty
       }
 }
 
+void bugsnag_setEnabledTelemetryTypes(const void *configuration, const char *types[], int count){
+    if(types == NULL)
+    {
+        return;
+    }
+
+    ((__bridge BugsnagConfiguration *)configuration).telemetry &= ~BSGTelemetryInternalErrors;
+    for (int i = 0; i < count; i++) {
+        const char *enabledType = types[i];
+        if (enabledType != nil) {
+            NSString *typeString = [[NSString alloc] initWithUTF8String:enabledType];
+            if([typeString isEqualToString:@"InternalErrors"])
+            {
+                ((__bridge BugsnagConfiguration *)configuration).telemetry |= BSGTelemetryInternalErrors;
+            }
+        }
+    }
+}
+
 void bugsnag_setThreadSendPolicy(const void *configuration, char *threadSendPolicy){
     NSString *ns_threadSendPolicy = [[NSString alloc] initWithUTF8String:threadSendPolicy];
     if([ns_threadSendPolicy isEqualToString:@"Always"])
@@ -657,18 +688,6 @@ void bugsnag_removeMetadata(const void *configuration, const char *tab) {
 
   NSString *tabName = [NSString stringWithUTF8String:tab];
   [Bugsnag.client clearMetadataFromSection:tabName];
-}
-
-void bugsnag_startBugsnagWithConfiguration(const void *configuration, char *notifierVersion) {
-  if (notifierVersion) {
-    ((__bridge BugsnagConfiguration *)configuration).notifier =
-      [[BugsnagNotifier alloc] initWithName:@"Unity Bugsnag Notifier"
-                                    version:@(notifierVersion)
-                                        url:@"https://github.com/bugsnag/bugsnag-unity"
-                               dependencies:@[[[BugsnagNotifier alloc] init]]];
-  }
-  [Bugsnag startWithConfiguration: (__bridge BugsnagConfiguration *)configuration];
-  // Memory introspection is unused in a C/C++ context
 }
 
 void bugsnag_addBreadcrumb(char *message, char *type, char *metadataJson) {

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -240,6 +240,8 @@ namespace BugsnagUnity
             return _onSessionCallbacks;
         }
 
+        public TelemetryType[] Telemetry = new[] { TelemetryType.InternalErrors };
+
         public void AddMetadata(string section, string key, object value) => Metadata.AddMetadata(section, key, value);
 
         public void AddMetadata(string section, IDictionary<string, object> metadata) => Metadata.AddMetadata(section, metadata);

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -240,7 +240,7 @@ namespace BugsnagUnity
             return _onSessionCallbacks;
         }
 
-        public TelemetryType[] Telemetry = new[] { TelemetryType.InternalErrors };
+        public List<TelemetryType> Telemetry = new List<TelemetryType> { TelemetryType.InternalErrors };
 
         public void AddMetadata(string section, string key, object value) => Metadata.AddMetadata(section, key, value);
 

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -338,7 +338,7 @@ namespace BugsnagUnity
                 using (AndroidJavaObject enabledTelemetry = new AndroidJavaObject("java.util.HashSet"))
                 {
                     AndroidJavaClass androidTelemetryEnumClass = new AndroidJavaClass("com.bugsnag.android.Telemetry");
-                    for (int i = 0; i < config.Telemetry.Length; i++)
+                    for (int i = 0; i < config.Telemetry.Count; i++)
                     {
                         if (config.Telemetry[i] == TelemetryType.InternalErrors)
                         {

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -333,6 +333,26 @@ namespace BugsnagUnity
                 }
             }
 
+            if (config.Telemetry != null)
+            {
+                using (AndroidJavaObject enabledTelemetry = new AndroidJavaObject("java.util.HashSet"))
+                {
+                    AndroidJavaClass androidTelemetryEnumClass = new AndroidJavaClass("com.bugsnag.android.Telemetry");
+                    for (int i = 0; i < config.Telemetry.Length; i++)
+                    {
+                        if (config.Telemetry[i] == TelemetryType.InternalErrors)
+                        {
+                            using (AndroidJavaObject telemetryType = androidTelemetryEnumClass.CallStatic<AndroidJavaObject>("valueOf", "INTERNAL_ERRORS"))
+                            {
+                                enabledTelemetry.Call<Boolean>("add", telemetryType);
+                            }
+                        }
+                       
+                    }
+                    obj.Call("setTelemetry", enabledTelemetry);
+                }
+            }
+
             // set feature flags
             if (config.FeatureFlags != null && config.FeatureFlags.Count > 0)
             {

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -62,7 +62,8 @@ namespace BugsnagUnity
             {
                 NativeCode.bugsnag_setRedactedKeys(obj, config.RedactedKeys, config.RedactedKeys.Length);
             }
-           
+
+            SetEnabledTelemetryTypes(obj,config);
             SetEnabledBreadcrumbTypes(obj,config);
             SetEnabledErrorTypes(obj, config);
             if (config.Context != null)
@@ -171,6 +172,22 @@ namespace BugsnagUnity
                 enabledTypes.Add(typeName);
             }
             NativeCode.bugsnag_setEnabledBreadcrumbTypes(obj, enabledTypes.ToArray(),enabledTypes.Count);
+        }
+
+        private void SetEnabledTelemetryTypes(IntPtr obj, Configuration config)
+        {
+            if (config.Telemetry == null)
+            {
+                NativeCode.bugsnag_setEnabledTelemetryTypes(obj, null, 0);
+                return;
+            }
+            var enabledTypes = new List<string>();
+            foreach (var enabledType in config.Telemetry)
+            {
+                var typeName = Enum.GetName(typeof(TelemetryType), enabledType);
+                enabledTypes.Add(typeName);
+            }
+            NativeCode.bugsnag_setEnabledTelemetryTypes(obj, enabledTypes.ToArray(), enabledTypes.Count);
         }
 
         private void SetEnabledErrorTypes(IntPtr obj, Configuration config)

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -99,7 +99,10 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setAppHangThresholdMillis(IntPtr configuration, ulong appHangThresholdMillis);
 
         [DllImport(Import)]
-        internal static extern void bugsnag_setEnabledBreadcrumbTypes(IntPtr configuration, string[] types, int count);
+        internal static extern void bugsnag_setEnabledBreadcrumbTypes(IntPtr configuration, string[] types, int count); 
+
+        [DllImport(Import)]
+        internal static extern void bugsnag_setEnabledTelemetryTypes(IntPtr configuration, string[] types, int count);
 
         [DllImport(Import)]
         internal static extern void bugsnag_setEnabledErrorTypes(IntPtr configuration, string[] types, int count);

--- a/src/BugsnagUnity/TelemetryType.cs
+++ b/src/BugsnagUnity/TelemetryType.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace BugsnagUnity
+{
+    public enum TelemetryType
+    {
+        InternalErrors
+    }
+}


### PR DESCRIPTION
## Goal

add telemetry config option to set value for android and cocoa

## Changeset

- Added TelemetryType enum
- Added config.Telemetry 
- Pass value to Android and Cocoa on start

## Testing

Manually tested (with logging) that the value is set correctly in the Android and Cocoa SDKs