### PR TITLE
Fix WebGL builds

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -12,6 +12,8 @@ steps:
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2018.4.36f1"
+      # Python2 needed for WebGL to build
+      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -34,6 +36,8 @@ steps:
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2019.4.35f1"
+      # Python2 needed for WebGL to build
+      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -131,7 +135,6 @@ steps:
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
   #
   - label: Run WebGL e2e tests for Unity 2018
-    skip: Pending PLAT-8984
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2018-fixtures'
     agents:
@@ -149,7 +152,6 @@ steps:
       - scripts/ci-run-webgl-tests.sh
 
   - label: Run WebGL e2e tests for Unity 2019
-    skip: Pending PLAT-8984
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2019-fixtures'
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,6 +51,7 @@ steps:
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2020.3.32f1"
+      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -92,7 +93,6 @@ steps:
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
   #
   - label: Run WebGL e2e tests for Unity 2020
-    skip: Pending PLAT-8984
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2020-fixtures'
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,6 +51,7 @@ steps:
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2020.3.32f1"
+      # Python2 needed for WebGL to build
       EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
     plugins:
       artifacts#v1.5.0:


### PR DESCRIPTION
## Goal

Fix the WebGL builds by ensuring that Python2 is present (for Unity <= 2020).

## Design

Python2 has now been reinstated on our build servers (it was removed when they were upgraded from macOS 13.0 to 13.6).

## Testing

Covered by a few CI run.