### PR TITLE
added event smoke tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -304,47 +304,47 @@ steps:
 
   #
   # Build Windows test fixture
-  #
-  # - label: Build Unity 2020 Windows test fixture
-  #   timeout_in_minutes: 30
-  #   key: 'windows-2020-fixture'
-  #   depends_on: 'build-artifacts'
-  #   agents:
-  #     queue: windows-unity-wsl
-  #   env:
-  #     UNITY_VERSION: "2020.3.32f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - Bugsnag.unitypackage
-  #       upload:
-  #         - unity.log
-  #         - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
-  #   commands:
-  #     - scripts/ci-build-windows-fixture-wsl.sh
-  #   retry:
-  #     automatic:
-  #       - exit_status: "*"
-  #         limit: 1
+  
+  - label: Build Unity 2020 Windows test fixture
+    timeout_in_minutes: 30
+    key: 'windows-2020-fixture'
+    depends_on: 'build-artifacts'
+    agents:
+      queue: windows-unity-wsl
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - unity.log
+          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
+    commands:
+      - scripts/ci-build-windows-fixture-wsl.sh
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
   #
   # Run Windows e2e tests
-  #
-  # - label: Run Windows e2e tests for Unity 2020
-  #   timeout_in_minutes: 30
-  #   depends_on: 'windows-2020-fixture'
-  #   agents:
-  #     queue: windows-general-wsl
-  #   env:
-  #     UNITY_VERSION: "2020.3.32f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
-  #       upload:
-  #         - maze_output/**/*
-  #   command:
-  #     - scripts/ci-run-windows-tests-wsl.sh
+  
+  - label: Run Windows e2e tests for Unity 2020
+    timeout_in_minutes: 30
+    depends_on: 'windows-2020-fixture'
+    agents:
+      queue: windows-general-wsl
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
+        upload:
+          - maze_output/**/*
+    command:
+      - scripts/ci-run-windows-tests-wsl.sh
 
   #
   # Conditionally trigger full pipeline

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -112,23 +112,23 @@ steps:
   # Run WebGL tests
   #
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
-  #
-  # - label: Run WebGL e2e tests for Unity 2020
-  #   timeout_in_minutes: 30
-  #   depends_on: 'cocoa-webgl-2020-fixtures'
-  #   agents:
-  #     queue: opensource-mac-cocoa-11
-  #   env:
-  #     UNITY_VERSION: "2020.3.32f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
-  #       upload:
-  #         - maze_output/**/*
-  #   # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-  #   commands:
-  #     - scripts/ci-run-webgl-tests.sh
+  
+  - label: Run WebGL e2e tests for Unity 2020
+    timeout_in_minutes: 30
+    depends_on: 'cocoa-webgl-2020-fixtures'
+    agents:
+      queue: opensource-mac-cocoa-11
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
+        upload:
+          - maze_output/**/*
+    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+    commands:
+      - scripts/ci-run-webgl-tests.sh
 
   #
   # Build Android test fixtures

--- a/features/csharp/csharp_breadcrumbs.feature
+++ b/features/csharp/csharp_breadcrumbs.feature
@@ -32,11 +32,12 @@ Feature: Fallback Breadcrumbs
   Scenario: Manual and Automatic Breadcrumbs
     When I run the game in the "ManualAndAutoBreadcrumbs" state
     And I wait to receive 3 errors
+    And I sort the errors by the payload field "events.0.exceptions.0.message"
     And I discard the oldest error
     And I discard the oldest error
 
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "SecondError"
+    And the exception "message" equals "Error3"
 
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.0.type" equals "state"
@@ -56,11 +57,11 @@ Feature: Fallback Breadcrumbs
 
     And the event "breadcrumbs.5.name" equals "Exception"
     And the event "breadcrumbs.5.type" equals "error"
-    And the event "breadcrumbs.5.metaData.message" equals "Debug.LogException"
+    And the event "breadcrumbs.5.metaData.message" equals "Error1"
 
     And the event "breadcrumbs.6.name" equals "Exception"
     And the event "breadcrumbs.6.type" equals "error"
-    And the event "breadcrumbs.6.metaData.message" equals "FirstError"
+    And the event "breadcrumbs.6.metaData.message" equals "Error2"
 
     And the event "breadcrumbs.7.name" equals "Metadata"
     And the event "breadcrumbs.7.type" equals "manual"

--- a/features/csharp/csharp_breadcrumbs.feature
+++ b/features/csharp/csharp_breadcrumbs.feature
@@ -10,10 +10,11 @@ Feature: Fallback Breadcrumbs
   Scenario: Enable Specific Breadcrumbs
     When I run the game in the "EnableBreadcrumbs" state
     And I wait to receive 2 errors
+    And I sort the errors by the payload field "events.0.exceptions.0.message"
     And I discard the oldest error
 
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "EnableBreadcrumbs"
+    And the exception "message" equals "Error2"
     And the event "breadcrumbs.0.name" equals "Debug.Log"
 
 

--- a/features/csharp/csharp_breadcrumbs.feature
+++ b/features/csharp/csharp_breadcrumbs.feature
@@ -1,14 +1,14 @@
 Feature: Fallback Breadcrumbs
 
   Scenario: Disabling Breadcrumbs
-    When I run the game in the "NEWDisableBreadcrumbs" state
+    When I run the game in the "DisableBreadcrumbs" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "DisableBreadcrumbs"
     And the event "breadcrumbs.0" is null
 
   Scenario: Enable Specific Breadcrumbs
-    When I run the game in the "NEWEnableBreadcrumbs" state
+    When I run the game in the "EnableBreadcrumbs" state
     And I wait to receive 2 errors
     And I discard the oldest error
 
@@ -18,7 +18,7 @@ Feature: Fallback Breadcrumbs
 
 
   Scenario: Setting max breadcrumbs
-    When I run the game in the "NEWMaxBreadcrumbs" state
+    When I run the game in the "MaxBreadcrumbs" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "MaxBreadcrumbs"
@@ -30,7 +30,7 @@ Feature: Fallback Breadcrumbs
     And the event "breadcrumbs.4.name" equals "Crumb 9"
 
   Scenario: Manual and Automatic Breadcrumbs
-    When I run the game in the "NEWManualAndAutoBreadcrumbs" state
+    When I run the game in the "ManualAndAutoBreadcrumbs" state
     And I wait to receive 3 errors
     And I discard the oldest error
     And I discard the oldest error

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -45,7 +45,7 @@ Scenario: Debug Log Exception smoke test
     And custom metadata is included in the event
     
     And the stack frame methods should match:
-      | DebugLogExceptionSmokeTest:Run()| DebugLogExceptionSmokeTest:Run() |
+      | DebugLogExceptionSmokeTest:Run()| DebugLogExceptionSmokeTest.Run() |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
 
     And expected device metadata is included in the event

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -45,8 +45,8 @@ Scenario: Debug Log Exception smoke test
     And custom metadata is included in the event
     
     And the stack frame methods should match:
