### PR TITLE
Test flake: Explicitly set offset from UTC when creating date/times

### DIFF
--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -221,7 +221,7 @@ public class MobileScenarioRunner : MonoBehaviour {
                     device.Jailbroken = true;
                     device.CpuAbi = new string[] { "poo", "baar" };
                     device.Orientation = "Custom Orientation";
-                    device.Time = new DateTimeOffset(1985, 08, 21, 01, 01, 01, new TimeSpan(0));
+                    device.Time = new DateTimeOffset(1985, 08, 21, 01, 01, 01, TimeSpan.Zero);
 
                     // breadcrumbs
                     foreach (var crumb in @event.Breadcrumbs)
@@ -281,7 +281,7 @@ public class MobileScenarioRunner : MonoBehaviour {
 
                     session.Id = "Custom Id";
 
-                    var newDate = new DateTimeOffset(1985, 08, 21, 01, 01, 01, new TimeSpan(0));
+                    var newDate = new DateTimeOffset(1985, 08, 21, 01, 01, 01, TimeSpan.Zero);
                     session.StartedAt = newDate;
 
                     var device = session.Device;

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -221,7 +221,7 @@ public class MobileScenarioRunner : MonoBehaviour {
                     device.Jailbroken = true;
                     device.CpuAbi = new string[] { "poo", "baar" };
                     device.Orientation = "Custom Orientation";
-                    device.Time = new DateTime(1985, 08, 21, 01, 01, 01);
+                    device.Time = new DateTimeOffset(1985, 08, 21, 01, 01, 01, new TimeSpan(0));
 
                     // breadcrumbs
                     foreach (var crumb in @event.Breadcrumbs)
@@ -281,7 +281,7 @@ public class MobileScenarioRunner : MonoBehaviour {
 
                     session.Id = "Custom Id";
 
-                    var newDate = new DateTime(1985, 08, 21, 01, 01, 01);
+                    var newDate = new DateTimeOffset(1985, 08, 21, 01, 01, 01, new TimeSpan(0));
                     session.StartedAt = newDate;
 
                     var device = session.Device;


### PR DESCRIPTION
## Goal

Fix tests that fail when run on a device whose timezone is anything but GMT.

## Changeset

Explicitly set the time using an offset to prevent misinterpretation occurring during casting.

## Testing

Ran the before and after using an Appium capability to set the device timezone to New_York - failed before and passed afterards.