### PR TITLE
[PLAT-8881] Add Event.FeatureFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Added `BugsnagEvent.FeatureFlags` to allow feature flags to be queried before event delivery.
+  [#613](https://github.com/bugsnag/bugsnag-unity/pull/613)
+
 ## 7.1.1 (2022-09-07)
 
 ### Bug fixes

--- a/features/android/android_callbacks.feature
+++ b/features/android/android_callbacks.feature
@@ -96,6 +96,12 @@ Feature: Callbacks
         And the event "breadcrumbs.0.type" equals "user"
         And the event "breadcrumbs.0.metaData.Custom" equals "Metadata"
 
+        # Feature flags
+        And the event "featureFlags.0.featureFlag" equals "fromStartup"
+        And the event "featureFlags.0.variant" equals "a"
+        And the event "featureFlags.1.featureFlag" equals "fromCallback"
+        And the event "featureFlags.1.variant" equals "a"
+
         # threads
         And the event "threads.0.name" equals "Custom Name"
 

--- a/features/desktop/callbacks.feature
+++ b/features/desktop/callbacks.feature
@@ -41,6 +41,12 @@ Feature: Callbacks
     And the event "breadcrumbs.0.name" equals "Custom Message"
     And the event "breadcrumbs.0.metaData.test" equals "test"
 
+	# Feature flags
+    And the event "featureFlags.0.featureFlag" equals "fromStartup"
+    And the event "featureFlags.0.variant" equals "a"
+    And the event "featureFlags.1.featureFlag" equals "fromCallback"
+    And the event "featureFlags.1.variant" equals "a"
+
     # Metadata
     And the event "metaData.test1.test" equals "test"
     And the event "metaData.test2" is null

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -475,6 +475,8 @@ public class Main : MonoBehaviour
                     @event.AddMetadata("test2", new Dictionary<string, object> { { "test", "test" } });
                     @event.ClearMetadata("test2");
 
+                    @event.AddFeatureFlag("fromCallback", @event.FeatureFlags[0].Variant);
+                    @event.ClearFeatureFlag("deleteMe");
 
                     return true;
                 });
@@ -537,6 +539,8 @@ public class Main : MonoBehaviour
                 Invoke("LaunchException",6);
                 break;
             case "EventCallbacks":
+                Bugsnag.AddFeatureFlag("fromStartup", "a");
+                Bugsnag.AddFeatureFlag("deleteMe");
                 DoNotify();
                 break;
             case "BackgroundThreadCrash":

--- a/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/MobileScenarioRunner.cs
@@ -270,6 +270,8 @@ public class MobileScenarioRunner : MonoBehaviour {
 
                     @event.AddMetadata("test", "scoop", "dewoop");
 
+                    @event.AddFeatureFlag("fromCallback", @event.FeatureFlags[0].Variant);
+                    @event.ClearFeatureFlag("deleteMe");
 
                     return true;
                 });
@@ -395,6 +397,9 @@ public class MobileScenarioRunner : MonoBehaviour {
 
                     @event.Errors[0].Stacktrace[0].Method = "Method";
 
+                    @event.AddFeatureFlag("fromCallback", @event.FeatureFlags[0].Variant);
+                    @event.ClearFeatureFlag("deleteMe");
+
                     return true;
                 });
                 break;
