### PR TITLE
Reinstate Windows build of plugin (dev purposes only)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,11 @@ steps:
       WSLENV: UNITY_VERSION
     command:
       - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
+    plugins:
+      artifacts#v1.5.0:
+        upload:
+          - from: Bugsnag.unitypackage
+            to: Bugsnag_WindowsBuilt.unitypackage
     retry:
       automatic:
         - exit_status: "*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,14 +22,13 @@ steps:
           limit: 1
 
   - label: Ensure notifier builds on Windows (for development)
-    skip: Pending PLAT-8676
     timeout_in_minutes: 30
     agents:
-      queue: opensource-windows-unity
+      queue: windows-general-wsl
     env:
       UNITY_VERSION: "2018.4.36f1"
     command:
-      - scripts/ci-build-windows-plugin.bat
+      - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
     retry:
       automatic:
         - exit_status: "*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,6 +27,7 @@ steps:
       queue: windows-general-wsl
     env:
       UNITY_VERSION: "2018.4.36f1"
+      WSLENV: UNITY_VERSION
     command:
       - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
     retry:


### PR DESCRIPTION
## Goal

Reinstate building of the plugin on Windows on CI.   

## Design

This is just for development purposes, to ensure that we don't break it for ourselves during development.  We do not ship the built package.  This step was broken when we moved to using WSL on CI, but fixed itself again after updating the build servers fro 2019 to 2022.

## Changeset

Skipping of Buildkite step removed, resulting artifact uploaded for some extra confidence that it's built properly (under a different name to avoid conflicting with the real one).

## Testing

Covered by a basic CI run.