### PR TITLE
Build and test on Windows with WSL Buildkite agent 

### DIFF
--- a/.buildkite/block.full.yml
+++ b/.buildkite/block.full.yml
@@ -1,0 +1,7 @@
+steps:
+  - block: 'Trigger a full build'
+    key: 'trigger-full-build'
+
+  - label: 'Upload the full test pipeline'
+    depends_on: 'trigger-full-build'
+    command: buildkite-agent pipeline upload .buildkite/pipeline.full.yml

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -639,37 +639,58 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'windows-2018-fixture'
     agents:
-      queue: opensource-windows-unity
+      queue: windows-general-wsl
     env:
       UNITY_VERSION: "2018.4.36f1"
-      WSLENV: "UNITY_VERSION"
-    command:
-      - scripts/ci-run-windows-tests.bat
-    artifact_paths:
-      - maze_output/**/*
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/Windows-2018.4.36f1.zip
+        upload:
+          - maze_output/**/*
+    commands:
+      - cd features/fixtures/maze_runner/build
+      - unzip Windows-2018.4.36f1.zip
+      - cd ../../../..
+      - bundle install
+      - bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop
 
   - label: Run Windows e2e tests for Unity 2019
     timeout_in_minutes: 30
     depends_on: 'windows-2019-fixture'
     agents:
-      queue: opensource-windows-unity
+      queue: windows-general-wsl
     env:
       UNITY_VERSION: "2019.4.35f1"
-      WSLENV: "UNITY_VERSION"
-    command:
-      - scripts/ci-run-windows-tests.bat
-    artifact_paths:
-      - maze_output/**/*
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/Windows-2019.4.35f1.zip
+        upload:
+          - maze_output/**/*
+    commands:
+      - cd features/fixtures/maze_runner/build
+      - unzip Windows-2019.4.35f1.zip
+      - cd ../../../..
+      - bundle install
+      - bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop
 
   - label: Run Windows e2e tests for Unity 2021
     timeout_in_minutes: 30
     depends_on: 'windows-2021-fixture'
     agents:
-      queue: opensource-windows-unity
+      queue: windows-general-wsl
     env:
       UNITY_VERSION: "2021.2.17f1"
-      WSLENV: "UNITY_VERSION"
-    command:
-      - scripts/ci-run-windows-tests.bat
-    artifact_paths:
-      - maze_output/**/*
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/Windows-2021.2.17f1.zip
+        upload:
+          - maze_output/**/*
+    commands:
+      - cd features/fixtures/maze_runner/build
+      - unzip Windows-2021.2.17f1.zip
+      - cd ../../../..
+      - bundle install
+      - bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -52,7 +52,7 @@ steps:
     key: 'cocoa-webgl-2021-fixtures'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -61,8 +61,8 @@ steps:
       - scripts/ci-build-macos-packages.sh
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2021.2.17f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2021.2.17f1.zip
+      - features/fixtures/maze_runner/build/MacOS-2021.3.3f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2021.3.3f1.zip
     retry:
       automatic:
         - exit_status: "*"
@@ -111,11 +111,11 @@ steps:
     agents:
       queue: macos-12-arm-unity
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - features/fixtures/maze_runner/build/MacOS-2021.2.17f1.zip
+          - features/fixtures/maze_runner/build/MacOS-2021.3.3f1.zip
         upload:
           - maze_output/**/*
           - Mazerunner.log
@@ -167,11 +167,11 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - features/fixtures/maze_runner/build/WebGL-2021.2.17f1.zip
+          - features/fixtures/maze_runner/build/WebGL-2021.3.3f1.zip
         upload:
           - maze_output/**/*
     # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
@@ -226,13 +226,13 @@ steps:
     key: 'build-android-fixture-2021'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
-          - features/fixtures/maze_runner/mazerunner_2021.2.17f1.apk
+          - features/fixtures/maze_runner/mazerunner_2021.3.3f1.apk
           - features/fixtures/unity.log
     commands:
       - rake test:android:build
