### PR TITLE
refac(delivery): make network health check threaded

### DIFF
--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -92,17 +92,26 @@ namespace BugsnagUnity
         // Push to the server and handle the result
         IEnumerator PushToServer(IPayload payload, byte[] body)
         {
-            var shouldDeliver = false;
-            var networkCheckDone = false;
-            new Thread(() => {
-                shouldDeliver = _client.NativeClient.ShouldAttemptDelivery();
-                networkCheckDone = true;
-            }).Start();
 
-            while (!networkCheckDone)
+            var shouldDeliver = false;
+
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
             {
-                yield return null;
+                shouldDeliver = _client.NativeClient.ShouldAttemptDelivery();
             }
+            else
+            {
+                var networkCheckDone = false;
+                new Thread(() => {
+                    shouldDeliver = _client.NativeClient.ShouldAttemptDelivery();
+                    networkCheckDone = true;
+                }).Start();
+
+                while (!networkCheckDone)
+                {
+                    yield return null;
+                }
+            }           
 
             if (!shouldDeliver)
             {


### PR DESCRIPTION
## Goal

On some platforms, a reliable network health check takes a while and blocks the main thread.

This simple change allows for the check to take as long as it needs to without blocking anything.

## Testing

Covered by existing CI tests