### PR TITLE
fix(stacktraces): fix for missing frames in exceptions occurring in async methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bug fixes
 
+* Fixed issue where exceptions thrown in async methods were missing some stack frames
+  [#610](https://github.com/bugsnag/bugsnag-unity/pull/610)
+
 * Added `DontSave` HideFlags to gameObjects created by the Bugsnag SDK to negate the chances of them making scenes dirty in the editor
   [#604](https://github.com/bugsnag/bugsnag-unity/pull/604)
 

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -26,6 +26,23 @@ Feature: Reporting unhandled events
       | Main.RunScenario(System.String scenario) | Main.RunScenario(string scenario)               |                                         |
       | UnityEngine.SetupCoroutine.InvokeMoveNext(System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) | |
 
+  Scenario: Reporting an uncaught exception in an async method
+    When I run the game in the "AsyncException" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "AsyncException"
+    And the event "unhandled" is false
+    And the event "device.runtimeVersions.unity" is not null
+    And the event "device.runtimeVersions.unityScriptingBackend" is not null
+    And the event "device.runtimeVersions.dotnetScriptingRuntime" is not null
+    And the event "device.runtimeVersions.dotnetApiCompatibility" is not null
+    And custom metadata is included in the event
+    And the stack frame methods should match:
+      | Main+<DoAsyncTest>d__51.MoveNext() |
+      | --- End of stack trace from previous location where exception was thrown --- |
+      | System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() |
+
   Scenario: Session is present in exception called directly after start
     When I run the game in the "ExceptionWithSessionAfterStart" state
     And I wait to receive an error

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -39,9 +39,9 @@ Feature: Reporting unhandled events
     And the event "device.runtimeVersions.dotnetApiCompatibility" is not null
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | Main+<DoAsyncTest>d__51.MoveNext() | Main+<DoAsyncTest>d__49.MoveNext() |
-      | --- End of stack trace from previous location where exception was thrown --- | |
-      | System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() | |
+      | Main+<DoAsyncTest>d__51.MoveNext() | Main+<DoAsyncTest>d__49.MoveNext() | Main.DoAsyncTest() |
+      | --- End of stack trace from previous location where exception was thrown --- | | |
+      | System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() | | |
 
   Scenario: Session is present in exception called directly after start
     When I run the game in the "ExceptionWithSessionAfterStart" state

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -40,8 +40,6 @@ Feature: Reporting unhandled events
     And custom metadata is included in the event
     And the stack frame methods should match:
       | Main+<DoAsyncTest>d__51.MoveNext() | Main+<DoAsyncTest>d__49.MoveNext() | Main.DoAsyncTest() |
-      | --- End of stack trace from previous location where exception was thrown --- | | |
-      | System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() | | |
 
   Scenario: Session is present in exception called directly after start
     When I run the game in the "ExceptionWithSessionAfterStart" state

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -40,8 +40,8 @@ Feature: Reporting unhandled events
     And custom metadata is included in the event
     And the stack frame methods should match:
       | Main+<DoAsyncTest>d__51.MoveNext() | Main+<DoAsyncTest>d__49.MoveNext() |
-      | --- End of stack trace from previous location where exception was thrown --- |
-      | System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() |
+      | --- End of stack trace from previous location where exception was thrown --- | |
+      | System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() | |
 
   Scenario: Session is present in exception called directly after start
     When I run the game in the "ExceptionWithSessionAfterStart" state

--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -39,7 +39,7 @@ Feature: Reporting unhandled events
     And the event "device.runtimeVersions.dotnetApiCompatibility" is not null
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | Main+<DoAsyncTest>d__51.MoveNext() |
+      | Main+<DoAsyncTest>d__51.MoveNext() | Main+<DoAsyncTest>d__49.MoveNext() |
       | --- End of stack trace from previous location where exception was thrown --- |
       | System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() |
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -9,6 +9,7 @@ using BugsnagUnity;
 using BugsnagUnity.Payload;
 using UnityEngine.SceneManagement;
 using System.IO;
+using System.Threading.Tasks;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -490,6 +491,9 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+            case "AsyncException":
+                DoAsyncTest();
+                break;
             case "ExceptionWithSessionAfterStart":
                 throw new Exception("ExceptionWithSessionAfterStart");
             case "MaxPersistEvents":
@@ -1023,6 +1027,12 @@ public class Main : MonoBehaviour
 #if UNITY_STANDALONE_OSX
          crashy_signal_runner(8);
 #endif
+    }
+
+    private async void DoAsyncTest()
+    {
+        throw new Exception("AsyncException");
+        await Task.Yield();
     }
 
 }

--- a/src/BugsnagUnity/Payload/Error.cs
+++ b/src/BugsnagUnity/Payload/Error.cs
@@ -133,10 +133,10 @@ namespace BugsnagUnity.Payload
 
         public string Type { get => "Unity"; }
 
+
         internal static Error FromSystemException(System.Exception exception, System.Diagnostics.StackFrame[] alternativeStackTrace)
-        {
+        {            
             var errorClass = exception.GetType().Name;
-            var stackFrames = new System.Diagnostics.StackTrace(exception, true).GetFrames();
 
             // JVM exceptions in the main thread are handled by unity and require extra formatting
             if (errorClass == ANDROID_JAVA_EXCEPTION_CLASS)
@@ -150,9 +150,9 @@ namespace BugsnagUnity.Payload
             else
             {
                 StackTraceLine[] lines;
-                if (stackFrames != null && stackFrames.Length > 0)
+                if (!string.IsNullOrEmpty(exception.StackTrace))
                 {
-                    lines = new StackTrace(stackFrames).ToArray();
+                    lines = new StackTrace(exception.StackTrace).ToArray();
                 }
                 else
                 {


### PR DESCRIPTION
## Goal

The new exception handler was missing stacktrace frames from exceptions that happened in async methods. 

This method `System.Diagnostics.StackTrace(exception, true).GetFrames();` Was ignoring any frame above the line `--- End of stack trace from previous location where exception was thrown ---`.

I changed it to use our own stacktrace parser and there seems to be no difference in the formatting so it should be a good fix.

## Changeset

- Changed the new exception handler to use the same method of trace generation as is used when generating a trace from unity log events.

## Testing

Manually tested grouping and added new async CI tests.