@@ -246,13 +246,13 @@ steps:
     key: 'build-edm-fixture-2021'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
-          - features/fixtures/EDM_Fixture/edm_2021.2.17f1.apk
+          - features/fixtures/EDM_Fixture/edm_2021.3.3f1.apk
           - features/scripts/mobile/buildEdmFixture.log
           - features/scripts/mobile/edmImport.log
           - features/scripts/mobile/enableEdm.log
@@ -322,14 +322,14 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2021.2.17f1.apk"
+          - "features/fixtures/maze_runner/mazerunner_2021.3.3f1.apk"
         upload:
           - "maze_output/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.17f1.apk"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.3f1.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "features/android"
@@ -343,18 +343,18 @@ steps:
     agents:
       queue: opensource
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/EDM_Fixture/edm_2021.2.17f1.apk"
+          - "features/fixtures/EDM_Fixture/edm_2021.3.3f1.apk"
         upload:
           - "maze_output/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.2.17f1.apk"
+          - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.3f1.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "features/edm"
@@ -460,7 +460,7 @@ steps:
     key: 'generate-fixture-project-2021'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -483,14 +483,14 @@ steps:
     agents:
       queue: macos-12-arm-unity
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
           - project_2021.tgz
         upload:
-          - features/fixtures/maze_runner/mazerunner_2021.2.17f1.ipa
+          - features/fixtures/maze_runner/mazerunner_2021.3.3f1.ipa
           - features/fixtures/unity.log
     commands:
       - tar -zxf project_2021.tgz features/fixtures/maze_runner
@@ -559,14 +559,14 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2021.2.17f1.ipa"
+          - "features/fixtures/maze_runner/mazerunner_2021.3.3f1.ipa"
         upload:
           - "maze_output/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.2.17f1.ipa"
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.3f1.ipa"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
@@ -621,12 +621,12 @@ steps:
     agents:
       queue: windows-general-wsl
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3"
     commands:
       - scripts/ci-build-windows-fixture-wsl.sh
     artifact_paths:
       - unity.log
-      - features/fixtures/maze_runner/build/Windows-2021.2.17f1.zip
+      - features/fixtures/maze_runner/build/Windows-2021.3.3.zip
     retry:
       automatic:
         - exit_status: "*"
@@ -673,11 +673,11 @@ steps:
     agents:
       queue: windows-general-wsl
     env:
-      UNITY_VERSION: "2021.2.17f1"
+      UNITY_VERSION: "2021.3.3f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - features/fixtures/maze_runner/build/Windows-2021.2.17f1.zip
+          - features/fixtures/maze_runner/build/Windows-2021.3.3f1.zip
         upload:
           - maze_output/**/*
     commands:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -629,7 +629,7 @@ steps:
     agents:
       queue: windows-general-wsl
     env:
-      UNITY_VERSION: "2021.3.3"
+      UNITY_VERSION: "2021.3.3f1"
     commands:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -638,7 +638,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - unity.log
-          - features/fixtures/maze_runner/build/Windows-2021.3.3.zip
+          - features/fixtures/maze_runner/build/Windows-2021.3.3f1.zip
     retry:
       automatic:
         - exit_status: "*"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -588,9 +588,13 @@ steps:
       UNITY_VERSION: "2018.4.36f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/Windows-2018.4.36f1.zip
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - unity.log
+          - features/fixtures/maze_runner/build/Windows-2018.4.36f1.zip
     retry:
       automatic:
         - exit_status: "*"
@@ -606,9 +610,13 @@ steps:
       UNITY_VERSION: "2019.4.35f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/Windows-2019.4.35f1.zip
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - unity.log
+          - features/fixtures/maze_runner/build/Windows-2019.4.35f1.zip
     retry:
       automatic:
         - exit_status: "*"
