### PR TITLE
refac(persistence): refactor the cache manager to be less generic and easier to read

### DIFF
--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -138,16 +138,30 @@ namespace BugsnagUnity
 
         private IEnumerator DeliverCachedPayloads()
         {
-            var payloadIds = _cacheManager.GetCachedPayloadIds();
-            foreach (var payloadId in payloadIds)
+            var cachedSessionIds = _cacheManager.GetCachedSessionIds();
+            foreach (var sessionId in cachedSessionIds)
             {
-                var payload = _cacheManager.GetCachedPayload(payloadId);
-                if (payload != null)
+                var sessionJson = _cacheManager.GetCachedSession(sessionId);
+                if (!string.IsNullOrEmpty(sessionJson))
                 {
-                    Deliver(payload);
-                    yield return new WaitUntil(() => CachedPayloadProcessed(payload.Id));
+                    var sessionReport = new SessionReport(_configuration, ((JsonObject)SimpleJson.DeserializeObject(sessionJson)).GetDictionary());
+                    Deliver(sessionReport);
+                    yield return new WaitUntil(() => CachedPayloadProcessed(sessionReport.Id));
                 }
             }
+
+            var cachedEvents = _cacheManager.GetCachedEventIds();
+            foreach (var eventId in cachedEvents)
+            {
+                var eventJson = _cacheManager.GetCachedEvent(eventId);
+                if (!string.IsNullOrEmpty(eventJson))
+                {
+                    var eventReport = new Report(_configuration, ((JsonObject)SimpleJson.DeserializeObject(eventJson)).GetDictionary());
+                    Deliver(eventReport);
+                    yield return new WaitUntil(() => CachedPayloadProcessed(eventReport.Id));
+                }
+            }
+
             _cacheDeliveryInProcess = false;
         }     
 

--- a/src/BugsnagUnity/ICacheManager.cs
+++ b/src/BugsnagUnity/ICacheManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using BugsnagUnity.Payload;
 
 namespace BugsnagUnity
@@ -11,7 +12,10 @@ namespace BugsnagUnity
         void SaveEventToCache(string id, string json);
         void RemoveCachedEvent(string id);
         void RemoveCachedSession(string id);
-        string[] GetCachedPayloadIds();
-        IPayload GetCachedPayload(string id);
+        List<string> GetCachedEventIds();
+        List<string> GetCachedSessionIds();
+        string GetCachedEvent(string id);
+        string GetCachedSession(string id);
+
     }
 }

--- a/src/BugsnagUnity/Native/Fallback/CacheManager.cs
+++ b/src/BugsnagUnity/Native/Fallback/CacheManager.cs
@@ -153,57 +153,15 @@ namespace BugsnagUnity
             }
         }
 
-        public string[] GetCachedPayloadIds()
-        {
-            var cachedPayloadIds = new List<string>();
-            foreach (var path in _cachedSessions)
-            {
-                cachedPayloadIds.Add(Path.GetFileNameWithoutExtension(path));
-            }
-            foreach (var path in _cachedEvents)
-            {
-                cachedPayloadIds.Add(Path.GetFileNameWithoutExtension(path));
-            }
-            return cachedPayloadIds.ToArray();
-        }
-
-        private string[] GetCachedPayloadPaths()
-        {
-            var cachedPayloadPaths = new List<string>();
-            cachedPayloadPaths.AddRange(_cachedSessions);
-            cachedPayloadPaths.AddRange(_cachedEvents);
-            return cachedPayloadPaths.OrderBy(file => File.GetCreationTimeUtc(file)).ToArray();
-        }
-
-        private IPayload GetPayloadFromCachePath(string path)
+        private string GetJsonFromCachePath(string path)
         {
             if (File.Exists(path))
             {
-                if (path.EndsWith(SESSION_FILE_PREFIX))
-                {
-                    var json = File.ReadAllText(path);
-                    var sessionReportFromCachedPayload = new SessionReport(_configuration, ((JsonObject)SimpleJson.DeserializeObject(json)).GetDictionary());
-                    return sessionReportFromCachedPayload;
-                }
-                else if (path.EndsWith(EVENT_FILE_PREFIX))
-                {
-                    var json = File.ReadAllText(path);
-                    var eventReportFromCachedPayload = new Report(_configuration, ((JsonObject)SimpleJson.DeserializeObject(json)).GetDictionary());
-                    return eventReportFromCachedPayload;
-                }
+                return File.ReadAllText(path);
             }
             return null;
         }
-
-        public IPayload GetCachedPayload(string id)
-        {
-            foreach (var path in GetCachedPayloadPaths())
-            {
-                return GetPayloadFromCachePath(path);
-            }
-            return null;
-        }
-
+       
         private static void CheckForDirectoryCreation()
         {
             try
@@ -228,5 +186,48 @@ namespace BugsnagUnity
 
         }
 
+        public List<string> GetCachedEventIds()
+        {
+            var cachedEventIds = new List<string>();
+            foreach (var path in _cachedEvents)
+            {
+                cachedEventIds.Add(Path.GetFileNameWithoutExtension(path));
+            }
+            return cachedEventIds;
+        }
+
+        public List<string> GetCachedSessionIds()
+        {
+            var cachedSessionIds = new List<string>();
+            foreach (var path in _cachedSessions)
+            {
+                cachedSessionIds.Add(Path.GetFileNameWithoutExtension(path));
+            }
+            return cachedSessionIds;
+        }
+
+        public string GetCachedEvent(string id)
+        {
+            foreach (var path in _cachedEvents)
+            {
+                if (path.Contains(id))
+                {
+                    return GetJsonFromCachePath(path);
+                }
+            }
+            return null;
+        }
+
+        public string GetCachedSession(string id)
+        {
+            foreach (var path in _cachedSessions)
+            {
+                if (path.Contains(id))
+                {
+                    return GetJsonFromCachePath(path);
+                }
+            }
+            return null;
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Fallback/CacheManager.cs
+++ b/src/BugsnagUnity/Native/Fallback/CacheManager.cs
@@ -189,7 +189,8 @@ namespace BugsnagUnity
         public List<string> GetCachedEventIds()
         {
             var cachedEventIds = new List<string>();
-            foreach (var path in _cachedEvents)
+            var ordered = _cachedEvents.OrderBy(file => File.GetCreationTimeUtc(file)).ToArray();
+            foreach (var path in ordered)
             {
                 cachedEventIds.Add(Path.GetFileNameWithoutExtension(path));
             }
@@ -199,7 +200,8 @@ namespace BugsnagUnity
         public List<string> GetCachedSessionIds()
         {
             var cachedSessionIds = new List<string>();
-            foreach (var path in _cachedSessions)
+            var ordered = _cachedSessions.OrderBy(file => File.GetCreationTimeUtc(file)).ToArray();
+            foreach (var path in ordered)
             {
                 cachedSessionIds.Add(Path.GetFileNameWithoutExtension(path));
             }


### PR DESCRIPTION
## Goal

While implementing the CacheManager on another native platform, i realised that it would be better if the CacheManager was a bit simpler and was only responsible for storing and retrieving the necessary json. Then the Delivery class could handle serialisation for all platforms, and there would be less duplicated code.

I also realised that the CacheManager interface was a little too generic, making implementation on the native platform more complex than it needed to be. It also made the existing code harder to read.

## Changeset

- Moved event and session payload serialisation out of the cache manager and into the Delivery class
- Swapped out generic GetCachedPayload methods for more explicit GetCachedEvent and GetCachedSession methods.

## Testing

Covered by existing CI tests