### PR TITLE
Mac os native error scenario classes

### DIFF
--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -840,6 +840,10 @@ GameObject:
   - component: {fileID: 425821759}
   - component: {fileID: 425821761}
   - component: {fileID: 425821760}
+  - component: {fileID: 425821762}
+  - component: {fileID: 425821763}
+  - component: {fileID: 425821764}
+  - component: {fileID: 425821765}
   m_Layer: 0
   m_Name: MacOS
   m_TagString: Untagged
@@ -873,6 +877,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1dc100132eb6e482c8ba12df3da883db, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &425821761
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -883,6 +890,66 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9ab26d7a70fc54951ab0ee9cec618b52, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &425821762
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425821758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1359596039b1545a48c96bce459e0a6a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &425821763
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425821758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8d5bb00c825346729ecfff0c7b91098, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &425821764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425821758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1725db6e50b34f2283ce6df6bb897d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &425821765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425821758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2a97f1dd73dd4eda8661b80e0f53165, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
@@ -2238,7 +2305,6 @@ GameObject:
   - component: {fileID: 1160627404}
   - component: {fileID: 1160627405}
   - component: {fileID: 1160627408}
-  - component: {fileID: 1160627407}
   - component: {fileID: 1160627406}
   m_Layer: 0
   m_Name: Callbacks
@@ -2306,18 +2372,6 @@ MonoBehaviour:
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
 
     Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
---- !u!114 &1160627407
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1160627402}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5009108c49bf4b9ca00afe56675326b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1160627408
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -829,6 +829,65 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &425821758
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 425821759}
+  - component: {fileID: 425821761}
+  - component: {fileID: 425821760}
+  m_Layer: 0
+  m_Name: MacOS
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &425821759
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425821758}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1754371141}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &425821760
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425821758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1dc100132eb6e482c8ba12df3da883db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &425821761
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425821758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ab26d7a70fc54951ab0ee9cec618b52, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
 --- !u!1 &472355624
 GameObject:
   m_ObjectHideFlags: 0
@@ -2875,7 +2934,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1419179097}
   m_Layer: 0
-  m_Name: CsharpTests
+  m_Name: Csharp
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3322,6 +3381,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1419179097}
+  - {fileID: 425821759}
   - {fileID: 2059449698}
   m_Father: {fileID: 1789907206}
   m_RootOrder: 0
@@ -4588,12 +4648,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2059449697}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1754371141}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2059449699
 MonoBehaviour:

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -2,10 +2,17 @@ using System.Collections.Generic;
 using UnityEngine;
 using BugsnagUnity;
 using BugsnagUnity.Payload;
+using System.Runtime.InteropServices;
 
 public class Scenario : MonoBehaviour
 {
 
+#if UNITY_STANDALONE_OSX
+
+    [DllImport("NativeCrashy")]
+    private static extern void crashy_signal_runner(float num);
+
+#endif
 
     public Configuration Configuration;
 
@@ -82,6 +89,14 @@ public class Scenario : MonoBehaviour
         Bugsnag.ClearMetadata("test", "test2");
     }
 