@@ -624,9 +632,13 @@ steps:
       UNITY_VERSION: "2021.3.3"
     commands:
       - scripts/ci-build-windows-fixture-wsl.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/Windows-2021.3.3.zip
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - unity.log
+          - features/fixtures/maze_runner/build/Windows-2021.3.3.zip
     retry:
       automatic:
         - exit_status: "*"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -583,11 +583,11 @@ steps:
     key: 'windows-2018-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: opensource-windows-unity
+      queue: windows-general-wsl
     env:
       UNITY_VERSION: "2018.4.36f1"
     command:
-      - scripts/ci-build-windows-package.bat
+      - scripts/ci-build-windows-fixture-wsl.sh
     artifact_paths:
       - unity.log
       - features/fixtures/maze_runner/build/Windows-2018.4.36f1.zip
@@ -601,11 +601,11 @@ steps:
     key: 'windows-2019-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: opensource-windows-unity
+      queue: windows-general-wsl
     env:
       UNITY_VERSION: "2019.4.35f1"
     command:
-      - scripts/ci-build-windows-package.bat
+      - scripts/ci-build-windows-fixture-wsl.sh
     artifact_paths:
       - unity.log
       - features/fixtures/maze_runner/build/Windows-2019.4.35f1.zip
@@ -619,11 +619,11 @@ steps:
     key: 'windows-2021-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: opensource-windows-unity
+      queue: windows-general-wsl
     env:
       UNITY_VERSION: "2021.2.17f1"
     commands:
-      - scripts/ci-build-windows-package.bat
+      - scripts/ci-build-windows-fixture-wsl.sh
     artifact_paths:
       - unity.log
       - features/fixtures/maze_runner/build/Windows-2021.2.17f1.zip
@@ -649,11 +649,7 @@ steps:
         upload:
           - maze_output/**/*
     commands:
-      - cd features/fixtures/maze_runner/build
-      - unzip Windows-2018.4.36f1.zip
-      - cd ../../../..
-      - bundle install
-      - bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop
+      - scripts/ci-run-windows-tests-wsl.sh
 
   - label: Run Windows e2e tests for Unity 2019
     timeout_in_minutes: 30
@@ -669,11 +665,7 @@ steps:
         upload:
           - maze_output/**/*
     commands:
-      - cd features/fixtures/maze_runner/build
-      - unzip Windows-2019.4.35f1.zip
-      - cd ../../../..
-      - bundle install
-      - bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop
+      - scripts/ci-run-windows-tests-wsl.sh
 
   - label: Run Windows e2e tests for Unity 2021
     timeout_in_minutes: 30
@@ -689,8 +681,4 @@ steps:
         upload:
           - maze_output/**/*
     commands:
-      - cd features/fixtures/maze_runner/build
-      - unzip Windows-2021.2.17f1.zip
-      - cd ../../../..
-      - bundle install
-      - bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop
+      - scripts/ci-run-windows-tests-wsl.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -299,14 +299,21 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'windows-2020-fixture'
     agents:
-      queue: opensource-windows-unity
+      queue: windows-general-wsl
     env:
       UNITY_VERSION: "2020.3.32f1"
-      WSLENV: "UNITY_VERSION"
-    command:
-      - scripts/ci-run-windows-tests.bat
-    artifact_paths:
-      - maze_output/**/*
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
+        upload:
+          - maze_output/**/*
+    commands:
+      - cd features/fixtures/maze_runner/build
+      - unzip Windows-2020.3.32f1.zip
+      - cd ../../../..
+      - bundle install
+      - bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop
 
   #
   # Conditionally trigger full pipeline

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -282,11 +282,15 @@ steps:
       queue: windows-general-wsl
     env:
       UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - unity.log
+          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
     commands:
       - scripts/ci-build-windows-fixture-wsl.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
     retry:
       automatic:
         - exit_status: "*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -279,7 +279,7 @@ steps:
     key: 'windows-2020-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: opensource-windows-unity
+      queue: windows-general-wsl
     env:
       UNITY_VERSION: "2020.3.32f1"
     commands:
@@ -309,7 +309,7 @@ steps:
         upload:
           - maze_output/**/*
     command:
-      - scripts/run-windows-tests-wsl.sh
+      - scripts/ci-run-windows-tests-wsl.sh
   #
   # Conditionally trigger full pipeline
   #

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -283,7 +283,7 @@ steps:
     env:
       UNITY_VERSION: "2020.3.32f1"
     commands:
-      - scripts/ci-build-windows-package.bat
+      - scripts/ci-build-windows-fixture-wsl.sh
     artifact_paths:
       - unity.log
       - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
@@ -308,13 +308,8 @@ steps:
           - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
         upload:
           - maze_output/**/*
-    commands:
-      - cd features/fixtures/maze_runner/build
-      - unzip Windows-2020.3.32f1.zip
-      - cd ../../../..
-      - bundle install
-      - bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop
-
+    command:
+      - scripts/run-windows-tests-wsl.sh
   #
   # Conditionally trigger full pipeline
   #

--- a/.buildkite/pipeline_trigger.sh
+++ b/.buildkite/pipeline_trigger.sh
@@ -7,4 +7,8 @@ if [[ "$BUILDKITE_MESSAGE" == *"[full ci]"* ||
   "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" == "master" ]]; then
   echo "Running full build"
   buildkite-agent pipeline upload .buildkite/pipeline.full.yml
+else
+  # Basic build, but allow a full build to be triggered
+  echo "Running basic build"
+  buildkite-agent pipeline upload .buildkite/block.full.yml
 fi

--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -17,6 +17,10 @@ elif [ "$1" == "windows" ]; then
   PLATFORM="Win64"
   set -m
   UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+elif [ "$1" == "wsl" ]; then
+  PLATFORM="Win64"
+  set -m
+  UNITY_PATH="/mnt/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
 elif [ "$1" == "webgl" ]; then
   PLATFORM="WebGL"
   if [ "$(uname)" == "Darwin" ]; then
@@ -33,31 +37,51 @@ fi
 SCRIPT_DIR=$(dirname "$(realpath $0)")
 pushd $SCRIPT_DIR
   pushd ../..
-    package_path=`pwd`
-    echo "Expecting to find Bugsnag package in: $package_path"
+    root_path=`pwd`
   popd
   pushd ../fixtures
-    import_log_file="$package_path/unity_import.log"
-    log_file="$package_path/unity.log"
-    project_path="$(pwd)/maze_runner"
+
+    import_log_file="$root_path/unity_import.log"
+    log_file="$root_path/unity.log"
+    package_path="$root_path/Bugsnag.unitypackage"
+    project_path="$root_path/features/fixtures/maze_runner"
+
+    if [ "$1" == "wsl" ]; then
+      import_log_file=`wslpath -w "$import_log_file"`
+      log_file=`wslpath -w "$log_file"`
+      package_path=`wslpath -w "$package_path"`
+      project_path=`wslpath -w "$project_path"`
+    fi
+
+    echo "Expecting to find Bugsnag package in: $package_path"
 
     # Run unity and immediately exit afterwards, log all output
     DEFAULT_CLI_ARGS="-nographics -quit -batchmode"
 
-    echo "Importing $package_path/Bugsnag.unitypackage into $project_path"
+    echo "Importing $package_path into $project_path"
+    echo "$UNITY_PATH" $DEFAULT_CLI_ARGS \
+      -logFile $import_log_file \
+      -projectPath "$project_path" \
+      -ignoreCompilerErrors \
+      -importPackage "$package_path"
+
     "$UNITY_PATH" $DEFAULT_CLI_ARGS \
       -logFile $import_log_file \
-      -projectPath $project_path \
+      -projectPath "$project_path" \
       -ignoreCompilerErrors \
-      -importPackage "$package_path/Bugsnag.unitypackage"
+      -importPackage "$package_path"
     RESULT=$?
     if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 
     echo "Building the fixture for $PLATFORM"
 
