### PR TITLE
task(CI): add test for switch max cache size

### DIFF
--- a/features/desktop/switch.feature
+++ b/features/desktop/switch.feature
@@ -12,3 +12,13 @@ Feature: Switch Specific Tests
     And the exception "message" equals "SwitchCacheNone"
     And I discard the oldest error
     Then I should receive no requests
+
+  @switch_only
+  Scenario: Max Cache Size
+    When I run the game in the "MaxSwitchCacheSize" state
+    And I wait for 10 seconds
+    And I close the Unity app
+    And I run the game in the "(noop)" state
+    And I wait to receive 1 errors
+    And the exception "message" equals "LARGE PAYLOAD 2"
+   

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -265,11 +265,16 @@ public class Main : MonoBehaviour
         Bugsnag.ClearMetadata("init");
         Bugsnag.ClearMetadata("test", "test2");
     }
-
+   
     void PrepareConfigForScenario(Configuration config, string scenario)
     {
         switch (scenario)
         {
+            case "MaxSwitchCacheSize":
+            config.SwitchCacheMaxSize = 2097155;
+            config.Endpoints = new EndpointConfiguration("https://notify.def-not-bugsnag.com", "https://notify.def-not-bugsnag.com");
+            config.AutoTrackSessions = false;
+            break;
             case "SwitchCacheNone":
                 config.SwitchCacheType = SwitchCacheType.None;
                 break;
@@ -568,6 +573,9 @@ public class Main : MonoBehaviour
     {
         switch (scenario)
         {
+        case "MaxSwitchCacheSize":
+                StartCoroutine(DoMaxSwitchCacheTest());
+                break;
             case "SwitchCacheNone":
                 throw new Exception("SwitchCacheNone");
             case "AsyncException":
@@ -827,7 +835,24 @@ public class Main : MonoBehaviour
         }
     }
 
+    private IEnumerator DoMaxSwitchCacheTest()
+    {
+        CacheLargePayload(1);
+        yield return new WaitForSeconds(1);
+        CacheLargePayload(2);
+    }
 
+    private void CacheLargePayload(int index)
+    {
+        Bugsnag.Notify(new System.Exception("LARGE PAYLOAD " + index), report =>
+        {
+            for (int i = 0; i < 100000; i++)
+            {
+                report.AddMetadata("test", "test" + i, "test");
+            }
+            return true;
+        });
+    }
     private void DoInnerException()
     {
         throw new Exception("Outer",new Exception("Inner"));


### PR DESCRIPTION
## Goal

add test for switch max cache size

## Design

1: The cache size is set to roughly 2 MiB and the endpoints to invalid values.

2: 2 events, both over 1 MiB in size are cached.

3: The first one should be discarded to make space for the second.

4: The app is then launched and it should only send the second event.