-      | DebugLogExceptionSmokeTest:Run()| 
-      | ScenarioRunner:RunScenario(String, String, String) | 
+      | DebugLogExceptionSmokeTest:Run()| DebugLogExceptionSmokeTest:Run() |
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
 
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -62,8 +62,8 @@ Scenario: Debug Log Error smoke test
     And custom metadata is included in the event
     
     And the stack frame methods should match:
-      | DebugLogErrorSmokeTest:Run() | 
-      | ScenarioRunner:RunScenario(String, String, String) | 
+      | DebugLogErrorSmokeTest:Run() | DebugLogErrorSmokeTest.Run() |
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
 
 
     And expected device metadata is included in the event
@@ -80,8 +80,8 @@ Scenario: Debug Log Warning smoke test
     And custom metadata is included in the event
     
     And the stack frame methods should match:
-      | DebugLogWarningSmokeTest:Run() | 
-      | ScenarioRunner:RunScenario(String, String, String) | 
+      | DebugLogWarningSmokeTest:Run() | DebugLogWarningSmokeTest.Run() |
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
 
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -97,8 +97,8 @@ Scenario: Debug Log smoke test
     And custom metadata is included in the event
     
     And the stack frame methods should match:
-      | DebugLogSmokeTest:Run() | 
-      | ScenarioRunner:RunScenario(String, String, String) | 
+      | DebugLogSmokeTest:Run() | DebugLogSmokeTest.Run() |
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
 
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -114,8 +114,17 @@ Scenario: Debug Log Assert smoke test
     And custom metadata is included in the event
     
     And the stack frame methods should match:
-      | DebugLogAssertSmokeTest:Run() | 
-      | ScenarioRunner:RunScenario(String, String, String) | 
+      | DebugLogAssertSmokeTest:Run() | DebugLogAssertSmokeTest.Run() |
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
 
     And expected device metadata is included in the event
     And expected app metadata is included in the event
+
+# @skip_unity_2018
+# Scenario: Reporting an inner exception
+#     When I run the game in the "InnerException" state
+#     And I wait to receive an error
+#     Then the error is valid for the error reporting API sent by the Unity notifier
+#     And the event "exceptions.0.message" equals "Outer"
+#     And the event "exceptions.1.message" equals "Inner"
+#     And the event "exceptions.2" is null

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -62,8 +62,8 @@ Scenario: Debug Log Error smoke test
     And custom metadata is included in the event
     
     And the stack frame methods should match:
-      | DebugLogErrorSmokeTest:Run() | DebugLogErrorSmokeTest.Run() |
-      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
+      | DebugLogErrorSmokeTest:Run() | DebugLogErrorSmokeTest.Run() ||
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
 
 
     And expected device metadata is included in the event
@@ -81,8 +81,7 @@ Scenario: Debug Log Warning smoke test
     
     And the stack frame methods should match:
       | DebugLogWarningSmokeTest:Run() | DebugLogWarningSmokeTest.Run() |
-      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
-
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
@@ -98,8 +97,7 @@ Scenario: Debug Log smoke test
     
     And the stack frame methods should match:
       | DebugLogSmokeTest:Run() | DebugLogSmokeTest.Run() |
-      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
-
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
@@ -115,8 +113,7 @@ Scenario: Debug Log Assert smoke test
     
     And the stack frame methods should match:
       | DebugLogAssertSmokeTest:Run() | DebugLogAssertSmokeTest.Run() |
-      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
-
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -120,10 +120,46 @@ Feature: csharp events
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "BackgroundThreadException"
 
+  @skip_webgl
+  Scenario: Notify from background thread
+    When I run the game in the "NotifyFromBackgroundThread" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "NotifyFromBackgroundThread"
+
   Scenario: Session present after start
     When I run the game in the "SessionAfterStart" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "SessionAfterStart"
     And the event "session" is not null
+
+  Scenario: Notify with custom stacktrace
+    When I run the game in the "NotifyWithCustomStacktrace" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "NotifyWithCustomStacktrace"
+        And the stack frame methods should match:
+      | Main.CUSTOM1() |
+      | Main.CUSTOM2() |
+
+  Scenario: Notify with strings
+    When I run the game in the "NotifyWithStrings" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "name"
+    And the exception "message" equals "NotifyWithStrings"
+        And the stack frame methods should match:
+      | Main.CUSTOM1() |
+      | Main.CUSTOM2() |
+
+  Scenario: Reporting a handled exception with a custom severity
+    When I run the game in the "CustomSeverity" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "CustomSeverity"
+    And the event "severity" equals "info"
+    And the event "severityReason.type" equals "userSpecifiedSeverity"
+    And the event "unhandled" is false
+
 

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -124,4 +124,10 @@ Scenario: Reporting an inner exception
   Then the error is valid for the error reporting API sent by the Unity notifier
   And the event "exceptions.0.message" equals "Outer"
   And the event "exceptions.1.message" equals "Inner"
-  And the event "exceptions.2" is null
+  And the event "exceptions.2" is 
+
+Scenario: Reporting an uncaught exception in an async method
+  When I run the game in the "AsyncException" state
+  And I wait to receive an error
+  Then the error is valid for the error reporting API sent by the Unity notifier
+  And the exception "message" equals "AsyncException"

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -7,127 +7,123 @@ Feature: csharp events
     And the exception "errorClass" equals "Exception"
     And the exception "message" equals "NotifySmokeTest"
     And the event "unhandled" is false
-    
     And custom metadata is included in the event
-    
     And the stack frame methods should match:
       | NotifySmokeTest.Run() | 
       | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | 
-
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
-Scenario: Uncaught Exception smoke test
-  When I run the game in the "UncaughtExceptionSmokeTest" state
-  And I wait to receive an error
-  Then the error is valid for the error reporting API sent by the Unity notifier
-  And the exception "errorClass" equals "Exception"
-  And the exception "message" equals "UncaughtExceptionSmokeTest"
-  And the event "unhandled" is false
-  
-  And custom metadata is included in the event
-  
-  And the stack frame methods should match:
-    | UncaughtExceptionSmokeTest.Run() | 
-    | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | 
+  Scenario: Uncaught Exception smoke test
+    When I run the game in the "UncaughtExceptionSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "UncaughtExceptionSmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+    And the stack frame methods should match:
+      | UncaughtExceptionSmokeTest.Run() | 
+      | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | 
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
 
-  And expected device metadata is included in the event
-  And expected app metadata is included in the event
+  Scenario: Debug Log Exception smoke test
+    When I run the game in the "DebugLogExceptionSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "DebugLogExceptionSmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+    And the stack frame methods should match:
+      | DebugLogExceptionSmokeTest:Run()| DebugLogExceptionSmokeTest.Run() |
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
 
-Scenario: Debug Log Exception smoke test
-  When I run the game in the "DebugLogExceptionSmokeTest" state
-  And I wait to receive an error
-  Then the error is valid for the error reporting API sent by the Unity notifier
-  And the exception "errorClass" equals "Exception"
-  And the exception "message" equals "DebugLogExceptionSmokeTest"
-  And the event "unhandled" is false
-  
-  And custom metadata is included in the event
-  
-  And the stack frame methods should match:
-    | DebugLogExceptionSmokeTest:Run()| DebugLogExceptionSmokeTest.Run() |
-    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
+  Scenario: Debug Log Error smoke test
+    When I run the game in the "DebugLogErrorSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "UnityLogError"
+    And the exception "message" equals "DebugLogErrorSmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+    And the stack frame methods should match:
+      | DebugLogErrorSmokeTest:Run() | DebugLogErrorSmokeTest.Run() ||
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
 
