### PR TITLE
bugFix(editor): set don't save hide flags on generated gameObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Update bugsnag-cocoa from v6.19.0 to [v6.22.1](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6221-2022-08-10)
 
+### Bug fixes
+
+* Added DontSave HideFlags to gameObjects created by the Bugsnag SDK to negate the chances of them making scenes dirty in the editor.
+  [#604](https://github.com/bugsnag/bugsnag-unity/pull/604)
+
 ## 7.1.0 (2022-07-12)
 
 ### Enhancements

--- a/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
+++ b/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
@@ -28,7 +28,22 @@ namespace BugsnagUnity
 {
     public class MainThreadDispatchBehaviour : MonoBehaviour
     {
+
+        private static MainThreadDispatchBehaviour _instance;       
+    
         private static readonly Queue<Action> _executionQueue = new Queue<Action>();
+
+
+        public static MainThreadDispatchBehaviour Instance()
+        {
+            if (_instance == null)
+            {
+                _instance = new GameObject("Bugsnag main thread dispatcher").AddComponent<MainThreadDispatchBehaviour>();
+                DontDestroyOnLoad(_instance.gameObject);
+                _instance.gameObject.hideFlags = HideFlags.DontSave;
+            }
+            return _instance;
+        }
 
         public void Update()
         {
@@ -72,7 +87,7 @@ namespace BugsnagUnity
 
         public void EnqueueWithDelayCoroutine(Action action, float delay)
         {
-            StartCoroutine(DelayAction(action,delay));
+            StartCoroutine(DelayAction(action, delay));
         }
 
         private IEnumerator DelayAction(Action action, float delay)
@@ -81,29 +96,5 @@ namespace BugsnagUnity
             action.Invoke();
         }
 
-        private static MainThreadDispatchBehaviour _instance;
-
-        public static MainThreadDispatchBehaviour Instance()
-        {
-            if (_instance == null)
-            {
-                _instance = new GameObject("Bugsnag main thread dispatcher").AddComponent<MainThreadDispatchBehaviour>();
-            }
-            return _instance;
-        }
-
-        void Awake()
-        {
-            if (_instance == null)
-            {
-                _instance = this;
-                DontDestroyOnLoad(gameObject);
-            }
-        }
-
-        void OnDestroy()
-        {
-            _instance = null;
-        }
     }
 }

--- a/src/BugsnagUnity/TimingTrackerBehaviour.cs
+++ b/src/BugsnagUnity/TimingTrackerBehaviour.cs
@@ -14,6 +14,7 @@ namespace BugsnagUnity
         {
             // Make sure that the tracker persists accross scenes.
             DontDestroyOnLoad(gameObject);
+            gameObject.hideFlags = HideFlags.DontSave;
         }
 
 


### PR DESCRIPTION
## Goal

Users have reported gameobjects generated by us persisting in the editor when they shouldn't.

I was unable to reproduce the particular issue reported, but this fix is harmless and actually a good idea regardless as it adds extra protection should this bug be a real issue in future versions of unity.

## Changeset

- Simplified the creation of the MainThreadDispatchHandler class.
- Added DontSave flags to the MainThreadDispatchHandler and the TimingTracker gameObjects.

## Testing

Covered by existing tests.