### PR TITLE
task(CI): add test for switch metadata in C# events

### DIFF
--- a/features/desktop/unhandled_errors.feature
+++ b/features/desktop/unhandled_errors.feature
@@ -48,6 +48,17 @@ Feature: Reporting unhandled events
     And the exception "message" equals "ExceptionWithSessionAfterStart"
     And the event "session" is not null
 
+  @switch_only
+  Scenario: Switch Metadata
+    When I run the game in the "UncaughtException" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "ExecutionEngineException"
+    And the event "app.type" equals "nintendo-switch"
+    And the event "device.osName" equals "Nintendo Switch"
+    And the event "device.model" equals "Switch"
+    And the event "device.manufacturer" equals "Nintendo"
+
   @windows_only
   Scenario: Windows device and app data
     When I run the game in the "UncaughtException" state

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -29,9 +29,15 @@ Before('@windows_only') do |_scenario|
   skip_this_scenario('Skipping scenario') unless Maze.config.os == 'windows'
 end
 
+Before('@switch_only') do |_scenario|
+  skip_this_scenario('Skipping scenario') unless Maze.config.os == 'switch'
+end
+
 Before('@skip_windows') do |_scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os == 'windows'
 end
+
+
 
 BeforeAll do
   $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'


### PR DESCRIPTION
## Goal

add test for switch metadata in C# events

## Changeset

- Added new switch only test in desktop/unhandled_errors.feature
- Added support for @switch_only 
