### PR TITLE
Ensure all existing CI tests pass locally for the unity switch notifier

### DIFF
--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -774,6 +774,9 @@ public class Main : MonoBehaviour
 
     private void ClearBugsnagCache()
     {
+#if UNITY_SWITCH
+        return;
+#endif
         var path = Application.persistentDataPath + "/Bugsnag";
         if(Directory.Exists(path))
         {

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -41,6 +41,9 @@ When('I clear the Bugsnag cache') do
     execute_command('clear_cache')
 
   when 'switch'
+
+    `ControlTarget.exe launch-application #{Maze.config.app}`
+
     execute_command('clear_cache')
 
   else
@@ -86,6 +89,9 @@ When('I run the game in the {string} state') do |state|
     execute_command('run_scenario', state)
 
   when 'switch'
+
+    `ControlTarget.exe launch-application #{Maze.config.app}`
+
     execute_command('run_scenario', state)
 
   else

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -65,9 +65,8 @@ Maze.hooks.before do
     # This is to get around a strange macos bug where clearing prefs does not work 
     $logger.info 'Killing defaults service'
     Maze::Runner.run_command("killall -u #{ENV['USER']} cfprefsd")
-  elsif Maze.config.os == 'switch'
-    # Launch the app
-    `ControlTarget.exe launch-application #{Maze.config.app}`
+
+   
   end
 end
 


### PR DESCRIPTION
## Goal

Ensure all existing CI tests pass locally for the unity switch notifier 

## Changes

The switch fixture was not restarting when new commands were issued so we moved the start up command to the steps.rb file.

Clear cache was not necessary and was causing crashes so it's returned early for now and will be implemented in the native layer later if required.