-  And expected device metadata is included in the event
-  And expected app metadata is included in the event
+  Scenario: Debug Log Warning smoke test
+    When I run the game in the "DebugLogWarningSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "UnityLogWarning"
+    And the exception "message" equals "DebugLogWarningSmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+    And the stack frame methods should match:
+      | DebugLogWarningSmokeTest:Run() | DebugLogWarningSmokeTest.Run() ||
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
 
-Scenario: Debug Log Error smoke test
-  When I run the game in the "DebugLogErrorSmokeTest" state
-  And I wait to receive an error
-  Then the error is valid for the error reporting API sent by the Unity notifier
-  And the exception "errorClass" equals "UnityLogError"
-  And the exception "message" equals "DebugLogErrorSmokeTest"
-  And the event "unhandled" is false
-  
-  And custom metadata is included in the event
-  
-  And the stack frame methods should match:
-    | DebugLogErrorSmokeTest:Run() | DebugLogErrorSmokeTest.Run() ||
-    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
+  Scenario: Debug Log smoke test
+    When I run the game in the "DebugLogSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "UnityLogLog"
+    And the exception "message" equals "DebugLogSmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+    And the stack frame methods should match:
+      | DebugLogSmokeTest:Run() | DebugLogSmokeTest.Run() ||
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
 
+  Scenario: Debug Log Assert smoke test
+    When I run the game in the "DebugLogAssertSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "UnityLogAssert"
+    And the exception "message" equals "DebugLogAssertSmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+    And the stack frame methods should match:
+      | DebugLogAssertSmokeTest:Run() | DebugLogAssertSmokeTest.Run() ||
+      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
 
-  And expected device metadata is included in the event
-  And expected app metadata is included in the event
+  @skip_unity_2018
+  Scenario: Reporting an inner exception
+    When I run the game in the "InnerException" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the event "exceptions.0.message" equals "Outer"
+    And the event "exceptions.1.message" equals "Inner"
+    And the event "exceptions.2" is 
 
-Scenario: Debug Log Warning smoke test
-  When I run the game in the "DebugLogWarningSmokeTest" state
-  And I wait to receive an error
-  Then the error is valid for the error reporting API sent by the Unity notifier
-  And the exception "errorClass" equals "UnityLogWarning"
-  And the exception "message" equals "DebugLogWarningSmokeTest"
-  And the event "unhandled" is false
-  
-  And custom metadata is included in the event
-  
-  And the stack frame methods should match:
-    | DebugLogWarningSmokeTest:Run() | DebugLogWarningSmokeTest.Run() ||
-    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
-  And expected device metadata is included in the event
-  And expected app metadata is included in the event
+  Scenario: Reporting an uncaught exception in an async method
+    When I run the game in the "AsyncException" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "AsyncException"
 
-Scenario: Debug Log smoke test
-  When I run the game in the "DebugLogSmokeTest" state
-  And I wait to receive an error
-  Then the error is valid for the error reporting API sent by the Unity notifier
-  And the exception "errorClass" equals "UnityLogLog"
-  And the exception "message" equals "DebugLogSmokeTest"
-  And the event "unhandled" is false
-  
-  And custom metadata is included in the event
-  
-  And the stack frame methods should match:
-    | DebugLogSmokeTest:Run() | DebugLogSmokeTest.Run() ||
-    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
-  And expected device metadata is included in the event
-  And expected app metadata is included in the event
+  @skip_webgl
+  Scenario: Report exception from background thread
+    When I run the game in the "BackgroundThreadException" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "BackgroundThreadException"
 
-Scenario: Debug Log Assert smoke test
-  When I run the game in the "DebugLogAssertSmokeTest" state
-  And I wait to receive an error
-  Then the error is valid for the error reporting API sent by the Unity notifier
-  And the exception "errorClass" equals "UnityLogAssert"
-  And the exception "message" equals "DebugLogAssertSmokeTest"
-  And the event "unhandled" is false
-  
-  And custom metadata is included in the event
-  
-  And the stack frame methods should match:
-    | DebugLogAssertSmokeTest:Run() | DebugLogAssertSmokeTest.Run() ||
-    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
-  And expected device metadata is included in the event
-  And expected app metadata is included in the event
+  Scenario: Session present after start
+    When I run the game in the "SessionAfterStart" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "SessionAfterStart"
+    And the event "session" is not null
 
-@skip_unity_2018
-Scenario: Reporting an inner exception
-  When I run the game in the "InnerException" state
-  And I wait to receive an error
-  Then the error is valid for the error reporting API sent by the Unity notifier
-  And the event "exceptions.0.message" equals "Outer"
-  And the event "exceptions.1.message" equals "Inner"
-  And the event "exceptions.2" is 
-
-Scenario: Reporting an uncaught exception in an async method
-  When I run the game in the "AsyncException" state
-  And I wait to receive an error
-  Then the error is valid for the error reporting API sent by the Unity notifier
-  And the exception "message" equals "AsyncException"

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -1,50 +1,121 @@
 Feature: csharp events
 
   Scenario: Notify smoke test
-    When I run the game in the "NEWNotifySmokeTest" state
+    When I run the game in the "NotifySmokeTest" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "errorClass" equals "Exception"
     And the exception "message" equals "NotifySmokeTest"
     And the event "unhandled" is false
+    
     And custom metadata is included in the event
+    
     And the stack frame methods should match:
       | NotifySmokeTest.Run() | 
       | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | 
 
-    # Device metadata
-    And the event "device.freeDisk" is not null
-    And the event "device.freeMemory" is not null
-    And the event "device.id" is not null
-    And the event "device.locale" is not null
-    And the event "device.manufacturer" is not null
-    And the event "device.model" is not null
-    And the event "device.osName" is not null
-    And the event "device.osVersion" is not null
-    And the event "device.runtimeVersions" is not null
-    And the event "device.time" is a timestamp
-    And the event "device.totalMemory" is not null
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
 
-    # Auto metadata
-    And the event "metaData.device.screenDensity" is not null
-    And the event "metaData.device.screenResolution" is not null
-    And the event "metaData.device.osLanguage" equals "English"
-    And the event "metaData.device.graphicsDeviceVersion" is not null
-    And the event "metaData.device.graphicsMemorySize" is not null
-    And the event "metaData.device.processorType" is not null
+  Scenario: Uncaught Exception smoke test
+    When I run the game in the "UncaughtExceptionSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "UncaughtExceptionSmokeTest"
+    And the event "unhandled" is false
+    
+    And custom metadata is included in the event
+    
+    And the stack frame methods should match:
+      | UncaughtExceptionSmokeTest.Run() | 
+      | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | 
 
