### PR TITLE
e2e testing on Nintendo Switch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'xcodeproj'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.19.1'
+  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.0.0'
 
   # Use a specific Maze Runner branch
   #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'xcodeproj'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.0.0'
+  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.19.1'
 
   # Use a specific Maze Runner branch
   #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 268df4be2824b784f8c6f53e805070313e6c2d9b
-  tag: v7.0.0
+  revision: efb5e94f4f321cd8553ac24bf73178466efcc7b6
+  tag: v6.19.1
   specs:
-    bugsnag-maze-runner (7.0.0)
-      appium_lib (~> 12.0)
+    bugsnag-maze-runner (6.19.1)
+      appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
@@ -13,7 +13,7 @@ GIT
       os (~> 1.0.0)
       rake (~> 12.3.3)
       rubyzip (~> 2.3.2)
-      selenium-webdriver (= 4.2.1)
+      selenium-webdriver (~> 3.11)
       test-unit (~> 3.5.2)
       webrick (~> 1.7.0)
 
@@ -22,18 +22,18 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    appium_lib (12.0.1)
-      appium_lib_core (~> 5.0)
+    appium_lib (11.2.0)
+      appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
-      tomlrb (>= 1.1, < 3.0)
-    appium_lib_core (5.3.0)
+      tomlrb (~> 1.1)
+    appium_lib_core (4.7.1)
       faye-websocket (~> 0.11.0)
-      selenium-webdriver (~> 4.2, < 4.5)
+      selenium-webdriver (~> 3.14, >= 3.14.1)
     atomos (0.1.3)
     bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
-    childprocess (4.1.0)
+    childprocess (3.0.0)
     claide (1.1.0)
     colored2 (3.1.2)
     concurrent-ruby (1.1.10)
@@ -92,18 +92,15 @@ GEM
     rexml (3.2.5)
     rouge (2.0.7)
     rubyzip (2.3.2)
-    selenium-webdriver (4.2.1)
-      childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     test-unit (3.5.3)
       power_assert
-    tomlrb (2.0.3)
+    tomlrb (1.3.0)
     webrick (1.7.0)
-    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: efb5e94f4f321cd8553ac24bf73178466efcc7b6
-  tag: v6.19.1
+  revision: 268df4be2824b784f8c6f53e805070313e6c2d9b
+  tag: v7.0.0
   specs:
-    bugsnag-maze-runner (6.19.1)
-      appium_lib (~> 11.2.0)
+    bugsnag-maze-runner (7.0.0)
+      appium_lib (~> 12.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
@@ -13,7 +13,7 @@ GIT
       os (~> 1.0.0)
       rake (~> 12.3.3)
       rubyzip (~> 2.3.2)
-      selenium-webdriver (~> 3.11)
+      selenium-webdriver (= 4.2.1)
       test-unit (~> 3.5.2)
       webrick (~> 1.7.0)
 
@@ -22,18 +22,18 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    appium_lib (11.2.0)
-      appium_lib_core (~> 4.1)
+    appium_lib (12.0.1)
+      appium_lib_core (~> 5.0)
       nokogiri (~> 1.8, >= 1.8.1)
-      tomlrb (~> 1.1)
-    appium_lib_core (4.7.1)
+      tomlrb (>= 1.1, < 3.0)
+    appium_lib_core (5.3.0)
       faye-websocket (~> 0.11.0)
-      selenium-webdriver (~> 3.14, >= 3.14.1)
+      selenium-webdriver (~> 4.2, < 4.5)
     atomos (0.1.3)
     bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
-    childprocess (3.0.0)
+    childprocess (4.1.0)
     claide (1.1.0)
     colored2 (3.1.2)
     concurrent-ruby (1.1.10)
@@ -80,7 +80,9 @@ GEM
     mime-types-data (3.2022.0105)
     multi_test (0.1.2)
     nanaimo (0.3.0)
-    nokogiri (1.13.6-x86_64-darwin)
+    nokogiri (1.13.8-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
@@ -90,15 +92,18 @@ GEM
     rexml (3.2.5)
     rouge (2.0.7)
     rubyzip (2.3.2)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.2.1)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     test-unit (3.5.3)
       power_assert
-    tomlrb (1.3.0)
+    tomlrb (2.0.3)
     webrick (1.7.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -115,6 +120,7 @@ GEM
 PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bugsnag-maze-runner!
@@ -123,4 +129,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   2.3.8
+   2.3.18

--- a/features/desktop/handled_errors.feature
+++ b/features/desktop/handled_errors.feature
@@ -55,7 +55,7 @@ Feature: Handled Errors and Exceptions
     And the event "app.type" equals the platform-dependent string:
       | macos   | MacOS   |
       | windows | Windows |
-      | switch  | Switch |
+      | switch  | nintendo-switch |
     And the stack frame methods should match:
       | Main.DoNotify() |
 

--- a/features/desktop/handled_errors.feature
+++ b/features/desktop/handled_errors.feature
@@ -55,6 +55,7 @@ Feature: Handled Errors and Exceptions
     And the event "app.type" equals the platform-dependent string:
       | macos   | MacOS   |
       | windows | Windows |
+      | switch  | Switch |
     And the stack frame methods should match:
       | Main.DoNotify() |
 
@@ -139,7 +140,7 @@ Feature: Handled Errors and Exceptions
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | Main.DoLogWarning() |
+      | Main.DoLogWarning() | Main:DoLogWarning() |
 
   Scenario: Notifying when the current release stage is not in "notify release stages"
     When I run the game in the "NotifyOutsideNotifyReleaseStages" state

--- a/features/desktop/sessions.feature
+++ b/features/desktop/sessions.feature
@@ -10,6 +10,7 @@ Feature: Session Tracking
     And the session payload field "app.type" equals the platform-dependent string:
       | macos   | MacOS   |
       | windows | Windows |
+      | switch | Switch |
     And the session payload field "device.osVersion" is not null
     And the session payload field "device.osName" equals the platform-dependent string:
       | macos   | Mac OS               |
@@ -71,14 +72,18 @@ Feature: Session Tracking
     Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
     And the session payload field "app.version" is not null
     And the session payload field "app.releaseStage" equals "production"
+    # TODO On Switch this is 0.0.0.0
     And the session payload field "device.osVersion" is not null
     And the session payload field "device.osName" equals the platform-dependent string:
       | macos   | Mac OS               |
       | windows | Microsoft Windows NT |
+      # TODO Is this correct for Switch?
+      | switch | Unix |
     And the session payload field "device.model" is not null
     And the session payload field "device.manufacturer" equals the platform-dependent string:
       | macos   | Apple |
       | windows | PC    |
+      | switch | Nintendo    |
 
     And the session "id" is not null
     And the session "startedAt" is not null

--- a/features/desktop/sessions.feature
+++ b/features/desktop/sessions.feature
@@ -10,15 +10,18 @@ Feature: Session Tracking
     And the session payload field "app.type" equals the platform-dependent string:
       | macos   | MacOS   |
       | windows | Windows |
-      | switch | Switch |
+      | switch | nintendo-switch |
+    # TODO Reported as 0.0.0.0 on our SDEV
     And the session payload field "device.osVersion" is not null
     And the session payload field "device.osName" equals the platform-dependent string:
       | macos   | Mac OS               |
       | windows | Microsoft Windows NT |
+      | switch | Nintendo Switch |
     And the session payload field "device.model" is not null
     And the session payload field "device.manufacturer" equals the platform-dependent string:
       | macos   | Apple |
       | windows | PC    |
+      | switch | Nintendo |
     And the session "id" is not null
     And the session "startedAt" is not null
     And the session "user.id" is not null
@@ -72,18 +75,17 @@ Feature: Session Tracking
     Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
     And the session payload field "app.version" is not null
     And the session payload field "app.releaseStage" equals "production"
-    # TODO On Switch this is 0.0.0.0
+    # TODO On our Switch SDEV this is 0.0.0.0
     And the session payload field "device.osVersion" is not null
     And the session payload field "device.osName" equals the platform-dependent string:
       | macos   | Mac OS               |
       | windows | Microsoft Windows NT |
-      # TODO Is this correct for Switch?
-      | switch | Unix |
+      | switch | Nintendo Switch |
     And the session payload field "device.model" is not null
     And the session payload field "device.manufacturer" equals the platform-dependent string:
       | macos   | Apple |
       | windows | PC    |
-      | switch | Nintendo    |
+      | switch | Nintendo |
 
     And the session "id" is not null
     And the session "startedAt" is not null

--- a/features/fixtures/maze_runner/Assets/Scripts/Editor/Builder.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Editor/Builder.cs
@@ -66,8 +66,10 @@ public class Builder : MonoBehaviour {
     {
         Debug.Log("Building Switch app...");
         PlayerSettings.SetApplicationIdentifier(BuildTargetGroup.Switch, "com.bugsnag.mazerunner");
+
         var opts = CommonOptions("mazerunner.nspd");
         opts.target = BuildTarget.Switch;
+        opts.options = BuildOptions.Development;
 
         var result = BuildPipeline.BuildPlayer(opts);
         Debug.Log("Result: " + result);

--- a/features/fixtures/maze_runner/Assets/Scripts/Editor/Builder.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Editor/Builder.cs
@@ -66,7 +66,6 @@ public class Builder : MonoBehaviour {
     {
         Debug.Log("Building Switch app...");
         PlayerSettings.SetApplicationIdentifier(BuildTargetGroup.Switch, "com.bugsnag.mazerunner");
-
         var opts = CommonOptions("mazerunner.nspd");
         opts.target = BuildTarget.Switch;
         opts.options = BuildOptions.Development;

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -35,14 +35,6 @@ public class Main : MonoBehaviour
 
 #endif
 
-//#if UNITY_SWITCH
-//    [DllImport("__Internal")]
-//    internal static extern int bugsnag_getArgsCount();
-//
-//    [DllImport("__Internal")]
-//    internal static extern string bugsnag_getArg(int index);
-//#endif
-
     private const string API_KEY = "a35a2a72bd230ac0aa0f52715bbdc6aa";
     private Dictionary<string, string> _webGlArguments;
 
@@ -58,18 +50,6 @@ public class Main : MonoBehaviour
         _mazeHost = "http://localhost:9339";
 #elif UNITY_SWITCH
         _mazeHost = "http://UPDATE_ME:9339";
-
-
-        // TODO Rmove this before review!
-        _mazeHost = "http://192.168.33.1:9339";
-
-        //    int count = bugsnag_getArgsCount();
-        //    Debug.Log("args count: " + count);
-        //
-        //    for (int i = 0; i < count; i ++)
-        //    {
-        //	    Debug.Log("env var: " + bugsnag_getArg(i));
-        //    }
 #else
     _mazeHost = "http://bs-local.com:9339";
 #endif

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -93,9 +93,10 @@ public class Main : MonoBehaviour
 
     IEnumerator RunNextMazeCommand()
     {
-        Console.WriteLine("RunNextMazeCommand called");
+        var url = _mazeHost + "/command";
+        Console.WriteLine("RunNextMazeCommand called, requesting command from: {0}", url);
 
-        using (UnityWebRequest request = UnityWebRequest.Get(_mazeHost + "/command"))
+        using (UnityWebRequest request = UnityWebRequest.Get(url))
         {
             yield return request.SendWebRequest();
 #if UNITY_2020_1_OR_NEWER

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -35,19 +35,45 @@ public class Main : MonoBehaviour
 
 #endif
 
+//#if UNITY_SWITCH
+//    [DllImport("__Internal")]
+//    internal static extern int bugsnag_getArgsCount();
+//
+//    [DllImport("__Internal")]
+//    internal static extern string bugsnag_getArg(int index);
+//#endif
+
     private const string API_KEY = "a35a2a72bd230ac0aa0f52715bbdc6aa";
     private Dictionary<string, string> _webGlArguments;
 
     private string _fakeTrace = "Main.CUSTOM () (at Assets/Scripts/Main.cs:123)\nMain.CUSTOM () (at Assets/Scripts/Main.cs:123)";
-
-#if UNITY_STANDALONE || UNITY_WEBGL
-    private string _mazeHost = "http://localhost:9339";
-#else
-    private string _mazeHost = "http://bs-local.com:9339";
-#endif
+    private string _mazeHost;
 
     public void Start()
     {
+        Debug.Log("Maze Runner app started");
+
+        // Detemine the MAze Runner endpoint based on platform
+#if UNITY_STANDALONE || UNITY_WEBGL
+        _mazeHost = "http://localhost:9339";
+#elif UNITY_SWITCH
+        _mazeHost = "http://UPDATE_ME:9339";
+
+
+        // TODO Rmove this before review!
+        _mazeHost = "http://192.168.33.1:9339";
+
+        //    int count = bugsnag_getArgsCount();
+        //    Debug.Log("args count: " + count);
+        //
+        //    for (int i = 0; i < count; i ++)
+        //    {
+        //	    Debug.Log("env var: " + bugsnag_getArg(i));
+        //    }
+#else
+    _mazeHost = "http://bs-local.com:9339";
+#endif
+
 
 #if UNITY_ANDROID || UNITY_IOS
         return;

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -36,17 +36,20 @@ When('I clear the Bugsnag cache') do
   when 'android', 'ios'
     # TODO: Come back to this
 
-  else
+  when 'webgl'
     url = "http://localhost:#{Maze.config.document_server_port}/index.html"
     $logger.debug "Navigating to URL: #{url}"
     step("I navigate to the URL \"#{url}\"")
     execute_command('clear_cache')
+
+  else
+    raise "Platform #{platform} has not been considered"
   end
 end
 
 When('I close the Unity app') do
   case Maze::Helper.get_current_platform
-  when 'macos','webgl','windows'
+  when 'macos','webgl','windows','switch'
     execute_command('close_application')
   when 'android', 'ios'
     # TODO: Come back to this
@@ -54,7 +57,8 @@ When('I close the Unity app') do
 end
 
 When('I run the game in the {string} state') do |state|
-  case Maze::Helper.get_current_platform
+  platform = Maze::Helper.get_current_platform
+  case platform
   when 'macos'
     # Call executable directly rather than use open, which flakes on CI
     log = File.join(Dir.pwd, 'mazerunner.log')
@@ -79,6 +83,11 @@ When('I run the game in the {string} state') do |state|
     $logger.debug "Navigating to URL: #{url}"
     step("I navigate to the URL \"#{url}\"")
     execute_command('run_scenario', state)
+
+  when 'switch'
+    execute_command('run_scenario', state)
+  else
+    raise "Platform #{platform} has not been considered"
   end
 end
 

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -23,14 +23,12 @@ When('I clear the Bugsnag cache') do
     log = File.join(Dir.pwd, 'mazerunner.log')
     command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args -logfile #{log} > /dev/null"
     Maze::Runner.run_command(command, blocking: false)
-
     execute_command('clear_cache')
 
   when 'windows'
     win_log = File.join(Dir.pwd, 'mazerunner.log')
     command = "#{Maze.config.app} --args -logfile #{win_log}"
     Maze::Runner.run_command(command, blocking: false)
-
     execute_command('clear_cache')
 
   when 'android', 'ios'
@@ -44,6 +42,7 @@ When('I clear the Bugsnag cache') do
 
   when 'switch'
     execute_command('clear_cache')
+
   else
     raise "Platform #{platform} has not been considered"
   end
@@ -77,7 +76,7 @@ When('I run the game in the {string} state') do |state|
     execute_command('run_scenario', state)
 
   when 'android', 'ios'
-    # TODO Come back to this
+    # TODO: Come back to this
 
   when 'browser'
     # WebGL in a browser
@@ -88,6 +87,7 @@ When('I run the game in the {string} state') do |state|
 
   when 'switch'
     execute_command('run_scenario', state)
+
   else
     raise "Platform #{platform} has not been considered"
   end

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -42,6 +42,8 @@ When('I clear the Bugsnag cache') do
     step("I navigate to the URL \"#{url}\"")
     execute_command('clear_cache')
 
+  when 'switch'
+    execute_command('clear_cache')
   else
     raise "Platform #{platform} has not been considered"
   end


### PR DESCRIPTION
## Goal

Get e2e tests running on Nintendo Switch.

@joshedney I would be grateful if you could sanity check this PR in conjunction with the associate PR for Switch (private repo) before I put it into full reivew.

## Design

This change extends the existing use of the Maze Runner `/command` pattern to control the behaviour of the Switch during tests.

Building the test fixture and running the tests is documented in our private Switch repo.

## Changeset

Additional logic added as needed for Switch, utilising Nintendo SDK executables as needed to launch/terminate the test fixture app.

## Testing

All e2e tests now run against our Switch dev kit (with some failures to be processed).  