### PR TITLE
task(delivery): check for internet connection before delivery

### DIFF
--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -109,7 +109,7 @@ namespace BugsnagUnity
             NativeClient = nativeClient;
             CacheManager = new CacheManager(Configuration);
             PayloadManager = new PayloadManager(CacheManager);
-            _delivery = new Delivery(Configuration,CacheManager,PayloadManager);
+            _delivery = new Delivery(this, Configuration,CacheManager,PayloadManager);
             MainThread = Thread.CurrentThread;
             SessionTracking = new SessionTracker(this);
             _isUnity2019OrHigher = IsUnity2019OrHigher();

--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -13,6 +13,8 @@ namespace BugsnagUnity
     class Delivery
     {
 
+        private Client _client;
+
         private Configuration _configuration;
 
         private CacheManager _cacheManager;
@@ -26,8 +28,11 @@ namespace BugsnagUnity
         private bool _cacheDeliveryInProcess;
 
 
-        internal Delivery(Configuration configuration, CacheManager cacheManager, PayloadManager payloadManager)
+
+
+        internal Delivery(Client client, Configuration configuration, CacheManager cacheManager, PayloadManager payloadManager)
         {
+            _client = client;
             _configuration = configuration;
             _cacheManager = cacheManager;
             _payloadManager = payloadManager;
@@ -86,6 +91,12 @@ namespace BugsnagUnity
         // Push to the server and handle the result
         IEnumerator PushToServer(IPayload payload, byte[] body)
         {
+            if (!_client.NativeClient.ShouldAttemptDelivery())
+            {
+                _payloadManager.SendPayloadFailed(payload);
+                _finishedCacheDeliveries.Add(payload.Id);
+                yield break;
+            }
             using (var req = new UnityWebRequest(payload.Endpoint.ToString()))
             {
                 req.SetRequestHeader("Content-Type", "application/json");

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -102,5 +102,7 @@ namespace BugsnagUnity
 
         IDictionary<string, object> GetNativeMetadata();
 
+        bool ShouldAttemptDelivery();
+
     }
 }

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -154,6 +154,11 @@ namespace BugsnagUnity
         {
             NativeInterface.ClearFeatureFlags();
         }
+
+        public bool ShouldAttemptDelivery()
+        {
+            return true;
+        }
     }
 
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -466,5 +466,10 @@ namespace BugsnagUnity
         {
             NativeCode.bugsnag_clearFeatureFlags();
         }
+
+        public bool ShouldAttemptDelivery()
+        {
+            return true;
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -163,7 +163,10 @@ namespace BugsnagUnity
         {
             return _featureFlags;
         }
-       
 
+        public bool ShouldAttemptDelivery()
+        {
+            return true;
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -203,5 +203,9 @@ namespace BugsnagUnity
         {
         }
 
+        public bool ShouldAttemptDelivery()
+        {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Goal

Some native platforms require an internet connectivity check before delivery is attempted. 

Platforms where this is not necessary will always return true.

## Changeset

- Added bool ShouldAttemptDelivery(); to INativeClient

## Testing

Covered by existing tests