-    # App metadata
-    And the event "app.duration" is greater than 0
-    And the event "app.durationInForeground" is not null
-    And the event "app.inForeground" is not null
-    And the event "app.isLaunching" is not null
-    And the event "app.releaseStage" is not null
-    And the event "app.type" is not null
-    And the event "app.version" is not null
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
 
-    # Auto app data
-    And the event "metaData.app.companyName" equals "bugsnag"
-    And the event "metaData.app.name" equals "Mazerunner"
-    And the event "metaData.app.buildno" is not null
+Scenario: Debug Log Exception smoke test
+    When I run the game in the "DebugLogExceptionSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "DebugLogExceptionSmokeTest"
+    And the event "unhandled" is false
+    
+    And custom metadata is included in the event
+    
+    And the stack frame methods should match:
+      | DebugLogExceptionSmokeTest:Run()| 
+      | ScenarioRunner:RunScenario(String, String, String) | 
+
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+
+Scenario: Debug Log Error smoke test
+    When I run the game in the "DebugLogErrorSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "UnityLogError"
+    And the exception "message" equals "DebugLogErrorSmokeTest"
+    And the event "unhandled" is false
+    
+    And custom metadata is included in the event
+    
+    And the stack frame methods should match:
+      | DebugLogErrorSmokeTest:Run() | 
+      | ScenarioRunner:RunScenario(String, String, String) | 
 
 
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+
+Scenario: Debug Log Warning smoke test
+    When I run the game in the "DebugLogWarningSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "UnityLogWarning"
+    And the exception "message" equals "DebugLogWarningSmokeTest"
+    And the event "unhandled" is false
+    
+    And custom metadata is included in the event
+    
+    And the stack frame methods should match:
+      | DebugLogWarningSmokeTest:Run() | 
+      | ScenarioRunner:RunScenario(String, String, String) | 
+
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+
+Scenario: Debug Log smoke test
+    When I run the game in the "DebugLogSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "UnityLogLog"
+    And the exception "message" equals "DebugLogSmokeTest"
+    And the event "unhandled" is false
+    
+    And custom metadata is included in the event
+    
+    And the stack frame methods should match:
+      | DebugLogSmokeTest:Run() | 
+      | ScenarioRunner:RunScenario(String, String, String) | 
+
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+
+Scenario: Debug Log Assert smoke test
+    When I run the game in the "DebugLogAssertSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "UnityLogAssert"
+    And the exception "message" equals "DebugLogAssertSmokeTest"
+    And the event "unhandled" is false
+    
+    And custom metadata is included in the event
+    
+    And the stack frame methods should match:
+      | DebugLogAssertSmokeTest:Run() | 
+      | ScenarioRunner:RunScenario(String, String, String) | 
+
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -17,111 +17,111 @@ Feature: csharp events
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
-  Scenario: Uncaught Exception smoke test
-    When I run the game in the "UncaughtExceptionSmokeTest" state
-    And I wait to receive an error
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "errorClass" equals "Exception"
-    And the exception "message" equals "UncaughtExceptionSmokeTest"
-    And the event "unhandled" is false
-    
-    And custom metadata is included in the event
-    
-    And the stack frame methods should match:
-      | UncaughtExceptionSmokeTest.Run() | 
-      | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | 
+Scenario: Uncaught Exception smoke test
+  When I run the game in the "UncaughtExceptionSmokeTest" state
+  And I wait to receive an error
+  Then the error is valid for the error reporting API sent by the Unity notifier
+  And the exception "errorClass" equals "Exception"
+  And the exception "message" equals "UncaughtExceptionSmokeTest"
+  And the event "unhandled" is false
+  
+  And custom metadata is included in the event
+  
+  And the stack frame methods should match:
+    | UncaughtExceptionSmokeTest.Run() | 
+    | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | 
 
-    And expected device metadata is included in the event
-    And expected app metadata is included in the event
+  And expected device metadata is included in the event
+  And expected app metadata is included in the event
 
 Scenario: Debug Log Exception smoke test
-    When I run the game in the "DebugLogExceptionSmokeTest" state
-    And I wait to receive an error
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "errorClass" equals "Exception"
-    And the exception "message" equals "DebugLogExceptionSmokeTest"
-    And the event "unhandled" is false
-    
-    And custom metadata is included in the event
-    
-    And the stack frame methods should match:
-      | DebugLogExceptionSmokeTest:Run()| DebugLogExceptionSmokeTest.Run() |
-      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
+  When I run the game in the "DebugLogExceptionSmokeTest" state
+  And I wait to receive an error
+  Then the error is valid for the error reporting API sent by the Unity notifier
+  And the exception "errorClass" equals "Exception"
+  And the exception "message" equals "DebugLogExceptionSmokeTest"
+  And the event "unhandled" is false
+  
+  And custom metadata is included in the event
+  
+  And the stack frame methods should match:
+    | DebugLogExceptionSmokeTest:Run()| DebugLogExceptionSmokeTest.Run() |
+    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
 
-    And expected device metadata is included in the event
-    And expected app metadata is included in the event
+  And expected device metadata is included in the event
+  And expected app metadata is included in the event
 
 Scenario: Debug Log Error smoke test
-    When I run the game in the "DebugLogErrorSmokeTest" state
-    And I wait to receive an error
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "errorClass" equals "UnityLogError"
-    And the exception "message" equals "DebugLogErrorSmokeTest"
-    And the event "unhandled" is false
-    
-    And custom metadata is included in the event
-    
-    And the stack frame methods should match:
-      | DebugLogErrorSmokeTest:Run() | DebugLogErrorSmokeTest.Run() ||
-      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
+  When I run the game in the "DebugLogErrorSmokeTest" state
+  And I wait to receive an error
+  Then the error is valid for the error reporting API sent by the Unity notifier
+  And the exception "errorClass" equals "UnityLogError"
+  And the exception "message" equals "DebugLogErrorSmokeTest"
+  And the event "unhandled" is false
+  
+  And custom metadata is included in the event
+  
+  And the stack frame methods should match:
+    | DebugLogErrorSmokeTest:Run() | DebugLogErrorSmokeTest.Run() ||
+    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
 
 
-    And expected device metadata is included in the event
-    And expected app metadata is included in the event
+  And expected device metadata is included in the event
+  And expected app metadata is included in the event
 
 Scenario: Debug Log Warning smoke test
-    When I run the game in the "DebugLogWarningSmokeTest" state
-    And I wait to receive an error
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "errorClass" equals "UnityLogWarning"
-    And the exception "message" equals "DebugLogWarningSmokeTest"
-    And the event "unhandled" is false
-    
-    And custom metadata is included in the event
-    
-    And the stack frame methods should match:
-      | DebugLogWarningSmokeTest:Run() | DebugLogWarningSmokeTest.Run() |
-      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
-    And expected device metadata is included in the event
-    And expected app metadata is included in the event
+  When I run the game in the "DebugLogWarningSmokeTest" state
+  And I wait to receive an error
+  Then the error is valid for the error reporting API sent by the Unity notifier
+  And the exception "errorClass" equals "UnityLogWarning"
+  And the exception "message" equals "DebugLogWarningSmokeTest"
+  And the event "unhandled" is false
+  
+  And custom metadata is included in the event
+  
+  And the stack frame methods should match:
+    | DebugLogWarningSmokeTest:Run() | DebugLogWarningSmokeTest.Run() ||
+    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
+  And expected device metadata is included in the event
+  And expected app metadata is included in the event
 
 Scenario: Debug Log smoke test
