### PR TITLE
PLAT-9200 Bundle Code not displaying on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Bug fixes
 
+* Fix an issue where bundle version was not reported correctly on iOS and MacOS. [#672](https://github.com/bugsnag/bugsnag-unity/pull/672)
+
 * Fix an issue where a null value in metadata could cause an exception. [#652](https://github.com/bugsnag/bugsnag-unity/pull/652)
 
 * Fix an issue where android metadata was not deserialised as the correct type, which could cause exceptions when processing metadata. [#652](https://github.com/bugsnag/bugsnag-unity/pull/652)

--- a/features/android/android_config.feature
+++ b/features/android/android_config.feature
@@ -7,3 +7,16 @@ Feature: Android Config
     When I run the game in the "AndroidPersistenceDirectory" state
     And I wait to receive an error
     And the exception "message" equals "Directory Found"
+
+  Scenario: Version Code From Player Settings
+    When I run the game in the "AndroidVersionCodeInPlayerSettings" state
+    And I wait to receive an error
+    And the exception "message" equals "AndroidVersionCodeInPlayerSettings"
+    And the event "app.versionCode" equals 111
+
+  Scenario: Version code From Config
+    When I run the game in the "AndroidVersionCodeInConfig" state
+    And I wait to receive an error
+    And the exception "message" equals "AndroidVersionCodeInConfig"
+    And the event "app.versionCode" equals 222
+

--- a/features/android/android_config.feature
+++ b/features/android/android_config.feature
@@ -12,11 +12,11 @@ Feature: Android Config
     When I run the game in the "AndroidVersionCodeInPlayerSettings" state
     And I wait to receive an error
     And the exception "message" equals "AndroidVersionCodeInPlayerSettings"
-    And the event "app.versionCode" equals 111
+    And the event "app.versionCode" equals 444
 
   Scenario: Version code From Config
     When I run the game in the "AndroidVersionCodeInConfig" state
     And I wait to receive an error
     And the exception "message" equals "AndroidVersionCodeInConfig"
-    And the event "app.versionCode" equals 222
+    And the event "app.versionCode" equals 555
 

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -1866,6 +1866,8 @@ GameObject:
   - component: {fileID: 1947744089}
   - component: {fileID: 1947744088}
   - component: {fileID: 1947744091}
+  - component: {fileID: 1947744093}
+  - component: {fileID: 1947744092}
   m_Layer: 0
   m_Name: Ios
   m_TagString: Untagged
@@ -1957,6 +1959,36 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bd5ef0d76c1a94bf8afacfea552d1a54, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &1947744092
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947744085}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d0996c4772394dd2a217a9246159be9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &1947744093
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947744085}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 370e163fadf3c407bbd6d0f5eda69737, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -1245,6 +1245,8 @@ GameObject:
   - component: {fileID: 1388241502}
   - component: {fileID: 1388241503}
   - component: {fileID: 1388241504}
+  - component: {fileID: 1388241506}
+  - component: {fileID: 1388241505}
   m_Layer: 0
   m_Name: Android
   m_TagString: Untagged
@@ -1366,6 +1368,36 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3b9fe89cc44fd455d9810d0f7183b32f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &1388241505
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1388241496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8f8f22bda9f84514ad885443765cccf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &1388241506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1388241496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad7cb7beeace84b0698b1d2cc73b3537, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInConfig.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInConfig.cs
@@ -3,7 +3,7 @@
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.VersionCode = 222;
+        Configuration.VersionCode = 555;
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInConfig.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInConfig.cs
@@ -1,0 +1,13 @@
+﻿public class AndroidVersionCodeInConfig : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.VersionCode = 222;
+    }
+
+    public override void Run()
+    {
+        DoSimpleNotify("AndroidVersionCodeInConfig");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInConfig.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad7cb7beeace84b0698b1d2cc73b3537
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInPlayerSettings.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInPlayerSettings.cs
@@ -1,0 +1,7 @@
+﻿public class AndroidVersionCodeInPlayerSettings : Scenario
+{
+    public override void Run()
+    {
+        DoSimpleNotify("AndroidVersionCodeInPlayerSettings");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInPlayerSettings.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidVersionCodeInPlayerSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8f8f22bda9f84514ad885443765cccf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosBundleVersionFromPlayerSettings.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosBundleVersionFromPlayerSettings.cs
@@ -1,0 +1,7 @@
+﻿public class IosBundleVersionFromPlayerSettings : Scenario
+{
+    public override void Run()
+    {
+        DoSimpleNotify("IosBundleVersionFromPlayerSettings");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosBundleVersionFromPlayerSettings.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosBundleVersionFromPlayerSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 370e163fadf3c407bbd6d0f5eda69737
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosBundleVersionInConfig.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosBundleVersionInConfig.cs
@@ -1,0 +1,13 @@
+﻿public class IosBundleVersionInConfig : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.BundleVersion = "222";
+    }
+
+    public override void Run()
+    {
+        DoSimpleNotify("IosBundleVersionInConfig");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosBundleVersionInConfig.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosBundleVersionInConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d0996c4772394dd2a217a9246159be9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
+++ b/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
@@ -164,8 +164,8 @@ PlayerSettings:
     iPhone: com.bugsnag.unity.mazerunner
   buildNumber:
     Standalone: 111
-    iOS: 111
-  AndroidBundleVersionCode: 111
+    iOS: 333
+  AndroidBundleVersionCode: 444
   AndroidMinSdkVersion: 16
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1

--- a/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
+++ b/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
@@ -165,7 +165,7 @@ PlayerSettings:
   buildNumber:
     Standalone: 111
     iOS: 111
-  AndroidBundleVersionCode: 1
+  AndroidBundleVersionCode: 111
   AndroidMinSdkVersion: 16
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1

--- a/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
+++ b/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
@@ -161,7 +161,10 @@ PlayerSettings:
   applicationIdentifier:
     Android: com.bugsnag.mazerunner
     iOS: com.bugsnag.unity.mazerunner
-  buildNumber: {}
+    iPhone: com.bugsnag.unity.mazerunner
+  buildNumber:
+    Standalone: 111
+    iOS: 111
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 16
   AndroidTargetSdkVersion: 0

--- a/features/ios/ios_config.feature
+++ b/features/ios/ios_config.feature
@@ -8,7 +8,7 @@ Feature: Config
     When I run the game in the "IosBundleVersionFromPlayerSettings" state
     And I wait to receive an error
     And the exception "message" equals "IosBundleVersionFromPlayerSettings"
-    And the event "app.bundleVersion" equals "111"
+    And the event "app.bundleVersion" equals "333"
 
   Scenario: Bundle Version From Config
 

--- a/features/ios/ios_config.feature
+++ b/features/ios/ios_config.feature
@@ -1,0 +1,19 @@
+Feature: Config
+
+  Background:
+    Given I clear the Bugsnag cache
+
+  Scenario: Bundle Version From Player Settings
+
+    When I run the game in the "IosBundleVersionFromPlayerSettings" state
+    And I wait to receive an error
+    And the exception "message" equals "IosBundleVersionFromPlayerSettings"
+    And the event "app.bundleVersion" equals "111"
+
+  Scenario: Bundle Version From Config
+
+    When I run the game in the "IosBundleVersionInConfig" state
+    And I wait to receive an error
+    And the exception "message" equals "IosBundleVersionInConfig"
+    And the event "app.bundleVersion" equals "222"
+

--- a/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
+++ b/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
@@ -39,7 +39,7 @@ namespace BugsnagUnity
         public bool SendLaunchCrashesSynchronously = true;
         public double SecondsPerUniqueLog = 5;
         public List<TelemetryType> Telemetry = new List<TelemetryType> { TelemetryType.InternalErrors, TelemetryType.Usage };
-        public int VersionCode;
+        public int VersionCode = -1;
 
         public SwitchCacheType SwitchCacheType = SwitchCacheType.R;
         public string SwitchCacheMountName = "BugsnagCache";

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -37,7 +37,10 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);
             NativeCode.bugsnag_setEndpoints(obj, config.Endpoints.Notify.ToString(), config.Endpoints.Session.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
-            NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
+            if (!string.IsNullOrEmpty(config.BundleVersion))
+            {
+                NativeCode.bugsnag_setBundleVersion(obj, config.BundleVersion);
+            }
             NativeCode.bugsnag_setAppType(obj, GetAppType(config));
             NativeCode.bugsnag_setPersistUser(obj,config.PersistUser);
             NativeCode.bugsnag_setMaxPersistedEvents(obj, config.MaxPersistedEvents);


### PR DESCRIPTION
## Goal

The cocoa bundle version was not being reported unless manually set in the bugsnag config.
If the config value is left blank then it should be automatically reported as the value in the player settings

While investigating we also realised that the android version code had the wrong default value in the settings UI.

## Changeset

- Added a check to only set the cocoa bundle version if a value has been added to the bugsnag config.
- Corrected the default value of the android version code in the settings UI/
## Testing

Added E2E tests for ios and android 