### PR TITLE
Remove wslpath from mazerunner steps

### DIFF
--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -27,8 +27,7 @@ When('I clear the Bugsnag cache') do
     execute_command('clear_cache')
 
   when 'windows'
-    wsl_log = File.join(Dir.pwd, 'mazerunner.log')
-    win_log = `wslpath -w #{wsl_log}`
+    win_log = File.join(Dir.pwd, 'mazerunner.log')
     command = "#{Maze.config.app} --args -logfile #{win_log}"
     Maze::Runner.run_command(command, blocking: false)
 
@@ -65,8 +64,7 @@ When('I run the game in the {string} state') do |state|
     execute_command('run_scenario', state)
 
   when 'windows'
-    wsl_log = File.join(Dir.pwd, 'mazerunner.log')
-    win_log = `wslpath -w #{wsl_log}`
+    win_log = File.join(Dir.pwd, 'mazerunner.log')
     command = "#{Maze.config.app} --args -logfile #{win_log}"
     Maze::Runner.run_command(command, blocking: false)
 


### PR DESCRIPTION
## Goal

Due to an issue with `wslpath` certain maze runner steps within the Unity E2E fail. As maze runner is running inside wsl, it doesn't need wslpath to convert the paths to windows paths. 

## Changeset

Remove `wslpath` from `unity_steps.rb` as it isn't needed.

## Testing

Covered by full CI.