-    When I run the game in the "DebugLogSmokeTest" state
-    And I wait to receive an error
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "errorClass" equals "UnityLogLog"
-    And the exception "message" equals "DebugLogSmokeTest"
-    And the event "unhandled" is false
-    
-    And custom metadata is included in the event
-    
-    And the stack frame methods should match:
-      | DebugLogSmokeTest:Run() | DebugLogSmokeTest.Run() |
-      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
-    And expected device metadata is included in the event
-    And expected app metadata is included in the event
+  When I run the game in the "DebugLogSmokeTest" state
+  And I wait to receive an error
+  Then the error is valid for the error reporting API sent by the Unity notifier
+  And the exception "errorClass" equals "UnityLogLog"
+  And the exception "message" equals "DebugLogSmokeTest"
+  And the event "unhandled" is false
+  
+  And custom metadata is included in the event
+  
+  And the stack frame methods should match:
+    | DebugLogSmokeTest:Run() | DebugLogSmokeTest.Run() ||
+    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
+  And expected device metadata is included in the event
+  And expected app metadata is included in the event
 
 Scenario: Debug Log Assert smoke test
-    When I run the game in the "DebugLogAssertSmokeTest" state
-    And I wait to receive an error
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "errorClass" equals "UnityLogAssert"
-    And the exception "message" equals "DebugLogAssertSmokeTest"
-    And the event "unhandled" is false
-    
-    And custom metadata is included in the event
-    
-    And the stack frame methods should match:
-      | DebugLogAssertSmokeTest:Run() | DebugLogAssertSmokeTest.Run() |
-      | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
-    And expected device metadata is included in the event
-    And expected app metadata is included in the event
+  When I run the game in the "DebugLogAssertSmokeTest" state
+  And I wait to receive an error
+  Then the error is valid for the error reporting API sent by the Unity notifier
+  And the exception "errorClass" equals "UnityLogAssert"
+  And the exception "message" equals "DebugLogAssertSmokeTest"
+  And the event "unhandled" is false
+  
+  And custom metadata is included in the event
+  
+  And the stack frame methods should match:
+    | DebugLogAssertSmokeTest:Run() | DebugLogAssertSmokeTest.Run() ||
+    | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) |
+  And expected device metadata is included in the event
+  And expected app metadata is included in the event
 
-# @skip_unity_2018
-# Scenario: Reporting an inner exception
-#     When I run the game in the "InnerException" state
-#     And I wait to receive an error
-#     Then the error is valid for the error reporting API sent by the Unity notifier
-#     And the event "exceptions.0.message" equals "Outer"
-#     And the event "exceptions.1.message" equals "Inner"
-#     And the event "exceptions.2" is null
+@skip_unity_2018
+Scenario: Reporting an inner exception
+  When I run the game in the "InnerException" state
+  And I wait to receive an error
+  Then the error is valid for the error reporting API sent by the Unity notifier
+  And the event "exceptions.0.message" equals "Outer"
+  And the event "exceptions.1.message" equals "Inner"
+  And the event "exceptions.2" is null

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -105,7 +105,7 @@ Feature: csharp events
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the event "exceptions.0.message" equals "Outer"
     And the event "exceptions.1.message" equals "Inner"
-    And the event "exceptions.2" is 
+    And the event "exceptions.2" is null
 
   Scenario: Reporting an uncaught exception in an async method
     When I run the game in the "AsyncException" state

--- a/features/csharp/csharp_user.feature
+++ b/features/csharp/csharp_user.feature
@@ -1,7 +1,7 @@
 Feature: User operations tests
 
   Scenario: Set User In Config Csharp error
-    When I run the game in the "NEWSetUserInConfig" state
+    When I run the game in the "SetUserInConfig" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "SetUserInConfig"
@@ -12,7 +12,7 @@ Feature: User operations tests
     And the event "user.name" equals "3"
 
   Scenario: Set User After Init Csharp Error
-    When I run the game in the "NEWSetUserAfterStart" state
+    When I run the game in the "SetUserAfterStart" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "SetUserAfterStart"

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -3376,6 +3376,7 @@ GameObject:
   - component: {fileID: 2039813465}
   - component: {fileID: 2039813464}
   - component: {fileID: 2039813469}
+  - component: {fileID: 2039813470}
   m_Layer: 0
   m_Name: Events
   m_TagString: Untagged
@@ -3491,6 +3492,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a770ab4689f1b49d78aa92e7f1b18dc8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58490dca261454ebdadb1702b44eddc3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &2042256587

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -1608,7 +1608,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1013696505
 GameObject:
@@ -2763,7 +2763,7 @@ RectTransform:
   - {fileID: 1292249762}
   - {fileID: 626947306}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2891,7 +2891,7 @@ Transform:
   m_Children:
   - {fileID: 1754371141}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1789907207
 MonoBehaviour:
@@ -3369,6 +3369,12 @@ GameObject:
   m_Component:
   - component: {fileID: 2039813461}
   - component: {fileID: 2039813462}
+  - component: {fileID: 2039813463}
+  - component: {fileID: 2039813468}
+  - component: {fileID: 2039813467}
+  - component: {fileID: 2039813466}
+  - component: {fileID: 2039813465}
+  - component: {fileID: 2039813464}
   m_Layer: 0
   m_Name: Events
   m_TagString: Untagged
@@ -3400,6 +3406,78 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8c7bec22fc97b49469efe0f898644b9b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6814e4a1ec9ea4458bb73fd5a3e20359, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 46d15c086aa9a41b9b3a6023b1e525a9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b359ba223a2624a60a350a2dddc54ca5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813466
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: afa88746a883d403e93a99cda7d6ba53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813467
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b808d8313b4674624802907326623fde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c271d58f23a94e8398c036c7cb556b2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &2042256587

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -3377,6 +3377,8 @@ GameObject:
   - component: {fileID: 2039813464}
   - component: {fileID: 2039813469}
   - component: {fileID: 2039813470}
+  - component: {fileID: 2039813471}
+  - component: {fileID: 2039813472}
   m_Layer: 0
   m_Name: Events
   m_TagString: Untagged
@@ -3504,6 +3506,30 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 58490dca261454ebdadb1702b44eddc3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813471
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5721675fafa764429a9710ee4919945f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b92297254c6274ab8a31a689afc65aa4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &2042256587

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -3375,6 +3375,7 @@ GameObject:
   - component: {fileID: 2039813466}
   - component: {fileID: 2039813465}
   - component: {fileID: 2039813464}
+  - component: {fileID: 2039813469}
   m_Layer: 0
   m_Name: Events
   m_TagString: Untagged