+    echo "$UNITY_PATH" $DEFAULT_CLI_ARGS \
+      -logFile "$log_file" \
+      -projectPath "$project_path" \
+      -executeMethod "Builder.$PLATFORM"
     "$UNITY_PATH" $DEFAULT_CLI_ARGS \
-      -logFile $log_file \
-      -projectPath $project_path \
+      -logFile "$log_file" \
+      -projectPath "$project_path" \
       -executeMethod "Builder.$PLATFORM"
     RESULT=$?
     if [ $RESULT -ne 0 ]; then exit $RESULT; fi

--- a/scripts/ci-build-windows-fixture-wsl.sh
+++ b/scripts/ci-build-windows-fixture-wsl.sh
@@ -6,3 +6,9 @@ IF NOT [%ERRORLEVEL%] EQU [0] EXIT /B %ERRORLEVEL%
 
 cd ..\fixtures\maze_runner\build
 7z a -r Windows-%UNITY_VERSION%.zip Windows
+
+#!/bin/bash -e
+cd features/scripts
+./build_maze_runner.sh windows
+cd ../fixtures/maze_runner/build
+zip -r Windows-$(UNITY_VERSION).zip Windows

--- a/scripts/ci-build-windows-fixture-wsl.sh
+++ b/scripts/ci-build-windows-fixture-wsl.sh
@@ -1,14 +1,5 @@
-REM Using the artifacts plugin v1.3 on Windows seems to break the whole step
-buildkite-agent artifact download "Bugsnag.unitypackage" .
-cd features\scripts
-C:\Progra~1\Git\bin\bash.exe build_maze_runner.sh windows
-IF NOT [%ERRORLEVEL%] EQU [0] EXIT /B %ERRORLEVEL%
-
-cd ..\fixtures\maze_runner\build
-7z a -r Windows-%UNITY_VERSION%.zip Windows
-
 #!/bin/bash -e
 cd features/scripts
-./build_maze_runner.sh windows
+./build_maze_runner.sh wsl
 cd ../fixtures/maze_runner/build
-zip -r Windows-$(UNITY_VERSION).zip Windows
+zip -r Windows-$UNITY_VERSION.zip Windows

--- a/scripts/ci-run-windows-tests-wsl.sh
+++ b/scripts/ci-run-windows-tests-wsl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 cd features/fixtures/maze_runner/build
-unzip Windows-$(UNITY_VERSION).zip
+unzip Windows-$UNITY_VERSION.zip
 cd ../../../..
 bundle install
 bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop

--- a/scripts/ci-run-windows-tests-wsl.sh
+++ b/scripts/ci-run-windows-tests-wsl.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+cd features/fixtures/maze_runner/build
+unzip Windows-$(UNITY_VERSION).zip
+cd ../../../..
+bundle install
+bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop

--- a/scripts/ci-run-windows-tests.bat
+++ b/scripts/ci-run-windows-tests.bat
@@ -1,7 +1,0 @@
-REM Using the artifacts plugin v1.3 on Windows seems to break the whole step
-buildkite-agent artifact download "features\fixtures\maze_runner\build\Windows-%UNITY_VERSION%.zip" .
-cd features\fixtures\maze_runner\build
-7z x Windows-%UNITY_VERSION%.zip
-cd ..\..\..\..
-wsl bundle install
-wsl bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop


### PR DESCRIPTION
## Goal

Moves the pipeline to build and test for Windows on our build servers set up to run the Linux Buildkite agent under WSL.

## Design

We've had a number of issues and annoyances with how tests run on Windows (e.g. cancel/timeouts not failing the step).  The idea here is to use Windows as little as possible (i.e. just for the running executable - the test harness and orchestration is now all Linux).

## Changeset

- Pipeline and supporting scripts update for Linux/WSL agent
- Unity 2021 test version bumped across the board
- Add the ability to always trigger a full build manually

## Testing

Covered by a full CI run.