### PR TITLE
[PLAT-8879] Store feature flags in OrderedDictionary

### DIFF
--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using BugsnagUnity.Payload;
 using UnityEngine;
@@ -51,7 +52,7 @@ namespace BugsnagUnity
 
         internal Metadata Metadata = new Metadata();
 
-        internal List<FeatureFlag> FeatureFlags = new List<FeatureFlag>();
+        internal OrderedDictionary FeatureFlags = new OrderedDictionary();
 
         public bool KeyIsRedacted(string key)
         {
@@ -295,15 +296,7 @@ namespace BugsnagUnity
 
         public void AddFeatureFlag(string name, string variant = null)
         {
-            foreach (var flag in FeatureFlags)
-            {
-                if (flag.Name.Equals(name))
-                {
-                    flag.Variant = variant;
-                    return;
-                }
-            }
-            FeatureFlags.Add(new FeatureFlag(name,variant));
+            FeatureFlags[name] = variant;
         }
 
         public void AddFeatureFlags(FeatureFlag[] featureFlags)
@@ -316,7 +309,7 @@ namespace BugsnagUnity
 
         public void ClearFeatureFlag(string name)
         {
-            FeatureFlags.RemoveAll(item => item.Name == name);
+            FeatureFlags.Remove(name);
         }
 
         public void ClearFeatureFlags()

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using BugsnagUnity.Payload;
@@ -356,9 +357,9 @@ namespace BugsnagUnity
             // set feature flags
             if (config.FeatureFlags != null && config.FeatureFlags.Count > 0)
             {
-                foreach (var flag in config.FeatureFlags)
+                foreach (DictionaryEntry entry in config.FeatureFlags)
                 {
-                    obj.Call("addFeatureFlag",flag.Name,flag.Variant);
+                    obj.Call("addFeatureFlag", (string)entry.Key, (string)entry.Value);
                 }
             }
 

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -84,9 +85,9 @@ namespace BugsnagUnity
             {
                 return;
             }
-            foreach (var flag in config.FeatureFlags)
+            foreach (DictionaryEntry entry in config.FeatureFlags)
             {
-                NativeCode.bugsnag_addFeatureFlagOnConfig(obj, flag.Name, flag.Variant);
+                NativeCode.bugsnag_addFeatureFlagOnConfig(obj, (string)entry.Key, (string)entry.Value);
             }
         }
 


### PR DESCRIPTION
## Goal

Improve performance of `AddFeatureFlag` APIs in apps that have large numbers of flags.

## Changeset

Switches to an [OrderedDictionary](https://docs.microsoft.com/en-us/dotnet/api/system.collections.specialized.ordereddictionary) to store feature flags as names and variants.

## Testing

Existing E2E tests verify that storage works as expected.

Manually compared performance and found that adding 1000 feature flags has gone from 40ms to < 1ms.