@@ -3478,6 +3479,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2c271d58f23a94e8398c036c7cb556b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2039813469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a770ab4689f1b49d78aa92e7f1b18dc8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &2042256587

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -1007,6 +1007,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7b818a85f031747088ad22cee18a95ba, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &555502129
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1019,6 +1022,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60ed80f7e7722451c958390a21603f05, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!1 &615950136
 GameObject:
   m_ObjectHideFlags: 0
@@ -2201,6 +2207,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e662e42a462864f19a5847dd0560f180, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &1338701867
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2213,6 +2222,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd616b7b5e89b47a88113ab6d55bc1e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &1338701868
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2225,6 +2237,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 484bb65c9535a4fb7b3ce8f38e121d49, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &1338701869
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2237,6 +2252,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b9e51f07962404c25a25098e49f23222, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!1 &1343498232
 GameObject:
   m_ObjectHideFlags: 0
@@ -3377,8 +3395,12 @@ GameObject:
   - component: {fileID: 2039813464}
   - component: {fileID: 2039813469}
   - component: {fileID: 2039813470}
+  - component: {fileID: 2039813476}
   - component: {fileID: 2039813471}
   - component: {fileID: 2039813472}
+  - component: {fileID: 2039813473}
+  - component: {fileID: 2039813475}
+  - component: {fileID: 2039813474}
   m_Layer: 0
   m_Name: Events
   m_TagString: Untagged
@@ -3412,6 +3434,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c7bec22fc97b49469efe0f898644b9b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813463
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3424,6 +3449,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6814e4a1ec9ea4458bb73fd5a3e20359, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813464
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3436,6 +3464,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 46d15c086aa9a41b9b3a6023b1e525a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813465
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3448,6 +3479,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b359ba223a2624a60a350a2dddc54ca5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813466
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3460,6 +3494,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: afa88746a883d403e93a99cda7d6ba53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813467
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3472,6 +3509,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b808d8313b4674624802907326623fde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813468
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3484,6 +3524,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2c271d58f23a94e8398c036c7cb556b2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813469
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3496,6 +3539,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a770ab4689f1b49d78aa92e7f1b18dc8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813470
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3508,6 +3554,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58490dca261454ebdadb1702b44eddc3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813471
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3520,6 +3569,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5721675fafa764429a9710ee4919945f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &2039813472
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3530,6 +3582,66 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b92297254c6274ab8a31a689afc65aa4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &2039813473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c97fbfba01a2c4b21a5705d6898fac72, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &2039813474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6e13c555aa9f5479c8196326e64fc0dd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &2039813475
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2a8a32ba6d1d46458bc88a9936739c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &2039813476
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 052cea8564f554e36879d176e45c4b8f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &2042256587

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -188,31 +188,27 @@ public class Main : MonoBehaviour
                         else if ("run_scenario".Equals(command.action))
                         {
 
-                            if (command.scenarioName.Contains("NEW"))
-                            {
-                                ScenarioRunner.RunScenario(command.scenarioName.Replace("NEW", string.Empty), API_KEY, _mazeHost);
-                            }
-                            else
-                            {
-#if UNITY_STANDALONE_OSX
-                                // some scenarios may need to start after a delay because starting an application via command line on macos launches it in the background 
-                                if (command.scenarioName.Equals("ExceptionWithSessionAfterStart"))
-                                {
-                                    StartCoroutine(StartScenarioAfterDelay(command.scenarioName, 1));
-                                }
-                                else
-                                {
-                                    // Start Bugsnag and run the scenario
-                                    StartBugsnag(command.scenarioName);
-                                    RunScenario(command.scenarioName);
-                                }
+                            ScenarioRunner.RunScenario(command.scenarioName, API_KEY, _mazeHost);
+                    
+//#if UNITY_STANDALONE_OSX
+//                                // some scenarios may need to start after a delay because starting an application via command line on macos launches it in the background 
+//                                if (command.scenarioName.Equals("ExceptionWithSessionAfterStart"))
+//                                {
+//                                    StartCoroutine(StartScenarioAfterDelay(command.scenarioName, 1));
+//                                }
+//                                else
+//                                {
+//                                    // Start Bugsnag and run the scenario
+//                                    StartBugsnag(command.scenarioName);
+//                                    RunScenario(command.scenarioName);
+//                                }
 
-#else
-                            // Start Bugsnag and run the scenario
-                            StartBugsnag(command.scenarioName);
-                            RunScenario(command.scenarioName);
-#endif
-                            }
+//#else
+//                            // Start Bugsnag and run the scenario
+//                            StartBugsnag(command.scenarioName);
+//                            RunScenario(command.scenarioName);
+//#endif
+                            
 
                         }
                         else if ("close_application".Equals(command.action))

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -9,6 +9,8 @@ public class Scenario : MonoBehaviour
 
     public Configuration Configuration;
 
