### PR TITLE
refac(android): simplify java string creation [full ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Added DontSave HideFlags to gameObjects created by the Bugsnag SDK to negate the chances of them making scenes dirty in the editor.
   [#604](https://github.com/bugsnag/bugsnag-unity/pull/604)
 
+* Fixed compilation errors when building with IL2CPP for Android after chenges to the Unity API BlockCopy method caused complications
+  [#605](https://github.com/bugsnag/bugsnag-unity/pull/605)
+
 ## 7.1.0 (2022-07-12)
 
 ### Enhancements

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -701,7 +701,7 @@ namespace BugsnagUnity
 
                 if (obj is string)
                 {
-                    itemsAsJavaObjects[i] = BuildJavaStringDisposable(obj as string);
+                    itemsAsJavaObjects[i] = new AndroidJavaObject("java.lang.String", obj as string);
                 }
                 else
                 {
@@ -786,7 +786,7 @@ namespace BugsnagUnity
             AndroidJavaObject[] itemsAsJavaObjects = new AndroidJavaObject[items.Length];
             for (int i = 0; i < items.Length; i++)
             {
-                itemsAsJavaObjects[i] = BuildJavaStringDisposable(items[i]);
+                itemsAsJavaObjects[i] = new AndroidJavaObject("java.lang.String", items[i]);
             }
 
             AndroidJavaObject first = itemsAsJavaObjects[0];
@@ -914,49 +914,15 @@ namespace BugsnagUnity
             {
                 foreach (var entry in src)
                 {
-                    using (AndroidJavaObject key = BuildJavaStringDisposable(entry.Key))
-                    using (AndroidJavaObject value = BuildJavaStringDisposable(entry.Value == null ? "null" : entry.Value.ToString()))
+                    using (AndroidJavaObject key = new AndroidJavaObject("java.lang.String", entry.Key))
+                    using (AndroidJavaObject value = new AndroidJavaObject("java.lang.String", entry.Value == null ? "null" : entry.Value.ToString()))
                     {
                         map.Call<AndroidJavaObject>("put", key, value);
                     }
                 }
             }
             return map;
-        }
-
-        internal static AndroidJavaObject BuildJavaStringDisposable(string input)
-        {
-            if (input == null)
-            {
-                return null;
-            }
-
-            try
-            {
-                // The default encoding on Android is UTF-8
-                using (AndroidJavaClass CharsetClass = new AndroidJavaClass("java.nio.charset.Charset"))
-                using (AndroidJavaObject Charset = CharsetClass.CallStatic<AndroidJavaObject>("defaultCharset"))
-                {
-                    byte[] Bytes = Encoding.UTF8.GetBytes(input);
-
-                    if (Unity2019OrNewer)
-                    { // should succeed on Unity 2019.1 and above
-                        sbyte[] SBytes = new sbyte[Bytes.Length];
-                        Buffer.BlockCopy(Bytes, 0, SBytes, 0, Bytes.Length);
-                        return new AndroidJavaObject("java.lang.String", SBytes, Charset);
-                    }
-                    else
-                    { // use legacy API on older versions
-                        return new AndroidJavaObject("java.lang.String", Bytes, Charset);
-                    }
-                }
-            }
-            catch (EncoderFallbackException _)
-            {
-                // The input string could not be encoded as UTF-8
-                return new AndroidJavaObject("java.lang.String");
-            }
-        }
+        }       
 
         internal static bool IsUnity2019OrNewer()
         {


### PR DESCRIPTION
## Goal

A change (possibly a bug) in the Unity code base caused existing notifier code in the android NativeInterface to crash.

This prompted us to examin the code and we decided that it could be simplified to resolve the issue and hopfully future proof it.

## Changeset

- Removed the `BuildJavaStringDisposable` method and replaced calls to it with simple usage of the `new AndroidJavaObject("java.lang.String", cSharpString);` style java string constructor.

## Testing

Covered by existing CI tests and manually tested on android 6 and 12 devices with a string containing a null specifier like so "test\0test". 