### PR TITLE
trak(delivery): try and flush cache on successfull payload delivery

### DIFF
--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -141,6 +141,7 @@ namespace BugsnagUnity
                 {
                     // success!
                     _payloadManager.PayloadSendSuccess(payload);
+                    StartDeliveringCachedPayloads();
                 }
                 else if (req.isNetworkError || code == 0 || code == 408 || code == 429 || code >= 500)
                 {


### PR DESCRIPTION
## Goal

Previously, the notifier would try to flush the C# event and fallback session cache on application start and when the application resumes from a backgrounded state.

Some platforms cannot reliably report changes in application focus state, so the notifier will now also try to flush the cache whenever a payload is sent successfully.

## Changeset

- flush cache on successful payload added to Delivery.cs

## Testing

Manually tested. I can't think of a way to test this on CI.