+    public string CustomStacktrace = "Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)\nMain.CUSTOM2 () (at Assets/Scripts/Main.cs:123)";
+
     public virtual void PrepareConfig(string apiKey, string host)
     {
         Configuration = new Configuration(apiKey);

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Breadcrumbs/EnableBreadcrumbs.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Breadcrumbs/EnableBreadcrumbs.cs
@@ -14,7 +14,7 @@ public class EnableBreadcrumbs : Scenario
     public override void Run()
     {
         Debug.Log("Debug.Log");
-        Bugsnag.Notify(new Exception("FirstError"));
-        throw new Exception("EnableBreadcrumbs");
+        Bugsnag.Notify(new Exception("Error1"));
+        throw new Exception("Error2");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Breadcrumbs/ManualAndAutoBreadcrumbs.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Breadcrumbs/ManualAndAutoBreadcrumbs.cs
@@ -13,12 +13,12 @@ public class ManualAndAutoBreadcrumbs : Scenario
         Debug.Log("Debug.Log");
         Debug.LogWarning("Debug.LogWarning");
         Debug.LogError("Debug.LogError");
-        Debug.LogException(new Exception("Debug.LogException"));
-        Bugsnag.Notify(new Exception("FirstError"));
+        Debug.LogException(new Exception("Error1"));
+        Bugsnag.Notify(new Exception("Error2"));
         Bugsnag.LeaveBreadcrumb("Metadata", new Dictionary<string, object>() {
             {"test" , "value" },
             {"nullTest" , null }
         });
-        throw new Exception("SecondError");
+        throw new Exception("Error3");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/AsyncException.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/AsyncException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+
+public class AsyncException : Scenario
+{
+    public override void Run()
+    {
+        DoAsyncTest();
+    }
+
+    private async void DoAsyncTest()
+    {
+        throw new Exception("AsyncException");
+        await Task.Yield();
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/AsyncException.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/AsyncException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58490dca261454ebdadb1702b44eddc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/BackgroundThreadException.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/BackgroundThreadException.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+
+public class BackgroundThreadException : Scenario
+{
+    public override void Run()
+    {
+        var bgThread = new Thread(() => { Debug.LogException(new System.Exception("BackgroundThreadException")); })
+        {
+            IsBackground = true
+        };
+        bgThread.Start();
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/BackgroundThreadException.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/BackgroundThreadException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5721675fafa764429a9710ee4919945f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/CustomSeverity.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/CustomSeverity.cs
@@ -1,0 +1,9 @@
+﻿using BugsnagUnity;
+
+public class CustomSeverity : Scenario
+{
+    public override void Run()
+    {
+        Bugsnag.Notify(new System.Exception("CustomSeverity"), Severity.Info);
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/CustomSeverity.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/CustomSeverity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 052cea8564f554e36879d176e45c4b8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogAssertSmokeTest.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogAssertSmokeTest.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DebugLogAssertSmokeTest : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.NotifyLogLevel = LogType.Log;
+    }
+
+    public override void Run()
+    {
+        AddTestingMetadata();
+        Debug.Assert(false, "DebugLogAssertSmokeTest");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogAssertSmokeTest.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogAssertSmokeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46d15c086aa9a41b9b3a6023b1e525a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogErrorSmokeTest.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogErrorSmokeTest.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+public class DebugLogErrorSmokeTest : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.NotifyLogLevel = LogType.Error;
+    }
+
+    public override void Run()
+    {
+        AddTestingMetadata();
+        Debug.LogError("DebugLogErrorSmokeTest");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogErrorSmokeTest.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogErrorSmokeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b808d8313b4674624802907326623fde
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogExceptionSmokeTest.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogExceptionSmokeTest.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using UnityEngine;
+
+public class DebugLogExceptionSmokeTest : Scenario
+{
+    public override void Run()
+    {
+        AddTestingMetadata();
+        Debug.LogException(new Exception("DebugLogExceptionSmokeTest"));
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogExceptionSmokeTest.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogExceptionSmokeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c271d58f23a94e8398c036c7cb556b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogSmokeTest.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogSmokeTest.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DebugLogSmokeTest : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.NotifyLogLevel = LogType.Log;
+    }
+
+    public override void Run()
+    {
+        AddTestingMetadata();
+        Debug.Log("DebugLogSmokeTest");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogSmokeTest.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogSmokeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b359ba223a2624a60a350a2dddc54ca5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogWarningSmokeTest.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogWarningSmokeTest.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+public class DebugLogWarningSmokeTest : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.NotifyLogLevel = LogType.Warning;
+    }
+
+    public override void Run()
+    {
+        AddTestingMetadata();
+        Debug.LogWarning("DebugLogWarningSmokeTest");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogWarningSmokeTest.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/DebugLogWarningSmokeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: afa88746a883d403e93a99cda7d6ba53
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/InnerException.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/InnerException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+public class InnerException : Scenario
+{
+    public override void Run()
+    {
+        throw new Exception("Outer", new Exception("Inner"));
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/InnerException.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/InnerException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a770ab4689f1b49d78aa92e7f1b18dc8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyFromBackgroundThread.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyFromBackgroundThread.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+using BugsnagUnity;
+
+public class NotifyFromBackgroundThread : Scenario
+{
+    public override void Run()
+    {
+        var bgThread = new Thread(() => { Bugsnag.Notify(new System.Exception("NotifyFromBackgroundThread")); })
+        {
+            IsBackground = true
+        };
+        bgThread.Start();
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyFromBackgroundThread.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyFromBackgroundThread.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2a8a32ba6d1d46458bc88a9936739c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyWithCustomStacktrace.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyWithCustomStacktrace.cs
@@ -1,0 +1,10 @@
+﻿using BugsnagUnity;
+using System;
+
+public class NotifyWithCustomStacktrace : Scenario
+{
+    public override void Run()
+    {
+        Bugsnag.Notify(new Exception("NotifyWithCustomStacktrace"), CustomStacktrace);        
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyWithCustomStacktrace.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyWithCustomStacktrace.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c97fbfba01a2c4b21a5705d6898fac72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyWithStrings.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyWithStrings.cs
@@ -1,0 +1,9 @@
+﻿using BugsnagUnity;
+
+public class NotifyWithStrings : Scenario
+{
+    public override void Run()
+    {
+        Bugsnag.Notify("name", "NotifyWithStrings", CustomStacktrace);
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyWithStrings.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/NotifyWithStrings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e13c555aa9f5479c8196326e64fc0dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/SessionAfterStart.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/SessionAfterStart.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SessionAfterStart : Scenario
+{
+    public override void Run()
+    {
+        if (Application.platform.Equals(RuntimePlatform.OSXPlayer))
+        {
+            Invoke("DoException",1);
+        }
+        else
+        {
+            DoException();
+        }
+    }
+
+    private void DoException()
+    {
+        throw new System.Exception("SessionAfterStart");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/SessionAfterStart.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/SessionAfterStart.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b92297254c6274ab8a31a689afc65aa4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/UncaughtExceptionSmokeTest.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/UncaughtExceptionSmokeTest.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using BugsnagUnity;
 
-public class NotifySmokeTest : Scenario
+public class UncaughtExceptionSmokeTest : Scenario
 {
     public override void Run()
     {
         AddTestingMetadata();
-        Bugsnag.Notify(new Exception("NotifySmokeTest"));
+        throw new Exception("UncaughtExceptionSmokeTest");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/UncaughtExceptionSmokeTest.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Fallback/Events/UncaughtExceptionSmokeTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6814e4a1ec9ea4458bb73fd5a3e20359
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -339,25 +339,49 @@ Then("custom metadata is included in the event") do
 end
 
 Then("expected device metadata is included in the event") do
-  steps %Q{
-    And the event "device.freeDisk" is not null
-    And the event "device.freeMemory" is not null
-    And the event "device.id" is not null
-    And the event "device.locale" is not null
-    And the event "device.manufacturer" is not null
-    And the event "device.model" is not null
-    And the event "device.osName" is not null
-    And the event "device.osVersion" is not null
-    And the event "device.runtimeVersions" is not null
-    And the event "device.time" is a timestamp
-    And the event "device.totalMemory" is not null
-    And the event "metaData.device.screenDensity" is not null
-    And the event "metaData.device.screenResolution" is not null
-    And the event "metaData.device.osLanguage" equals "English"
-    And the event "metaData.device.graphicsDeviceVersion" is not null
-    And the event "metaData.device.graphicsMemorySize" is not null
-    And the event "metaData.device.processorType" is not null
-  }
+
+  case Maze::Helper.get_current_platform
+    when 'webgl'
+        steps %Q{
+        And the event "device.id" is not null
+        And the event "device.locale" is not null
+        And the event "device.model" is not null
+        And the event "device.osName" is not null
+        And the event "device.osVersion" is not null
+        And the event "device.runtimeVersions" is not null
+        And the event "device.time" is a timestamp
+        And the event "device.totalMemory" is not null
+        And the event "metaData.device.screenDensity" is not null
+        And the event "metaData.device.screenResolution" is not null
+        And the event "metaData.device.osLanguage" equals "English"
+        And the event "metaData.device.graphicsDeviceVersion" is not null
+        And the event "metaData.device.graphicsMemorySize" is not null
+        And the event "metaData.device.processorType" is not null
+      }
+    else
+      steps %Q{
+        And the event "device.freeDisk" is not null
+        And the event "device.freeMemory" is not null
+        And the event "device.id" is not null
+        And the event "device.locale" is not null
+        And the event "device.manufacturer" is not null
+        And the event "device.model" is not null
+        And the event "device.osName" is not null
+        And the event "device.osVersion" is not null
+        And the event "device.runtimeVersions" is not null
+        And the event "device.time" is a timestamp
+        And the event "device.totalMemory" is not null
+        And the event "metaData.device.screenDensity" is not null
+        And the event "metaData.device.screenResolution" is not null
+        And the event "metaData.device.osLanguage" equals "English"
+        And the event "metaData.device.graphicsDeviceVersion" is not null
+        And the event "metaData.device.graphicsMemorySize" is not null
+        And the event "metaData.device.processorType" is not null
+      }
+    end
+
+
+  
 end
 
 Then("expected app metadata is included in the event") do

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -34,7 +34,7 @@ When('I clear the Bugsnag cache') do
   when 'android', 'ios'
     # TODO: Come back to this
 
-  when 'webgl'
+  when 'browser'
     url = "http://localhost:#{Maze.config.document_server_port}/index.html"
     $logger.debug "Navigating to URL: #{url}"
     step("I navigate to the URL \"#{url}\"")
@@ -343,8 +343,7 @@ Then("expected device metadata is included in the event") do
   puts Maze::Helper.get_current_platform
 
   case Maze::Helper.get_current_platform
-    when 'webgl'
-
+    when 'browser'
         steps %Q{
         And the event "device.id" is not null
         And the event "device.locale" is not null
@@ -361,7 +360,6 @@ Then("expected device metadata is included in the event") do
         And the event "metaData.device.graphicsMemorySize" is not null
         And the event "metaData.device.processorType" is not null
       }
-      break
     else
       steps %Q{
         And the event "device.freeDisk" is not null

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -338,6 +338,43 @@ Then("custom metadata is included in the event") do
   }
 end
 
+Then("expected device metadata is included in the event") do
+  steps %Q{
+    And the event "device.freeDisk" is not null
+    And the event "device.freeMemory" is not null
+    And the event "device.id" is not null
+    And the event "device.locale" is not null
+    And the event "device.manufacturer" is not null
+    And the event "device.model" is not null
+    And the event "device.osName" is not null
+    And the event "device.osVersion" is not null
+    And the event "device.runtimeVersions" is not null
+    And the event "device.time" is a timestamp
+    And the event "device.totalMemory" is not null
+    And the event "metaData.device.screenDensity" is not null
+    And the event "metaData.device.screenResolution" is not null
+    And the event "metaData.device.osLanguage" equals "English"
+    And the event "metaData.device.graphicsDeviceVersion" is not null
+    And the event "metaData.device.graphicsMemorySize" is not null
+    And the event "metaData.device.processorType" is not null
+  }
+end
+
+Then("expected app metadata is included in the event") do
+  steps %Q{
+    And the event "app.duration" is greater than 0
+    And the event "app.durationInForeground" is not null
+    And the event "app.inForeground" is not null
+    And the event "app.isLaunching" is not null
+    And the event "app.releaseStage" is not null
+    And the event "app.type" is not null
+    And the event "app.version" is not null
+    And the event "metaData.app.companyName" equals "bugsnag"
+    And the event "metaData.app.name" equals "Mazerunner"
+    And the event "metaData.app.buildno" is not null
+  }
+end
+
 When("I clear any error dialogue") do
   click_if_present 'android:id/button1'
   click_if_present 'android:id/aerr_close'

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -340,8 +340,11 @@ end
 
 Then("expected device metadata is included in the event") do
 
+  puts Maze::Helper.get_current_platform
+
   case Maze::Helper.get_current_platform
     when 'webgl'
+
         steps %Q{
         And the event "device.id" is not null
         And the event "device.locale" is not null
@@ -358,6 +361,7 @@ Then("expected device metadata is included in the event") do
         And the event "metaData.device.graphicsMemorySize" is not null
         And the event "metaData.device.processorType" is not null
       }
+      break
     else
       steps %Q{
         And the event "device.freeDisk" is not null

--- a/scripts/ci-run-webgl-tests.sh
+++ b/scripts/ci-run-webgl-tests.sh
@@ -6,4 +6,4 @@ popd
 
 bundle install
 # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-bundle exec maze-runner --farm=local --browser=firefox -e features/desktop/persistence.feature features/desktop
+bundle exec maze-runner --farm=local --browser=firefox -e features/csharp

--- a/scripts/ci-run-webgl-tests.sh
+++ b/scripts/ci-run-webgl-tests.sh
@@ -6,4 +6,4 @@ popd
 
 bundle install
 # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-bundle exec maze-runner --farm=local --browser=firefox -e features/csharp
+bundle exec maze-runner --farm=local --browser=firefox features/csharp

--- a/scripts/ci-run-windows-tests-wsl.sh
+++ b/scripts/ci-run-windows-tests-wsl.sh
@@ -3,4 +3,4 @@ cd features/fixtures/maze_runner/build
 unzip Windows-$UNITY_VERSION.zip
 cd ../../../..
 bundle install
-bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/desktop
+bundle exec maze-runner --app=features/fixtures/maze_runner/build/Windows/Mazerunner.exe --os=windows features/csharp


### PR DESCRIPTION
## Goal

Add Scenario class tests that cover event payloads

## Design

The following test cases are covered, replacing the existing coverage

1: General smoke tests for notify, unhandled exception, Debug.LogError, Debug.LogException, Debug.LogWarning, Debug.Log call

	- errorClass
	- message
	- unhandled
	- device.runtimeVersions.unity
	- device.runtimeVersions.unityScriptingBackend
	- device.runtimeVersions.dotnetScriptingRuntime
	- device.runtimeVersions.dotnetApiCompatibility
	- custom metadata is included in the event
	- the stack frame methods

	- Device info
		- freeDisk
		- freeMemory
		- id
		- locale
		- manufacturer
		- model
		- osName
		- osVersion
		- runtimeVersions
		- time
		- totalMemory

	- App info
		- duration
		- durationInForeground
		- inForeground
		- isLaunching
		- lowMemory
		- releaseStage
		- type
		- version

	- Auto collected metadata
		- metaData.device.screenDensity
		- metaData.device.screenResolution
		- metaData.device.osLanguage
		- metaData.device.graphicsDeviceVersion
		- metaData.device.graphicsMemorySize
		- metaData.device.processorType
		- metaData.app.companyName
		- metaData.app.name
		- metaData.app.buildno


2: uncaught exception and notifying with an inner exception
	 
3: uncaught exception that occurs within an async method

4: A session is present in exception occuring directly after Bugsnag.Start

5: Reporting an assertion failure

6: Report exception from background thread  @skip_webgl 

7: Call notify and pass a custom stacktrace

8: Call notify only passign strings and stacktrace

9: Call notify from a background thread

10: Call notify with a custom severity

## Changeset

Added event test files

## Testing

Test will run on MacOS, Windows and WebGL