### PR TITLE
PLAT-8627 truncate breadcrumbs when payload oversized

### DIFF
--- a/features/csharp/csharp_breadcrumbs.feature
+++ b/features/csharp/csharp_breadcrumbs.feature
@@ -67,3 +67,12 @@ Feature: Csharp Breadcrumbs
     And the event "breadcrumbs.7.type" equals "manual"
     And the event "breadcrumbs.7.metaData.test" equals "value"
     And the event "breadcrumbs.7.metaData.nullTest" is null
+
+  Scenario: Breadcrumb Truncation
+    When I run the game in the "BreadcrumbTruncation" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "BreadcrumbTruncation"
+    And the error payload field "events.0.breadcrumbs" is an array with 99 elements
+    And the event "breadcrumbs.98.name" equals "Removed, along with 2 older breadcrumbs, to reduce payload size"
+    And the event "breadcrumbs.98.type" equals "manual"

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -1132,6 +1132,7 @@ GameObject:
   - component: {fileID: 1338701867}
   - component: {fileID: 1338701868}
   - component: {fileID: 1338701869}
+  - component: {fileID: 1338701870}
   m_Layer: 0
   m_Name: Breadcrumbs
   m_TagString: Untagged
@@ -1213,6 +1214,21 @@ MonoBehaviour:
   CustomStacktrace: 'Main.CUSTOM () (at Assets/Scripts/Main.cs:123)
 
     Main.CUSTOM () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &1338701870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338701864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e212851ed37b45559b76b0c6c959121, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
 --- !u!1 &1388241496
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/BreadcrumbTruncation.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/BreadcrumbTruncation.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using BugsnagUnity;
+using UnityEngine;
+
+public class BreadcrumbTruncation : Scenario
+{
+    public override void Run()
+    {
+        var largeString = "";
+        for (int i = 0; i < 10000; i++)
+        {
+            largeString += "1";
+        }
+
+        for (int i = 0; i < 100; i++)
+        {
+            Bugsnag.LeaveBreadcrumb(i.ToString(), new Dictionary<string, object>() { { "1", largeString } });
+        }
+
+        DoSimpleNotify("BreadcrumbTruncation");
+    }
+}
+

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/BreadcrumbTruncation.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/BreadcrumbTruncation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e212851ed37b45559b76b0c6c959121
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
+++ b/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
@@ -24,7 +24,7 @@ namespace BugsnagUnity
         public EnabledErrorTypes EnabledErrorTypes = new EnabledErrorTypes();
         public EditorBreadcrumbTypes EnabledBreadcrumbTypes = new EditorBreadcrumbTypes();
         public long LaunchDurationMillis = 5000;
-        public int MaximumBreadcrumbs = 50;
+        public int MaximumBreadcrumbs = 100;
         public int MaxPersistedEvents = 32;
         public int MaxPersistedSessions = 128;
         public int MaxReportedThreads = 200;

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -110,18 +110,18 @@ namespace BugsnagUnity
 
         public string ApiKey { get; set; }
 
-        private int _maximumBreadcrumbs = 50;
+        private int _maximumBreadcrumbs = 100;
 
         public int MaximumBreadcrumbs
         {
             get { return _maximumBreadcrumbs; }
             set
             {
-                if (value < 0 || value > 100)
+                if (value < 0 || value > 500)
                 {
                     if (IsRunningInEditor())
                     {
-                        Debug.LogError("Invalid configuration value detected. Option maxBreadcrumbs should be an integer between 0-100. Supplied value is " + value);
+                        Debug.LogError("Invalid configuration value detected. Option maxBreadcrumbs should be an integer between 0-500. Supplied value is " + value);
                     }
                     return;
                 }

--- a/tests/BugsnagUnity.Tests/ConfigurationTests.cs
+++ b/tests/BugsnagUnity.Tests/ConfigurationTests.cs
@@ -26,10 +26,10 @@ namespace BugsnagUnity.Payload.Tests
         public void MaxBreadcrumbsLimit()
         {
             var config = new Configuration("foo");
-            config.MaximumBreadcrumbs = 101;
-            Assert.AreEqual(config.MaximumBreadcrumbs, 50);
+            config.MaximumBreadcrumbs = 501;
+            Assert.AreEqual(config.MaximumBreadcrumbs, 100);
             config.MaximumBreadcrumbs = -1;
-            Assert.AreEqual(config.MaximumBreadcrumbs, 50);
+            Assert.AreEqual(config.MaximumBreadcrumbs, 100);
             config.MaximumBreadcrumbs = 20;
             Assert.AreEqual(config.MaximumBreadcrumbs, 20);
         }


### PR DESCRIPTION
## Goal

truncate breadcrumbs when payload oversized

## Design

If. a payload is bigger than 1MB and truncating the strings in metadata does not bring it below 1MB, then breadcrumbs are removed until there are none left or the payload is under 1MB

## Changes

- Raised max breadcrumbs default to 100
- Set max value of max breadcrumbs to 500
- Added check for breadcrumb truncation to the Delivery class

## Testing

Added E2E test