### PR TITLE
enable android 2021 tests [full ci]

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -323,10 +323,8 @@ steps:
     concurrency_group: browserstack-app
     concurrency_method: eager
 
-  # TODO: PLAT-7967 Investigate failures specific to Unity 2021 on Android
   - label: ':android: Run Android e2e tests for Unity 2021'
     timeout_in_minutes: 60
-    skip: Pending PLAT-7967
     depends_on: 'build-android-fixture-2021'
     agents:
       queue: opensource


### PR DESCRIPTION
## Goal

Android 2021 tests where disabled due to an issue in the native android sdk.
This appears to have been fixed and android 2021 tests are now passing.

## Testing

Full CI run