@@ -485,6 +490,8 @@ public class MobileScenarioRunner : MonoBehaviour {
                 Invoke("ThrowException", 6);
                 break;
             case "Ios Signal":
+                Bugsnag.AddFeatureFlag("fromStartup", "a");
+                Bugsnag.AddFeatureFlag("deleteMe");
                 MobileNative.DoIosSignal();
                 break;
             case "Check Last Run Info":
@@ -543,6 +550,8 @@ public class MobileScenarioRunner : MonoBehaviour {
             case "Java Background Crash No Threads":
             case "Java Background Crash":
                 AddMetadataForRedaction();
+                Bugsnag.AddFeatureFlag("fromStartup", "a");
+                Bugsnag.AddFeatureFlag("deleteMe");
                 MobileNative.TriggerBackgroundJavaCrash();
                 break;
             case "Native exception":

--- a/features/ios/ios_callbacks.feature
+++ b/features/ios/ios_callbacks.feature
@@ -36,4 +36,10 @@ Feature: Callbacks
         And the event "app.inForeground" is false
         And the event "app.isLaunching" is false
 
+        # Feature flags
+        And the event "featureFlags.0.featureFlag" equals "fromStartup"
+        And the event "featureFlags.0.variant" equals "a"
+        And the event "featureFlags.1.featureFlag" equals "fromCallback"
+        And the event "featureFlags.1.variant" equals "a"
+
         And the event "exceptions.0.stacktrace.0.method" equals "Method"

--- a/src/BugsnagUnity/Native/Android/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Android/NativeEvent.cs
@@ -171,5 +171,23 @@ namespace BugsnagUnity
         {
             NativePointer.Call("clearFeatureFlags");
         }
+
+        public ReadOnlyCollection<FeatureFlag> FeatureFlags
+        {
+            get
+            {
+                var objects = new List<FeatureFlag>();
+                var list = NativePointer.Call<AndroidJavaObject>("getFeatureFlags");
+                var iterator = list.Call<AndroidJavaObject>("iterator");
+                while (iterator.Call<bool>("hasNext"))
+                {
+                    var javaObject = iterator.Call<AndroidJavaObject>("next");
+                    var name = javaObject.Call<String>("getName");
+                    var variant = javaObject.Call<String>("getVariant");
+                    objects.Add(new FeatureFlag(name, variant));
+                }
+                return new ReadOnlyCollection<FeatureFlag>(objects);
+            }
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -281,7 +281,8 @@ namespace BugsnagUnity
 
         [DllImport(Import)]
         internal static extern void bugsnag_clearFeatureFlagsOnEvent(IntPtr @event);
+
+        [DllImport(Import)]
+        internal static extern string bugsnag_getFeatureFlagsFromEvent(IntPtr @event);
     }
 }
-
-

--- a/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using AOT;
@@ -201,7 +202,18 @@ namespace BugsnagUnity
         public void ClearFeatureFlags()
         {
             NativeCode.bugsnag_clearFeatureFlagsOnEvent(NativePointer);
+        }
 
+        public ReadOnlyCollection<FeatureFlag> FeatureFlags
+        {
+            get
+            {
+                var jsonString = NativeCode.bugsnag_getFeatureFlagsFromEvent(NativePointer);
+                var jsonArray = (JsonArray)SimpleJson.DeserializeObject(jsonString);
+                var objects = jsonArray.Select((item)
+                    => new FeatureFlag(((JsonObject)item).GetDictionary()));
+                return new ReadOnlyCollection<FeatureFlag>(objects.ToList());
+            }
         }
     }
 }

--- a/src/BugsnagUnity/Payload/Event.cs
+++ b/src/BugsnagUnity/Payload/Event.cs
@@ -341,5 +341,10 @@ namespace BugsnagUnity.Payload
         {
             _featureFlags.Clear();
         }
+
+        public ReadOnlyCollection<FeatureFlag> FeatureFlags
+        {
+            get => new ReadOnlyCollection<FeatureFlag>(_featureFlags);
+        }
     }
 }

--- a/src/BugsnagUnity/Payload/IEvent.cs
+++ b/src/BugsnagUnity/Payload/IEvent.cs
@@ -19,6 +19,8 @@ namespace BugsnagUnity
 
         List<IError> Errors { get; }
 
+        ReadOnlyCollection<FeatureFlag> FeatureFlags { get; }
+
         string GroupingHash { get; set; }
 
         Severity Severity { get; set; }


### PR DESCRIPTION
## Goal

Allow event feature flags to be inspected in `OnSendError` callbacks.

## Changeset

Adds `FeatureFlags` getter to IEvent and implementations.

## Testing

Amends existing E2E scenarios to verify that `FeatureFlags` getter returns the expected values.