### PR TITLE
Skip Windows build of plugin 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,6 +22,7 @@ steps:
           limit: 1
 
   - label: Ensure notifier builds on Windows (for development)
+    skip: Pending PLAT-8676
     timeout_in_minutes: 30
     agents:
       queue: opensource-windows-unity


### PR DESCRIPTION
## Goal

Skip Windows build of plugin pending further investigation.

## Design

This step fails to build under WSL, leaving the agent process locked up and the build server in need of a restart (even closing WSL doesn't stop the process consuming maximum CPU).  As this step is not needed for the product, rather than getting bogged down in trying to solve the issue now I've skipped it and raised an internal ticket to look at a later date.  Moving to WSL2 way help.

## Changeset

Skip Windows build of the plugin.

## Testing

Covered by a basic CI run.