### PR TITLE
task(ci): add macos test for events sent after start containing session information

### DIFF
--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -26,7 +26,6 @@ Feature: Reporting unhandled events
       | Main.RunScenario(System.String scenario) | Main.RunScenario(string scenario)               |                                         |
       | UnityEngine.SetupCoroutine.InvokeMoveNext(System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) | |
 
-  @windows_only
   Scenario: Session is present in exception called directly after start
     When I run the game in the "ExceptionWithSessionAfterStart" state
     And I wait to receive an error

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -67,7 +67,7 @@ public class Main : MonoBehaviour
 
     IEnumerator RunNextMazeCommand()
     {
-        Debug.Log("RunNextMazeCommand called");
+        Console.WriteLine("RunNextMazeCommand called");
 
         using (UnityWebRequest request = UnityWebRequest.Get(_mazeHost + "/command"))
         {
@@ -80,23 +80,23 @@ public class Main : MonoBehaviour
                 !request.isNetworkError;
 #endif
 
-            Debug.Log("result is " + result);
+            Console.WriteLine("result is " + result);
             if (result)
             {
                 var response = request.downloadHandler?.text;
-                Debug.Log("Raw response: " + response);
+                Console.WriteLine("Raw response: " + response);
                 if (response == null || response == "null" || response == "No commands to provide")
                 {
-                    Debug.Log("No Maze Runner command to process at present");
+                    Console.WriteLine("No Maze Runner command to process at present");
                 }
                 else
                 { 
                     var command = JsonUtility.FromJson<Command>(response);
                     if (command != null)
                     {
-                        Debug.Log("Received Maze Runner command:");
-                        Debug.Log("Action: " + command.action);
-                        Debug.Log("Scenario: " + command.scenarioName);
+                        Console.WriteLine("Received Maze Runner command:");
+                        Console.WriteLine("Action: " + command.action);
+                        Console.WriteLine("Scenario: " + command.scenarioName);
 
                         if ("clear_cache".Equals(command.action))
                         {


### PR DESCRIPTION
## Goal

There was a bug where exceptions reported directly after Bugsnag.Start() contained no session information.

This was fixed, but the CI test for MacOS did not work as MacOS apps launched via command line, launch in the background, and there is a delay before the application gets the inForeground notification.

## Changeset

- Added the abillity to delay the start of a scenario

## Testing

CI test coverage