### PR TITLE
Macos ci fixes

### DIFF
--- a/features/fixtures/maze_runner/Assets/Plugins/OSX/NativeCrashy.bundle.meta
+++ b/features/fixtures/maze_runner/Assets/Plugins/OSX/NativeCrashy.bundle.meta
@@ -13,18 +13,21 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      : Any
+      '': Any
     second:
       enabled: 0
       settings:
         Exclude Android: 1
-        Exclude Editor: 0
+        Exclude Editor: 1
+        Exclude Linux: 1
         Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
         Exclude OSXUniversal: 0
         Exclude WebGL: 1
         Exclude Win: 1
         Exclude Win64: 1
         Exclude iOS: 1
+        Exclude tvOS: 1
   - first:
       Android: Android
     second:
@@ -39,11 +42,29 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true
         OS: AnyOS
+  - first:
+      Facebook: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Facebook: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  - first:
+      Standalone: Linux
+    second:
+      enabled: 0
+      settings:
+        CPU: x86
   - first:
       Standalone: Linux64
     second:
@@ -61,20 +82,26 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: x86
+        CPU: AnyCPU
   - first:
       Standalone: Win64
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       iPhone: iOS
     second:
       enabled: 0
       settings:
         AddToEmbeddedBinaries: false
-        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 0
+      settings:
         CompileFlags: 
         FrameworkDependencies: 
   userData: 

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -59,7 +59,7 @@ When('I run the game in the {string} state') do |state|
   when 'macos'
     # Call executable directly rather than use open, which flakes on CI
     log = File.join(Dir.pwd, 'mazerunner.log')
-    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args -logfile #{log} > /dev/null"
+    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner"
     Maze::Runner.run_command(command, blocking: false)
 
     execute_command('run_scenario', state)


### PR DESCRIPTION
- Removed custom log path from player rinning command so that the default player log is created where it's expected.
- Setup the correct meta file for the macos native code bundle as it was incorrect and breaking local builds.