### PR TITLE
Build an nspd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bugsnag-android-unity/.cxx
 features/**/*.zip
 *.ipa
 **/maze_runner/output/
+**/maze_runner/SwitchIL2CPPCache/
 **/maze_runner/Mazerunner.log
 **/maze_output
 PackageBranch

--- a/features/fixtures/maze_runner/Assets/Scripts/Editor/Builder.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Editor/Builder.cs
@@ -19,11 +19,6 @@ public class Builder : MonoBehaviour {
         BuildPipeline.BuildPlayer(opts);
     }
 
-    public static void Switch()
-    {
-        Build("build/Switch/Mazerunner", BuildTarget.Switch);
-    }
-
     public static void MacOS()
     {
         Build("build/MacOS/Mazerunner", BuildTarget.StandaloneOSX);
@@ -62,6 +57,17 @@ public class Builder : MonoBehaviour {
 
         var opts = CommonOptions("mazerunner_xcode");
         opts.target = BuildTarget.iOS;
+
+        var result = BuildPipeline.BuildPlayer(opts);
+        Debug.Log("Result: " + result);
+    }
+
+    public static void SwitchBuild()
+    {
+        Debug.Log("Building Switch app...");
+        PlayerSettings.SetApplicationIdentifier(BuildTargetGroup.Switch, "com.bugsnag.mazerunner");
+        var opts = CommonOptions("mazerunner.nspd");
+        opts.target = BuildTarget.Switch;
 
         var result = BuildPipeline.BuildPlayer(opts);
         Debug.Log("Result: " + result);


### PR DESCRIPTION
## Goal

Changes the build mechanism for Switch so that it creates a `.nspd` folder, which can then be converted into an installable `.nsp` file using the Switch AuthoringTool.

## Changeset

Build method updated to follow the pattern that iOS/Android use.

## Testing

I have a branch now ready for review in the Switch repo, which successfully builds the nsp.  A basic CI run is sufficient here to show that it does not break bugsnag-unity.