### PR TITLE
task(config): pass maxStringValueLength to Android & Cocoa notifiers

### DIFF
--- a/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
+++ b/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
@@ -173,8 +173,9 @@ namespace BugsnagUnity.Editor
             EditorGUILayout.PropertyField(so.FindProperty("LaunchDurationMillis"));
             settings.MaximumBreadcrumbs = EditorGUILayout.IntField("Max Breadcrumbs", settings.MaximumBreadcrumbs);
             EditorGUILayout.PropertyField(so.FindProperty("MaxPersistedEvents"));
-            EditorGUILayout.PropertyField(so.FindProperty("MaxPersistedSessions"));
+            EditorGUILayout.PropertyField(so.FindProperty("MaxPersistedSessions"));            
             settings.MaxReportedThreads = EditorGUILayout.IntField(new GUIContent("Max Reported Threads ⓘ", "Android devices only"), settings.MaxReportedThreads);
+            EditorGUILayout.PropertyField(so.FindProperty("MaxStringValueLength"));
             EditorGUILayout.PropertyField(so.FindProperty("NotifyLogLevel"));
             EditorGUILayout.PropertyField(so.FindProperty("PersistUser"));
             EditorGUILayout.PropertyField(so.FindProperty("RedactedKeys"));

--- a/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
+++ b/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
@@ -28,6 +28,7 @@ namespace BugsnagUnity
         public int MaxPersistedEvents = 32;
         public int MaxPersistedSessions = 128;
         public int MaxReportedThreads = 200;
+        public int MaxStringValueLength = 10000;
         public string NotifyEndpoint = "https://notify.bugsnag.com";
         public EditorLogLevel NotifyLogLevel = EditorLogLevel.Exception;
         public bool PersistUser = true;
@@ -90,6 +91,7 @@ namespace BugsnagUnity
             config.MaxPersistedEvents = MaxPersistedEvents;
             config.MaxPersistedSessions = MaxPersistedSessions;
             config.MaxReportedThreads = MaxReportedThreads;
+            config.MaxStringValueLength = MaxStringValueLength;
             config.NotifyLogLevel = GetLogTypeFromLogLevel( NotifyLogLevel );
             config.SendThreads = SendThreads;
             if (!string.IsNullOrEmpty(NotifyEndpoint) && !string.IsNullOrEmpty(SessionEndpoint))

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -497,6 +497,10 @@ void bugsnag_setMaxPersistedEvents(const void *configuration, int maxPersistedEv
   ((__bridge BugsnagConfiguration *)configuration).maxPersistedEvents = maxPersistedEvents;
 }
 
+void bugsnag_setMaxStringValueLength(const void *configuration, int maxStringValueLength) {
+  ((__bridge BugsnagConfiguration *)configuration).maxStringValueLength = maxStringValueLength;
+}
+
 void bugsnag_setMaxPersistedSessions(const void *configuration, int maxPersistedSessions) {
   ((__bridge BugsnagConfiguration *)configuration).maxPersistedSessions = maxPersistedSessions;
 }

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -28,6 +28,8 @@ namespace BugsnagUnity
         public int SwitchCacheMaxSize = 10485760; //10MiB in Bytes
         // ----------
 
+        public int MaxStringValueLength = 10000;
+
         public string AppType;
 
         public string BundleVersion;

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -281,6 +281,7 @@ namespace BugsnagUnity
             obj.Call("setLaunchDurationMillis", config.LaunchDurationMillis);
             obj.Call("setSendLaunchCrashesSynchronously", config.SendLaunchCrashesSynchronously);
             obj.Call("setMaxReportedThreads", config.MaxReportedThreads);
+            obj.Call("setMaxStringValueLength", config.MaxStringValueLength);
 
 
             if (config.GetUser() != null)

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -49,6 +49,9 @@ namespace BugsnagUnity
             NativeCode.bugsnag_registerForOnSendCallbacks(obj, HandleOnSendCallbacks);
             NativeCode.bugsnag_registerForSessionCallbacks(obj, HandleSessionCallbacks);
             NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);
+            NativeCode.bugsnag_setMaxStringValueLength(obj, config.MaxStringValueLength);
+
+
             AddFeatureFlagsToConfig(obj,config);
             if (config.GetUser() != null)
             {

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -93,6 +93,9 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setMaxPersistedEvents(IntPtr configuration, int maxPersistedEvents);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_setMaxStringValueLength(IntPtr configuration, int maxStringValueLength);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_setMaxPersistedSessions(IntPtr configuration, int maxPersistedSessions);
 
         [DllImport(Import)]


### PR DESCRIPTION
## Goal

Pass maxStringValueLength to Android & Cocoa notifiers

## Testing

Manually tested. CI tests will be added when the csharp layer is implemented. 