+    public void AddTestingFeatureFlags()
+    {
+        Bugsnag.AddFeatureFlag("flag1","variant1");
+        Bugsnag.AddFeatureFlag("flag2", "variant2");
+        Bugsnag.AddFeatureFlag("flag3", "variant3");
+        Bugsnag.ClearFeatureFlag("flag2");
+    }
+
     public void SetInvalidEndpoints()
     {
         Configuration.Endpoints = new EndpointConfiguration("https://notify.def-not-bugsnag.com", "https://notify.def-not-bugsnag.com");
@@ -89,27 +104,8 @@ public class Scenario : MonoBehaviour
 
     public bool SimpleCallback(IEvent @event)
     {
-        @event.App.BinaryArch = "BinaryArch";
-        @event.App.BundleVersion = "BundleVersion";
-        @event.App.CodeBundleId = "CodeBundleId";
-        @event.App.DsymUuid = "DsymUuid";
-        @event.App.Id = "Id";
-        @event.App.ReleaseStage = "ReleaseStage";
-        @event.App.Type = "Type";
-        @event.App.Version = "Version";
-        @event.App.InForeground = false;
-        @event.App.IsLaunching = false;
-
-        @event.Device.Id = "Id";
-        @event.Device.Jailbroken = true;
-        @event.Device.Locale = "Locale";
-        @event.Device.Manufacturer = "Manufacturer";
-        @event.Device.Model = "Model";
-        @event.Device.OsName = "OsName";
-        @event.Device.OsVersion = "OsVersion";
-        @event.Device.FreeDisk = 123;
-        @event.Device.FreeMemory = 456;
-        @event.Device.Orientation = "Orientation";
+        EditAllAppData(@event);
+        EditAllDeviceData(@event);
 
         @event.Errors[0].ErrorClass = "ErrorClass";
 
@@ -133,8 +129,85 @@ public class Scenario : MonoBehaviour
         return true;
     }
 
+    public bool CocoaNativeEventCallback(IEvent @event)
+    {
+        EditAllAppData(@event);
+        EditAllDeviceData(@event);
+
+        @event.Errors[0].ErrorClass = "ErrorClass";
+
+        @event.Errors[0].Stacktrace[0].Method = "Method";
+
+        //@event.Errors[0].Stacktrace[0].FrameAddress = "FrameAddress";
+
+        @event.Errors[0].Stacktrace[0].IsLr = true;
+
+        @event.Errors[0].Stacktrace[0].IsPc = true;
+
+        @event.Errors[0].Stacktrace[0].MachoFile = "MachoFile";
+
+        //@event.Errors[0].Stacktrace[0].MachoLoadAddress = "MachoLoadAddress";
+
+        @event.Errors[0].Stacktrace[0].MachoUuid = "MachoUuid";
+
+        //@event.Errors[0].Stacktrace[0].MachoVmAddress = "MachoVmAddress";
+
+        //@event.Errors[0].Stacktrace[0].SymbolAddress = "SymbolAddress";
+
+
+        foreach (var crumb in @event.Breadcrumbs)
+        {
+            crumb.Message = "Custom Message";
+            crumb.Type = BreadcrumbType.Request;
+            crumb.Metadata = new Dictionary<string, object> { { "test", "test" } };
+        }
+
+        @event.AddMetadata("test1", new Dictionary<string, object> { { "test", "test" } });
+        @event.AddMetadata("test2", new Dictionary<string, object> { { "test", "test" } });
+        @event.ClearMetadata("test2");
+
+        @event.AddFeatureFlag("fromCallback", "a");
+
+        return true;
+    }
+
+    private void EditAllAppData(IEvent @event)
+    {
+        @event.App.BinaryArch = "BinaryArch";
+        @event.App.BundleVersion = "BundleVersion";
+        @event.App.CodeBundleId = "CodeBundleId";
+        @event.App.DsymUuid = "DsymUuid";
+        @event.App.Id = "Id";
+        @event.App.ReleaseStage = "ReleaseStage";
+        @event.App.Type = "Type";
+        @event.App.Version = "Version";
+        @event.App.InForeground = false;
+        @event.App.IsLaunching = false;
+    }
+
+    private void EditAllDeviceData(IEvent @event)
+    {
+        @event.Device.Id = "Id";
+        @event.Device.Jailbroken = true;
+        @event.Device.Locale = "Locale";
+        @event.Device.Manufacturer = "Manufacturer";
+        @event.Device.Model = "Model";
+        @event.Device.OsName = "OsName";
+        @event.Device.OsVersion = "OsVersion";
+        @event.Device.FreeDisk = 123;
+        @event.Device.FreeMemory = 456;
+        @event.Device.Orientation = "Orientation";
+    }
+
     public void DoSimpleNotify(string msg)
     {
         Bugsnag.Notify(new System.Exception(msg));
+    }
+
+    public void MacOSNativeCrash()
+    {
+#if UNITY_STANDALONE_OSX
+        crashy_signal_runner(8);
+#endif
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -168,6 +168,8 @@ public class Scenario : MonoBehaviour
 
         @event.AddFeatureFlag("fromCallback", "a");
 
+        @event.SetUser("4", "5", "6");
+
         return true;
     }
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 807f73f99ccc64443999c080c02cc25d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrash.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrash.cs
@@ -1,0 +1,12 @@
+﻿using BugsnagUnity;
+
+public class MacOSNativeCrash : Scenario
+{
+    public override void Run()
+    {
+        Bugsnag.LeaveBreadcrumb("test");
+        AddTestingMetadata();
+        AddTestingFeatureFlags();
+        MacOSNativeCrash();
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrash.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrash.cs
@@ -2,6 +2,13 @@
 
 public class MacOSNativeCrash : Scenario
 {
+
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.SetUser("1", "2", "3");
+    }
+
     public override void Run()
     {
         Bugsnag.LeaveBreadcrumb("test");

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrash.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrash.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ab26d7a70fc54951ab0ee9cec618b52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashAutoDetectErrorsFalse.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashAutoDetectErrorsFalse.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MacOSNativeCrashAutoDetectErrorsFalse : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.AutoDetectErrors = false;
+    }
+
+    public override void Run()
+    {
+        MacOSNativeCrash();
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashAutoDetectErrorsFalse.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashAutoDetectErrorsFalse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1725db6e50b34f2283ce6df6bb897d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashCallback.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashCallback.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MacOSNativeCrashCallback : Scenario
+{
+
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.AddOnSendError(CocoaNativeEventCallback);
+    }
+
+  
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashCallback.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashCallback.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1dc100132eb6e482c8ba12df3da883db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashEnabledErrorTypes.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashEnabledErrorTypes.cs
@@ -1,0 +1,13 @@
+﻿public class MacOSNativeCrashEnabledErrorTypes : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.EnabledErrorTypes.Crashes = false;
+    }
+
+    public override void Run()
+    {
+        MacOSNativeCrash();
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashEnabledErrorTypes.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashEnabledErrorTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2a97f1dd73dd4eda8661b80e0f53165
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashOutsideReleaseStages.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashOutsideReleaseStages.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MacOSNativeCrashOutsideReleaseStages : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.EnabledReleaseStages = new string[] { "production" };
+        Configuration.ReleaseStage = "notProduction";
+    }
+
+    public override void Run()
+    {
+        MacOSNativeCrash();
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashOutsideReleaseStages.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSNativeCrashOutsideReleaseStages.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8d5bb00c825346729ecfff0c7b91098
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSSetUserAfterInitNativeCrash.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSSetUserAfterInitNativeCrash.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using BugsnagUnity;
+using UnityEngine;
+
+public class MacOSSetUserAfterInitNativeCrash : Scenario
+{
+    public override void Run()
+    {
+        StartCoroutine(DoTest());
+    }
+
+    private IEnumerator DoTest()
+    {
+        Bugsnag.SetUser("1","2","3");
+        yield return new WaitForSeconds(1);
+        MacOSNativeCrash();
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSSetUserAfterInitNativeCrash.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/MacOS/MacOSSetUserAfterInitNativeCrash.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1359596039b1545a48c96bce459e0a6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/macos/macos_native_crashes.feature
+++ b/features/macos/macos_native_crashes.feature
@@ -1,0 +1,77 @@
+Feature: MacOS native crashes
+
+  Scenario: Reporting a MacOS native crash
+    When I run the game in the "MacOSNativeCrash" state
+    And I run the game in the "StartSDKDefault" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the native Unity notifier
+    And the exception "errorClass" equals "SIGABRT"
+    And the event "unhandled" is true
+    And the stack frame methods should match:
+      | __pthread_kill       |
+      | abort                |
+      | crashy_signal_runner |
+    And the error payload field "notifier.name" equals "Unity Bugsnag Notifier"
+    And expected device metadata is included in the event
+    And custom metadata is included in the event
+    And feature flags are included in the event
+    And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
+    And the event "breadcrumbs.1.name" equals "test"
+
+Scenario: Reporting a MacOS native crash with an onsend callback
+    When I run the game in the "MacOSNativeCrash" state
+    And I run the game in the "MacOSNativeCrashCallback" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the native Unity notifier
+    And the exception "errorClass" equals "ErrorClass"
+    And the event "unhandled" is true
+    And the error payload field "notifier.name" equals "Unity Bugsnag Notifier"
+    
+     # Device metadata
+    And the event "device.osName" equals "OsName"
+    And the event "device.osVersion" equals "OsVersion"
+    And the event "device.id" equals "Id"
+    And the event "device.model" equals "Model"
+    And the event "device.orientation" equals "Orientation"
+    And the event "device.manufacturer" equals "Manufacturer"
+    And the event "device.freeDisk" equals 123
+    And the event "device.freeMemory" equals 456
+    And the event "device.jailbroken" is true
+    And the event "device.locale" equals "Locale"
+
+    # App metadata
+    And the event "app.id" equals "Id"
+    And the event "app.releaseStage" equals "ReleaseStage"
+    And the event "app.type" equals "Type"
+    And the event "app.version" equals "Version"
+    And the event "app.bundleVersion" equals "BundleVersion"
+    And the event "app.binaryArch" equals "BinaryArch"
+    And the event "app.codeBundleId" equals "CodeBundleId"
+    And the event "app.dsymUUIDs" is not null
+    And the event "app.inForeground" is false
+    And the event "app.isLaunching" is false
+
+    # Exception data
+    And the event "exceptions.0.errorClass" equals "ErrorClass"
+    And the event "exceptions.0.stacktrace.0.method" equals "Method"
+    #And the event "exceptions.0.stacktrace.0.frameAddress" equals "FrameAddress"
+    And the event "exceptions.0.stacktrace.0.isLR" is true
+    And the event "exceptions.0.stacktrace.0.isPC" is true
+    And the event "exceptions.0.stacktrace.0.machoFile" equals "MachoFile"
+    #And the event "exceptions.0.stacktrace.0.machoLoadAddress" equals "MachoLoadAddress"
+    And the event "exceptions.0.stacktrace.0.machoUUID" equals "MachoUuid"
+    #And the event "exceptions.0.stacktrace.0.machoVmAddress" equals "MachoVmAddress"
+    #And the event "exceptions.0.stacktrace.0.symbolAddress" equals "SymbolAddress"
+
+ # Breadcrumbs
+    And the event "breadcrumbs.0.type" equals "request"
+    And the event "breadcrumbs.0.name" equals "Custom Message"
+    And the event "breadcrumbs.0.metaData.test" equals "test"
+
+  # Feature flags
+    And the event "featureFlags.2.featureFlag" equals "fromCallback"
+    And the event "featureFlags.2.variant" equals "a"
+
+    # Metadata
+    And the event "metaData.test1.test" equals "test"
+    And the event "metaData.test2" is null

--- a/features/macos/macos_native_crashes.feature
+++ b/features/macos/macos_native_crashes.feature
@@ -2,6 +2,7 @@ Feature: MacOS native crashes
 
   Scenario: Reporting a MacOS native crash
     When I run the game in the "MacOSNativeCrash" state
+    And I wait for 2 seconds
     And I run the game in the "StartSDKDefault" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the native Unity notifier

--- a/features/macos/macos_native_crashes.feature
+++ b/features/macos/macos_native_crashes.feature
@@ -1,5 +1,6 @@
 Feature: MacOS native crashes
 
+  @macos_only
   Scenario: Reporting a MacOS native crash
     When I run the game in the "MacOSNativeCrash" state
     And I wait for 2 seconds
@@ -18,9 +19,15 @@ Feature: MacOS native crashes
     And feature flags are included in the event
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.1.name" equals "test"
+    And the event "user.id" equals "1"
+    And the event "user.email" equals "2"
+    And the event "user.name" equals "3"
 
-Scenario: Reporting a MacOS native crash with an onsend callback
+
+  @macos_only
+  Scenario: Reporting a MacOS native crash with an onsend callback
     When I run the game in the "MacOSNativeCrash" state
+    And I wait for 2 seconds
     And I run the game in the "MacOSNativeCrashCallback" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the native Unity notifier
@@ -64,15 +71,56 @@ Scenario: Reporting a MacOS native crash with an onsend callback
     #And the event "exceptions.0.stacktrace.0.machoVmAddress" equals "MachoVmAddress"
     #And the event "exceptions.0.stacktrace.0.symbolAddress" equals "SymbolAddress"
 
- # Breadcrumbs
+    # Breadcrumbs
     And the event "breadcrumbs.0.type" equals "request"
     And the event "breadcrumbs.0.name" equals "Custom Message"
     And the event "breadcrumbs.0.metaData.test" equals "test"
 
-  # Feature flags
+    # Feature flags
     And the event "featureFlags.2.featureFlag" equals "fromCallback"
     And the event "featureFlags.2.variant" equals "a"
 
     # Metadata
     And the event "metaData.test1.test" equals "test"
     And the event "metaData.test2" is null
+
+    # User
+    And the event "user.id" equals "4"
+    And the event "user.email" equals "5"
+    And the event "user.name" equals "6"
+
+  @macos_only
+  Scenario: Set User After Init Native Error
+    When I run the game in the "MacOSSetUserAfterInitNativeCrash" state
+    And I wait for 2 seconds
+    And I run the game in the "StartSDKDefault" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the native Unity notifier
+    And the exception "errorClass" equals "SIGABRT"
+
+    # User
+    And the event "user.id" equals "1"
+    And the event "user.email" equals "2"
+    And the event "user.name" equals "3"
+
+  @macos_only
+  Scenario: Native crash outside of release stage
+    When I run the game in the "MacOSNativeCrashOutsideReleaseStages" state
+    And I wait for 2 seconds
+    And I run the game in the "StartSDKDefault" state
+    Then I should receive no errors
+
+  @macos_only
+  Scenario: Reporting a native crash when AutoDetectErrors = false
+    When I run the game in the "MacOSNativeCrashAutoDetectErrorsFalse" state
+    And I wait for 2 seconds
+    And I run the game in the "StartSDKDefault" state
+    Then I should receive no errors
+
+   @macos_only
+  Scenario: Reporting a native crash when EnabledErrorTypes.Crashes = false
+    When I run the game in the "MacOSNativeCrashEnabledErrorTypes" state
+    And I wait for 2 seconds
+    And I run the game in the "StartSDKDefault" state
+    Then I should receive no errors
+

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -338,6 +338,16 @@ Then("custom metadata is included in the event") do
   }
 end
 
+Then("feature flags are included in the event") do
+  steps %Q{
+    And the event "featureFlags.0.featureFlag" equals "flag1"
+    And the event "featureFlags.0.variant" equals "variant1"
+    And the event "featureFlags.1.featureFlag" equals "flag3"
+    And the event "featureFlags.1.variant" equals "variant3"
+    And the event "featureFlags.2" is null
+  }
+end
+
 Then("all possible parameters have been edited in a callback") do
   steps %Q{
 

--- a/scripts/ci-run-macos-tests-csharp.sh
+++ b/scripts/ci-run-macos-tests-csharp.sh
@@ -4,4 +4,4 @@ pushd features/fixtures/maze_runner/build
 popd
 
 bundle install
-bundle exec maze-runner --app=features/fixtures/maze_runner/build/MacOS/Mazerunner.app --os=macos features/csharp
+bundle exec maze-runner --app=features/fixtures/maze_runner/build/MacOS/Mazerunner.app --os=macos features/macos features/csharp


### PR DESCRIPTION
## Goal

Add MacOS native error scenario classes

## Changeset

Added tests that run only on MacOS to test native cocoa crash functionality

## Testing

Existing coverage replicated and improved.