### PR TITLE
revert hide flags addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Added `BugsnagEvent.FeatureFlags` to allow feature flags to be queried before event delivery.
   [#613](https://github.com/bugsnag/bugsnag-unity/pull/613)
 
+### Bug fixes
+
+* Reverted the hide flags bug fix introduced [here](https://github.com/bugsnag/bugsnag-unity/pull/604) as it was causing null ref errors when using Bugsnag in the editor. Please see this PR for more details
+  [#617](https://github.com/bugsnag/bugsnag-unity/pull/617)
+
 ## 7.1.1 (2022-09-07)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Bug fixes
 
-* Reverted the hide flags bug fix introduced [here](https://github.com/bugsnag/bugsnag-unity/pull/604) as it was causing null ref errors when using Bugsnag in the editor. Please see this PR for more details
+* Reverted the `HideFlags` fix introduced [here](https://github.com/bugsnag/bugsnag-unity/pull/604) as it was causing (harmless) `NullReferenceException`s in the editor.
   [#617](https://github.com/bugsnag/bugsnag-unity/pull/617)
 
 ## 7.1.1 (2022-09-07)

--- a/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
+++ b/src/BugsnagUnity/MainThreadDispatchBehaviour.cs
@@ -39,8 +39,6 @@ namespace BugsnagUnity
             if (_instance == null)
             {
                 _instance = new GameObject("Bugsnag main thread dispatcher").AddComponent<MainThreadDispatchBehaviour>();
-                DontDestroyOnLoad(_instance.gameObject);
-                _instance.gameObject.hideFlags = HideFlags.DontSave;
             }
             return _instance;
         }
@@ -94,6 +92,11 @@ namespace BugsnagUnity
         {
             yield return new WaitForSeconds(delay);
             action.Invoke();
+        }
+
+        private void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
         }
 
     }

--- a/src/BugsnagUnity/TimingTrackerBehaviour.cs
+++ b/src/BugsnagUnity/TimingTrackerBehaviour.cs
@@ -9,14 +9,11 @@ namespace BugsnagUnity
     class TimingTrackerBehaviour : MonoBehaviour
     {
 
-
         private void Awake()
         {
             // Make sure that the tracker persists accross scenes.
             DontDestroyOnLoad(gameObject);
-            gameObject.hideFlags = HideFlags.DontSave;
         }
-
 
         /// <summary>
         /// OnApplicationFocus is called when the application loses or gains focus.


### PR DESCRIPTION
## Goal

A bug fix introduced [here](https://github.com/bugsnag/bugsnag-unity/pull/604) caused null reff errors when using Bugsnag in the editor. 

This is due to that fact that when dont save hide flags are set then the objects must be destroyed manually, which, due the the nature of the SDK, is not possible without some major changes.

Because the original issue of gameobjects remaining after playmode is exited was not reproducable, we will revert the fix and investigate further before making any related changes.

