### PR TITLE
Allow running of indexed cache tests on Switch

### DIFF
--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -356,17 +356,14 @@ end
 
 def switch_run_on_target
   # Maze IP must always be provided
-  maze_ip = ENV['SWITCH_MAZE_IP']
-  if maze_ip
-    maze_ip_arg = "--mazeIp #{maze_ip}"
-  else
-    raise 'SWITCH_MAZE_IP must be set'
-  end
+  maze_ip_arg = "--mazeIp #{ENV['SWITCH_MAZE_IP']}"
 
   # Other args are optional
   cache_type_arg = $switch_cache_type ? "--cacheType #{$switch_cache_type}" : ''
   cache_index_arg = $switch_cache_index ? "--cacheIndex #{$switch_cache_index}" : ''
   cache_mount_name_arg = $switch_cache_mount_name ? "--cacheMountName #{$switch_cache_mount_name}" : ''
 
-  `RunOnTarget.exe #{Maze.config.app} --no-wait -- #{maze_ip_arg} #{cache_type_arg} #{cache_index_arg} #{cache_mount_name_arg}`
+  command = "RunOnTarget.exe #{Maze.config.app} --no-wait -- #{maze_ip_arg} #{cache_type_arg} #{cache_index_arg} " \
+              "#{cache_mount_name_arg}"
+  Maze::Runner.run_command(command)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -47,7 +47,23 @@ BeforeAll do
   elsif Maze.config.browser != nil # WebGL
     Maze.config.document_server_root = 'features/fixtures/maze_runner/build/WebGL/Mazerunner'
   elsif Maze.config.os&.downcase == 'switch'
-    # Placeholder for Switch
+    maze_ip = ENV['SWITCH_MAZE_IP']
+    raise 'SWITCH_MAZE_IP must be set' unless maze_ip
+
+    cache_type = ENV['SWITCH_CACHE_TYPE']
+    case cache_type
+    when nil, 'r'
+      $logger.info 'Running tests for regular cache'
+    when 'i'
+      $logger.info 'Running tests for indexed cache'
+      $switch_cache_type = 'i'
+      $switch_cache_index = 3
+      $switch_cache_mount_name = 'BugsnagCache'
+    else
+      raise "SWITCH_CACHE_TYPE must be 'r', or 'i', given: #{cache_type}"
+    end
+
+
   elsif Maze.config.device.nil?
     raise '--browser (WebGL), --device (for Android/iOS) or --os (for desktop or switch) option must be set'
   end


### PR DESCRIPTION
## Goal

Provide the ability to run the same e2e tests that run on regular cache test fixture, on the indexed cache test fixture.

## Changeset

Moves the existing logic for the reading of `SWITCH_MAZE_IP` to the Cucumber `BeforeAll` hook and adds a check on `SWITCH_CACHE_TYPE` (if it is set, it must be meaningful).

## Testing

Tested locally that the general mechanism works with our dev kit.