### PR TITLE
Move unity install path on CI and bump version for Windows

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -602,7 +602,7 @@ steps:
     key: 'windows-2018-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: win-general-1-wsl
+      queue: win-general-1
     env:
       UNITY_VERSION: "2018.4.36f1"
     command:
@@ -624,7 +624,7 @@ steps:
     key: 'windows-2019-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: win-general-1-wsl
+      queue: win-general-1
     env:
       UNITY_VERSION: "2019.4.35f1"
     command:
@@ -646,7 +646,7 @@ steps:
     key: 'windows-2021-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: win-general-1-wsl
+      queue: win-general-1
     env:
       UNITY_VERSION: "2021.3.13f1"
     commands:
@@ -702,7 +702,7 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'windows-2021-fixture'
     agents:
-      queue: win-general-1-wsl
+      queue: win-general-1
     env:
       UNITY_VERSION: "2021.3.13f1"
     plugins:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -602,7 +602,7 @@ steps:
     key: 'windows-2018-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: win-general-1
+      queue: windows-unity-wsl
     env:
       UNITY_DIR: "/mnt/f/unity/2018.4.36f1"
       UNITY_VERSION: "2018.4.36f1"
@@ -625,7 +625,7 @@ steps:
     key: 'windows-2019-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: win-general-1
+      queue: windows-unity-wsl
     env:
       UNITY_DIR: "/mnt/f/unity/2019.4.35f1"
       UNITY_VERSION: "2019.4.35f1"
@@ -648,7 +648,7 @@ steps:
     key: 'windows-2021-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: win-general-1
+      queue: windows-unity-wsl
     env:
       UNITY_DIR: "/mnt/f/unity/2021.3.13f1"
       UNITY_VERSION: "2021.3.13f1"
@@ -707,7 +707,7 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'windows-2021-fixture'
     agents:
-      queue: win-general-1
+      queue: windows-unity-wsl
     env:
       UNITY_DIR: "/mnt/f/unity/2021.3.13f1"
       UNITY_VERSION: "2021.3.13f1"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -604,7 +604,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_VERSION: "2018.4.36f1"
+      UNITY_DIR: "F:\\unity\\2018.4.36f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -626,7 +626,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_VERSION: "2019.4.35f1"
+      UNITY_DIR: "F:\\unity\\2019.4.35f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -648,7 +648,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_VERSION: "2021.3.13f1"
+      UNITY_DIR: "F:\\unity\\2021.3.13f1"
     commands:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -672,7 +672,7 @@ steps:
     agents:
       queue: windows-general-wsl
     env:
-      UNITY_VERSION: "2018.4.36f1"
+      UNITY_DIR: "F:\\unity\2018.4.36f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -688,7 +688,7 @@ steps:
     agents:
       queue: windows-general-wsl
     env:
-      UNITY_VERSION: "2019.4.35f1"
+      UNITY_DIR: "F:\\unity\2019.4.35f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -704,7 +704,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_VERSION: "2021.3.13f1"
+      UNITY_DIR: "F:\\unity\2021.3.13f1"
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -605,6 +605,7 @@ steps:
       queue: win-general-1
     env:
       UNITY_DIR: "/mnt/f/unity/2018.4.36f1"
+      UNITY_VERSION: "2018.4.36f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -627,6 +628,7 @@ steps:
       queue: win-general-1
     env:
       UNITY_DIR: "/mnt/f/unity/2019.4.35f1"
+      UNITY_VERSION: "2019.4.35f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -649,6 +651,7 @@ steps:
       queue: win-general-1
     env:
       UNITY_DIR: "/mnt/f/unity/2021.3.13f1"
+      UNITY_VERSION: "2021.3.13f1"
     commands:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -673,6 +676,7 @@ steps:
       queue: windows-general-wsl
     env:
       UNITY_DIR: "/mnt/f/unity/2018.4.36f1"
+      UNITY_VERSION: "2018.4.36f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -689,6 +693,7 @@ steps:
       queue: windows-general-wsl
     env:
       UNITY_DIR: "/mnt/f/unity/2019.4.35f1"
+      UNITY_VERSION: "2019.4.35f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -705,6 +710,7 @@ steps:
       queue: win-general-1
     env:
       UNITY_DIR: "/mnt/f/unity/2021.3.13f1"
+      UNITY_VERSION: "2021.3.13f1"
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -248,27 +248,27 @@ steps:
         - exit_status: "*"
           limit: 1
 
-#  - label: ':android: Build Android EDM test fixture for Unity 2021'
-#    timeout_in_minutes: 30
-#    key: 'build-edm-fixture-2021'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2021.3.13f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk
-#          - features/scripts/buildEdmFixture.log
-#          - features/scripts/edmImport.log
-#          - features/scripts/enableEdm.log
-#    commands:
-#      - rake test:edm:build
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
+  # - label: ':android: Build Android EDM test fixture for Unity 2021'
+  #   timeout_in_minutes: 30
+  #   key: 'build-edm-fixture-2021'
+  #   depends_on: 'build-artifacts'
+  #   env:
+  #     UNITY_VERSION: "2021.3.13f1"
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       download:
+  #         - Bugsnag.unitypackage
+  #       upload:
+  #         - features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk
+  #         - features/scripts/buildEdmFixture.log
+  #         - features/scripts/edmImport.log
+  #         - features/scripts/enableEdm.log
+  #   commands:
+  #     - rake test:edm:build
+  #   retry:
+  #     automatic:
+  #       - exit_status: "*"
+  #         limit: 1
 
   #
   # Run Android tests
@@ -348,30 +348,30 @@ steps:
     concurrency_group: browserstack-app
     concurrency_method: eager
 
-#  - label: ':android: Run Android EDM e2e tests for Unity 2021'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-edm-fixture-2021'
-#    agents:
-#      queue: opensource
-#    env:
-#      UNITY_VERSION: "2021.3.13f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
-#          - "--farm=bs"
-#          - "--device=ANDROID_11_0"
-#          - "features/edm"
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
+  # - label: ':android: Run Android EDM e2e tests for Unity 2021'
+  #   timeout_in_minutes: 60
+  #   depends_on: 'build-edm-fixture-2021'
+  #   agents:
+  #     queue: opensource
+  #   env:
+  #     UNITY_VERSION: "2021.3.13f1"
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       download:
+  #         - "features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
+  #       upload:
+  #         - "maze_output/**/*"
+  #     docker-compose#v3.7.0:
+  #       pull: maze-runner
+  #       run: maze-runner
+  #       command:
+  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
+  #         - "--farm=bs"
+  #         - "--device=ANDROID_11_0"
+  #         - "features/edm"
+  #   concurrency: 24
+  #   concurrency_group: browserstack-app
+  #   concurrency_method: eager
 
   #
   # Build iOS test fixtures

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -604,7 +604,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_DIR: "F:\\unity\\2018.4.36f1"
+      UNITY_DIR: "/mnt/f/unity/2018.4.36f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -626,7 +626,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_DIR: "F:\\unity\\2019.4.35f1"
+      UNITY_DIR: "/mnt/f/unity/2019.4.35f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -648,7 +648,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_DIR: "F:\\unity\\2021.3.13f1"
+      UNITY_DIR: "/mnt/f/unity/2021.3.13f1"
     commands:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -672,7 +672,7 @@ steps:
     agents:
       queue: windows-general-wsl
     env:
-      UNITY_DIR: "F:\\unity\2018.4.36f1"
+      UNITY_DIR: "/mnt/f/unity/2018.4.36f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -688,7 +688,7 @@ steps:
     agents:
       queue: windows-general-wsl
     env:
-      UNITY_DIR: "F:\\unity\2019.4.35f1"
+      UNITY_DIR: "/mnt/f/unity/2019.4.35f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -704,7 +704,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_DIR: "F:\\unity\2021.3.13f1"
+      UNITY_DIR: "/mnt/f/unity/2021.3.13f1"
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -646,9 +646,9 @@ steps:
     key: 'windows-2021-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: windows-unity-wsl
+      queue: win-general-1-wsl
     env:
-      UNITY_VERSION: "2021.3.3f1"
+      UNITY_VERSION: "2021.3.13f1"
     commands:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:
@@ -657,7 +657,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - unity.log
-          - features/fixtures/maze_runner/build/Windows-2021.3.3f1.zip
+          - features/fixtures/maze_runner/build/Windows-2021.3.13f1.zip
     retry:
       automatic:
         - exit_status: "*"
@@ -702,13 +702,13 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'windows-2021-fixture'
     agents:
-      queue: windows-general-wsl
+      queue: win-general-1-wsl
     env:
-      UNITY_VERSION: "2021.3.3f1"
+      UNITY_VERSION: "2021.3.13f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - features/fixtures/maze_runner/build/Windows-2021.3.3f1.zip
+          - features/fixtures/maze_runner/build/Windows-2021.3.13f1.zip
         upload:
           - maze_output/**/*
     commands:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -248,27 +248,27 @@ steps:
         - exit_status: "*"
           limit: 1
 
-   - label: ':android: Build Android EDM test fixture for Unity 2021'
-     timeout_in_minutes: 30
-     key: 'build-edm-fixture-2021'
-     depends_on: 'build-artifacts'
-     env:
-       UNITY_VERSION: "2021.3.13f1"
-     plugins:
-       artifacts#v1.5.0:
-         download:
-           - Bugsnag.unitypackage
-         upload:
-           - features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk
-           - features/scripts/buildEdmFixture.log
-           - features/scripts/edmImport.log
-           - features/scripts/enableEdm.log
-     commands:
-       - rake test:edm:build
-     retry:
-       automatic:
-         - exit_status: "*"
-           limit: 1
+  - label: ':android: Build Android EDM test fixture for Unity 2021'
+    timeout_in_minutes: 30
+    key: 'build-edm-fixture-2021'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2021.3.13f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk
+          - features/scripts/buildEdmFixture.log
+          - features/scripts/edmImport.log
+          - features/scripts/enableEdm.log
+    commands:
+      - rake test:edm:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
   #
   # Run Android tests
@@ -348,30 +348,30 @@ steps:
     concurrency_group: browserstack-app
     concurrency_method: eager
 
-   - label: ':android: Run Android EDM e2e tests for Unity 2021'
-     timeout_in_minutes: 60
-     depends_on: 'build-edm-fixture-2021'
-     agents:
-       queue: opensource
-     env:
-       UNITY_VERSION: "2021.3.13f1"
-     plugins:
-       artifacts#v1.5.0:
-         download:
-           - "features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
-         upload:
-           - "maze_output/**/*"
-       docker-compose#v3.7.0:
-         pull: maze-runner
-         run: maze-runner
-         command:
-           - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
-           - "--farm=bs"
-           - "--device=ANDROID_11_0"
-           - "features/edm"
-     concurrency: 24
-     concurrency_group: browserstack-app
-     concurrency_method: eager
+  - label: ':android: Run Android EDM e2e tests for Unity 2021'
+    timeout_in_minutes: 60
+    depends_on: 'build-edm-fixture-2021'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2021.3.13f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_11_0"
+          - "features/edm"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
 
   #
   # Build iOS test fixtures

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -135,39 +135,39 @@ steps:
   #
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
   #
-#  - label: Run WebGL e2e tests for Unity 2018
-#    timeout_in_minutes: 30
-#    depends_on: 'cocoa-webgl-2018-fixtures'
-#    agents:
-#      queue: opensource-mac-cocoa-11
-#    env:
-#      UNITY_VERSION: "2018.4.36f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
-#        upload:
-#          - maze_output/**/*
-#    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-#    commands:
-#      - scripts/ci-run-webgl-tests.sh
-#
-#  - label: Run WebGL e2e tests for Unity 2019
-#    timeout_in_minutes: 30
-#    depends_on: 'cocoa-webgl-2019-fixtures'
-#    agents:
-#      queue: opensource-mac-cocoa-11
-#    env:
-#      UNITY_VERSION: "2019.4.35f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
-#        upload:
-#          - maze_output/**/*
-#    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-#    commands:
-#      - scripts/ci-run-webgl-tests.sh
+  - label: Run WebGL e2e tests for Unity 2018
+    timeout_in_minutes: 30
+    depends_on: 'cocoa-webgl-2018-fixtures'
+    agents:
+      queue: opensource-mac-cocoa-11
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
+        upload:
+          - maze_output/**/*
+    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+    commands:
+      - scripts/ci-run-webgl-tests.sh
+
+  - label: Run WebGL e2e tests for Unity 2019
+    timeout_in_minutes: 30
+    depends_on: 'cocoa-webgl-2019-fixtures'
+    agents:
+      queue: opensource-mac-cocoa-11
+    env:
+      UNITY_VERSION: "2019.4.35f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
+        upload:
+          - maze_output/**/*
+    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+    commands:
+      - scripts/ci-run-webgl-tests.sh
 
   # DISABLED Pending PLAT-9177
   # - label: Run WebGL e2e tests for Unity 2021
@@ -248,27 +248,27 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':android: Build Android EDM test fixture for Unity 2021'
-    timeout_in_minutes: 30
-    key: 'build-edm-fixture-2021'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2021.3.13f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk
-          - features/scripts/buildEdmFixture.log
-          - features/scripts/edmImport.log
-          - features/scripts/enableEdm.log
-    commands:
-      - rake test:edm:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+#  - label: ':android: Build Android EDM test fixture for Unity 2021'
+#    timeout_in_minutes: 30
+#    key: 'build-edm-fixture-2021'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2021.3.13f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk
+#          - features/scripts/buildEdmFixture.log
+#          - features/scripts/edmImport.log
+#          - features/scripts/enableEdm.log
+#    commands:
+#      - rake test:edm:build
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
 
   #
   # Run Android tests
@@ -348,30 +348,30 @@ steps:
     concurrency_group: browserstack-app
     concurrency_method: eager
 
-  - label: ':android: Run Android EDM e2e tests for Unity 2021'
-    timeout_in_minutes: 60
-    depends_on: 'build-edm-fixture-2021'
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: "2021.3.13f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
-          - "features/edm"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
+#  - label: ':android: Run Android EDM e2e tests for Unity 2021'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-edm-fixture-2021'
+#    agents:
+#      queue: opensource
+#    env:
+#      UNITY_VERSION: "2021.3.13f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
+#          - "--farm=bs"
+#          - "--device=ANDROID_11_0"
+#          - "features/edm"
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
 
   #
   # Build iOS test fixtures

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -627,6 +627,7 @@ steps:
       queue: win-general-1
     env:
       UNITY_VERSION: "2019.4.35f1"
+      UNITY_DIR: "F:\unity\2019.4.35f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -5,112 +5,112 @@ steps:
 
   # Build MacOS and WebGL test fixtures
   #
-#  - label: Build Unity 2018 MacOS and WebGL test fixtures
-#    timeout_in_minutes: 30
-#    key: 'cocoa-webgl-2018-fixtures'
-#    depends_on: 'build-artifacts'
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2018.4.36f1"
-#      # Python2 needed for WebGL to build
-#      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#    commands:
-#      - scripts/ci-build-macos-packages.sh
-#    artifact_paths:
-#      - unity.log
-#      - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
-#      - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: Build Unity 2019 MacOS and WebGL test fixtures
-#    timeout_in_minutes: 30
-#    key: 'cocoa-webgl-2019-fixtures'
-#    depends_on: 'build-artifacts'
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2019.4.35f1"
-#      # Python2 needed for WebGL to build
-#      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#    commands:
-#      - scripts/ci-build-macos-packages.sh
-#    artifact_paths:
-#      - unity.log
-#      - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
-#      - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: Build Unity 2021 MacOS and WebGL test fixtures
-#    timeout_in_minutes: 30
-#    key: 'cocoa-webgl-2021-fixtures'
-#    depends_on: 'build-artifacts'
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2021.3.13f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#    commands:
-#      - scripts/ci-build-macos-packages.sh
-#    artifact_paths:
-#      - unity.log
-#      - features/fixtures/maze_runner/build/MacOS-2021.3.13f1.zip
-#      - features/fixtures/maze_runner/build/WebGL-2021.3.13f1.zip
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  #
-#  # Run macOS desktop tests
-#  #
-#  - label: Run MacOS e2e tests for Unity 2018
-#    timeout_in_minutes: 60
-#    depends_on: 'cocoa-webgl-2018-fixtures'
-#    agents:
-#      queue: macos-12-arm-unity
-#    env:
-#      UNITY_VERSION: "2018.4.36f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
-#        upload:
-#          - maze_output/**/*
-#          - Mazerunner.log
-#    commands:
-#      - scripts/ci-run-macos-tests-csharp.sh
-#
-#  - label: Run MacOS e2e tests for Unity 2019
-#    timeout_in_minutes: 60
-#    depends_on: 'cocoa-webgl-2019-fixtures'
-#    agents:
-#      queue: macos-12-arm-unity
-#    env:
-#      UNITY_VERSION: "2019.4.35f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
-#        upload:
-#          - maze_output/**/*
-#          - Mazerunner.log
-#    commands:
-#      - scripts/ci-run-macos-tests-csharp.sh
+  - label: Build Unity 2018 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
+    key: 'cocoa-webgl-2018-fixtures'
+    depends_on: 'build-artifacts'
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2018.4.36f1"
+      # Python2 needed for WebGL to build
+      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+    commands:
+      - scripts/ci-build-macos-packages.sh
+    artifact_paths:
+      - unity.log
+      - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: Build Unity 2019 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
+    key: 'cocoa-webgl-2019-fixtures'
+    depends_on: 'build-artifacts'
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2019.4.35f1"
+      # Python2 needed for WebGL to build
+      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+    commands:
+      - scripts/ci-build-macos-packages.sh
+    artifact_paths:
+      - unity.log
+      - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: Build Unity 2021 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
+    key: 'cocoa-webgl-2021-fixtures'
+    depends_on: 'build-artifacts'
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2021.3.13f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+    commands:
+      - scripts/ci-build-macos-packages.sh
+    artifact_paths:
+      - unity.log
+      - features/fixtures/maze_runner/build/MacOS-2021.3.13f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2021.3.13f1.zip
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  #
+  # Run macOS desktop tests
+  #
+  - label: Run MacOS e2e tests for Unity 2018
+    timeout_in_minutes: 60
+    depends_on: 'cocoa-webgl-2018-fixtures'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
+        upload:
+          - maze_output/**/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-macos-tests-csharp.sh
+
+  - label: Run MacOS e2e tests for Unity 2019
+    timeout_in_minutes: 60
+    depends_on: 'cocoa-webgl-2019-fixtures'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      UNITY_VERSION: "2019.4.35f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
+        upload:
+          - maze_output/**/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-macos-tests-csharp.sh
 
       # DISABLED Pending PLAT-9177
   # - label: Run MacOS e2e tests for Unity 2021
@@ -169,7 +169,7 @@ steps:
 #    commands:
 #      - scripts/ci-run-webgl-tests.sh
 
-      # DISABLED Pending PLAT-9177
+  # DISABLED Pending PLAT-9177
   # - label: Run WebGL e2e tests for Unity 2021
   #   timeout_in_minutes: 30
   #   depends_on: 'cocoa-webgl-2021-fixtures'
@@ -188,411 +188,411 @@ steps:
   #
   # Build Android test fixtures
   #
-#  - label: ':android: Build Android test fixture for Unity 2018'
-#    timeout_in_minutes: 30
-#    key: 'build-android-fixture-2018'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2018.4.36f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk
-#          - features/fixtures/unity.log
-#    commands:
-#      - rake test:android:build
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':android: Build Android test fixture for Unity 2019'
-#    timeout_in_minutes: 30
-#    key: 'build-android-fixture-2019'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2019.4.35f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk
-#          - features/fixtures/unity.log
-#    commands:
-#      - rake test:android:build
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':android: Build Android test fixture for Unity 2021'
-#    timeout_in_minutes: 30
-#    key: 'build-android-fixture-2021'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2021.3.13f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk
-#          - features/fixtures/unity.log
-#    commands:
-#      - rake test:android:build
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
+  - label: ':android: Build Android test fixture for Unity 2018'
+    timeout_in_minutes: 30
+    key: 'build-android-fixture-2018'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk
+          - features/fixtures/unity.log
+    commands:
+      - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
-  # - label: ':android: Build Android EDM test fixture for Unity 2021'
-  #   timeout_in_minutes: 30
-  #   key: 'build-edm-fixture-2021'
-  #   depends_on: 'build-artifacts'
-  #   env:
-  #     UNITY_VERSION: "2021.3.13f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - Bugsnag.unitypackage
-  #       upload:
-  #         - features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk
-  #         - features/scripts/buildEdmFixture.log
-  #         - features/scripts/edmImport.log
-  #         - features/scripts/enableEdm.log
-  #   commands:
-  #     - rake test:edm:build
-  #   retry:
-  #     automatic:
-  #       - exit_status: "*"
-  #         limit: 1
+  - label: ':android: Build Android test fixture for Unity 2019'
+    timeout_in_minutes: 30
+    key: 'build-android-fixture-2019'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2019.4.35f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk
+          - features/fixtures/unity.log
+    commands:
+      - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':android: Build Android test fixture for Unity 2021'
+    timeout_in_minutes: 30
+    key: 'build-android-fixture-2021'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2021.3.13f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk
+          - features/fixtures/unity.log
+    commands:
+      - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+   - label: ':android: Build Android EDM test fixture for Unity 2021'
+     timeout_in_minutes: 30
+     key: 'build-edm-fixture-2021'
+     depends_on: 'build-artifacts'
+     env:
+       UNITY_VERSION: "2021.3.13f1"
+     plugins:
+       artifacts#v1.5.0:
+         download:
+           - Bugsnag.unitypackage
+         upload:
+           - features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk
+           - features/scripts/buildEdmFixture.log
+           - features/scripts/edmImport.log
+           - features/scripts/enableEdm.log
+     commands:
+       - rake test:edm:build
+     retry:
+       automatic:
+         - exit_status: "*"
+           limit: 1
 
   #
   # Run Android tests
   #
-#  - label: ':android: Run Android e2e tests for Unity 2018'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-android-fixture-2018'
-#    agents:
-#      queue: opensource
-#    env:
-#      UNITY_VERSION: "2018.4.36f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
-#          - "--farm=bs"
-#          - "--device=ANDROID_11_0"
-#          - "features/csharp"
-#          - "features/android"
-#
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
-#
-#  - label: ':android: Run Android e2e tests for Unity 2019'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-android-fixture-2019'
-#    agents:
-#      queue: opensource
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
-#          - "--farm=bs"
-#          - "--device=ANDROID_11_0"
-#          - "features/csharp"
-#          - "features/android"
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
-#
-#  - label: ':android: Run Android e2e tests for Unity 2021'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-android-fixture-2021'
-#    agents:
-#      queue: opensource
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
-#          - "--farm=bs"
-#          - "--device=ANDROID_11_0"
-#          - "features/csharp"
-#          - "features/android"
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
+  - label: ':android: Run Android e2e tests for Unity 2018'
+    timeout_in_minutes: 60
+    depends_on: 'build-android-fixture-2018'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_11_0"
+          - "features/csharp"
+          - "features/android"
 
-  # - label: ':android: Run Android EDM e2e tests for Unity 2021'
-  #   timeout_in_minutes: 60
-  #   depends_on: 'build-edm-fixture-2021'
-  #   agents:
-  #     queue: opensource
-  #   env:
-  #     UNITY_VERSION: "2021.3.13f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - "features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
-  #       upload:
-  #         - "maze_output/**/*"
-  #     docker-compose#v3.7.0:
-  #       pull: maze-runner
-  #       run: maze-runner
-  #       command:
-  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
-  #         - "--farm=bs"
-  #         - "--device=ANDROID_11_0"
-  #         - "features/edm"
-  #   concurrency: 24
-  #   concurrency_group: browserstack-app
-  #   concurrency_method: eager
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+
+  - label: ':android: Run Android e2e tests for Unity 2019'
+    timeout_in_minutes: 60
+    depends_on: 'build-android-fixture-2019'
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_11_0"
+          - "features/csharp"
+          - "features/android"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+
+  - label: ':android: Run Android e2e tests for Unity 2021'
+    timeout_in_minutes: 60
+    depends_on: 'build-android-fixture-2021'
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_11_0"
+          - "features/csharp"
+          - "features/android"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+
+   - label: ':android: Run Android EDM e2e tests for Unity 2021'
+     timeout_in_minutes: 60
+     depends_on: 'build-edm-fixture-2021'
+     agents:
+       queue: opensource
+     env:
+       UNITY_VERSION: "2021.3.13f1"
+     plugins:
+       artifacts#v1.5.0:
+         download:
+           - "features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
+         upload:
+           - "maze_output/**/*"
+       docker-compose#v3.7.0:
+         pull: maze-runner
+         run: maze-runner
+         command:
+           - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.13f1.apk"
+           - "--farm=bs"
+           - "--device=ANDROID_11_0"
+           - "features/edm"
+     concurrency: 24
+     concurrency_group: browserstack-app
+     concurrency_method: eager
 
   #
   # Build iOS test fixtures
   #
-#  - label: ':ios: Generate Xcode project - Unity 2018'
-#    timeout_in_minutes: 30
-#    key: 'generate-fixture-project-2018'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2018.4.36f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/unity.log
-#          - project_2018.tgz
-#    commands:
-#      - rake test:ios:generate_xcode
-#      - tar -zvcf project_2018.tgz  features/fixtures/maze_runner/mazerunner_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':ios: Build iOS test fixture for Unity 2018'
-#    timeout_in_minutes: 30
-#    key: 'build-ios-fixture-2018'
-#    depends_on: 'generate-fixture-project-2018'
-#    agents:
-#      queue: macos-12-arm-unity
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2018.4.36f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#          - project_2018.tgz
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa
-#          - features/fixtures/unity.log
-#    commands:
-#      - tar -zxf project_2018.tgz features/fixtures/maze_runner
-#      - rake test:ios:build_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':ios: Generate Xcode project - Unity 2019'
-#    timeout_in_minutes: 30
-#    key: 'generate-fixture-project-2019'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2019.4.35f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/unity.log
-#          - project_2019.tgz
-#    commands:
-#      - rake test:ios:generate_xcode
-#      - tar -zvcf project_2019.tgz features/fixtures/maze_runner/mazerunner_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':ios: Build iOS test fixture for Unity 2019'
-#    timeout_in_minutes: 30
-#    key: 'build-ios-fixture-2019'
-#    depends_on: 'generate-fixture-project-2019'
-#    agents:
-#      queue: macos-12-arm-unity
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2019.4.35f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#          - project_2019.tgz
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa
-#          - features/fixtures/unity.log
-#    commands:
-#      - tar -zxf project_2019.tgz features/fixtures/maze_runner
-#      - rake test:ios:build_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':ios: Generate Xcode project - Unity 2021'
-#    timeout_in_minutes: 30
-#    key: 'generate-fixture-project-2021'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2021.3.13f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/unity.log
-#          - project_2021.tgz
-#    commands:
-#      - rake test:ios:generate_xcode
-#      - tar -zvcf project_2021.tgz features/fixtures/maze_runner/mazerunner_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':ios: Build iOS test fixture for Unity 2021'
-#    timeout_in_minutes: 30
-#    key: 'build-ios-fixture-2021'
-#    depends_on: 'generate-fixture-project-2021'
-#    agents:
-#      queue: macos-12-arm-unity
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2021.3.13f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#          - project_2021.tgz
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa
-#          - features/fixtures/unity.log
-#    commands:
-#      - tar -zxf project_2021.tgz features/fixtures/maze_runner
-#      - rake test:ios:build_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
+  - label: ':ios: Generate Xcode project - Unity 2018'
+    timeout_in_minutes: 30
+    key: 'generate-fixture-project-2018'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/unity.log
+          - project_2018.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2018.tgz  features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Build iOS test fixture for Unity 2018'
+    timeout_in_minutes: 30
+    key: 'build-ios-fixture-2018'
+    depends_on: 'generate-fixture-project-2018'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2018.4.36f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+          - project_2018.tgz
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa
+          - features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2018.tgz features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Generate Xcode project - Unity 2019'
+    timeout_in_minutes: 30
+    key: 'generate-fixture-project-2019'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2019.4.35f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/unity.log
+          - project_2019.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2019.tgz features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Build iOS test fixture for Unity 2019'
+    timeout_in_minutes: 30
+    key: 'build-ios-fixture-2019'
+    depends_on: 'generate-fixture-project-2019'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2019.4.35f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+          - project_2019.tgz
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa
+          - features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2019.tgz features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Generate Xcode project - Unity 2021'
+    timeout_in_minutes: 30
+    key: 'generate-fixture-project-2021'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2021.3.13f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/unity.log
+          - project_2021.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2021.tgz features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Build iOS test fixture for Unity 2021'
+    timeout_in_minutes: 30
+    key: 'build-ios-fixture-2021'
+    depends_on: 'generate-fixture-project-2021'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2021.3.13f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+          - project_2021.tgz
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa
+          - features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2021.tgz features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
   #
   # Run iOS tests
   #
-#  - label: ':ios: Run iOS e2e tests for Unity 2018'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-ios-fixture-2018'
-#    agents:
-#      queue: opensource
-#    env:
-#      UNITY_VERSION: "2018.4.36f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
-#          - "--farm=bs"
-#          - "--device=IOS_15"
-#          - "--fail-fast"
-#          - "features/csharp"
-#          - "features/ios"
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
-#
-#  - label: ':ios: Run iOS e2e tests for Unity 2019'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-ios-fixture-2019'
-#    agents:
-#      queue: opensource
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
-#          - "--farm=bs"
-#          - "--device=IOS_15"
-#          - "--fail-fast"
-#          - "features/csharp"
-#          - "features/ios"
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
-#
-#  - label: ':ios: Run iOS e2e tests for Unity 2021'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-ios-fixture-2021'
-#    agents:
-#      queue: opensource
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa"
-#          - "--farm=bs"
-#          - "--device=IOS_15"
-#          - "--fail-fast"
-#          - "features/csharp"
-#          - "features/ios"
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
+  - label: ':ios: Run iOS e2e tests for Unity 2018'
+    timeout_in_minutes: 60
+    depends_on: 'build-ios-fixture-2018'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
+          - "--farm=bs"
+          - "--device=IOS_15"
+          - "--fail-fast"
+          - "features/csharp"
+          - "features/ios"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+
+  - label: ':ios: Run iOS e2e tests for Unity 2019'
+    timeout_in_minutes: 60
+    depends_on: 'build-ios-fixture-2019'
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
+          - "--farm=bs"
+          - "--device=IOS_15"
+          - "--fail-fast"
+          - "features/csharp"
+          - "features/ios"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+
+  - label: ':ios: Run iOS e2e tests for Unity 2021'
+    timeout_in_minutes: 60
+    depends_on: 'build-ios-fixture-2021'
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa"
+          - "--farm=bs"
+          - "--device=IOS_15"
+          - "--fail-fast"
+          - "features/csharp"
+          - "features/ios"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
 
   #
   # Build Windows test fixtures

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -627,7 +627,6 @@ steps:
       queue: win-general-1
     env:
       UNITY_VERSION: "2019.4.35f1"
-      UNITY_DIR: "F:\unity\2019.4.35f1"
     command:
       - scripts/ci-build-windows-fixture-wsl.sh
     plugins:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -5,112 +5,112 @@ steps:
 
   # Build MacOS and WebGL test fixtures
   #
-  - label: Build Unity 2018 MacOS and WebGL test fixtures
-    timeout_in_minutes: 30
-    key: 'cocoa-webgl-2018-fixtures'
-    depends_on: 'build-artifacts'
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2018.4.36f1"
-      # Python2 needed for WebGL to build
-      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-    commands:
-      - scripts/ci-build-macos-packages.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: Build Unity 2019 MacOS and WebGL test fixtures
-    timeout_in_minutes: 30
-    key: 'cocoa-webgl-2019-fixtures'
-    depends_on: 'build-artifacts'
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2019.4.35f1"
-      # Python2 needed for WebGL to build
-      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-    commands:
-      - scripts/ci-build-macos-packages.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: Build Unity 2021 MacOS and WebGL test fixtures
-    timeout_in_minutes: 30
-    key: 'cocoa-webgl-2021-fixtures'
-    depends_on: 'build-artifacts'
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2021.3.13f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-    commands:
-      - scripts/ci-build-macos-packages.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2021.3.13f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2021.3.13f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  #
-  # Run macOS desktop tests
-  #
-  - label: Run MacOS e2e tests for Unity 2018
-    timeout_in_minutes: 60
-    depends_on: 'cocoa-webgl-2018-fixtures'
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      UNITY_VERSION: "2018.4.36f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
-        upload:
-          - maze_output/**/*
-          - Mazerunner.log
-    commands:
-      - scripts/ci-run-macos-tests-csharp.sh
-
-  - label: Run MacOS e2e tests for Unity 2019
-    timeout_in_minutes: 60
-    depends_on: 'cocoa-webgl-2019-fixtures'
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      UNITY_VERSION: "2019.4.35f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
-        upload:
-          - maze_output/**/*
-          - Mazerunner.log
-    commands:
-      - scripts/ci-run-macos-tests-csharp.sh
+#  - label: Build Unity 2018 MacOS and WebGL test fixtures
+#    timeout_in_minutes: 30
+#    key: 'cocoa-webgl-2018-fixtures'
+#    depends_on: 'build-artifacts'
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2018.4.36f1"
+#      # Python2 needed for WebGL to build
+#      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#    commands:
+#      - scripts/ci-build-macos-packages.sh
+#    artifact_paths:
+#      - unity.log
+#      - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
+#      - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: Build Unity 2019 MacOS and WebGL test fixtures
+#    timeout_in_minutes: 30
+#    key: 'cocoa-webgl-2019-fixtures'
+#    depends_on: 'build-artifacts'
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2019.4.35f1"
+#      # Python2 needed for WebGL to build
+#      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#    commands:
+#      - scripts/ci-build-macos-packages.sh
+#    artifact_paths:
+#      - unity.log
+#      - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
+#      - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: Build Unity 2021 MacOS and WebGL test fixtures
+#    timeout_in_minutes: 30
+#    key: 'cocoa-webgl-2021-fixtures'
+#    depends_on: 'build-artifacts'
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2021.3.13f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#    commands:
+#      - scripts/ci-build-macos-packages.sh
+#    artifact_paths:
+#      - unity.log
+#      - features/fixtures/maze_runner/build/MacOS-2021.3.13f1.zip
+#      - features/fixtures/maze_runner/build/WebGL-2021.3.13f1.zip
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  #
+#  # Run macOS desktop tests
+#  #
+#  - label: Run MacOS e2e tests for Unity 2018
+#    timeout_in_minutes: 60
+#    depends_on: 'cocoa-webgl-2018-fixtures'
+#    agents:
+#      queue: macos-12-arm-unity
+#    env:
+#      UNITY_VERSION: "2018.4.36f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
+#        upload:
+#          - maze_output/**/*
+#          - Mazerunner.log
+#    commands:
+#      - scripts/ci-run-macos-tests-csharp.sh
+#
+#  - label: Run MacOS e2e tests for Unity 2019
+#    timeout_in_minutes: 60
+#    depends_on: 'cocoa-webgl-2019-fixtures'
+#    agents:
+#      queue: macos-12-arm-unity
+#    env:
+#      UNITY_VERSION: "2019.4.35f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
+#        upload:
+#          - maze_output/**/*
+#          - Mazerunner.log
+#    commands:
+#      - scripts/ci-run-macos-tests-csharp.sh
 
       # DISABLED Pending PLAT-9177
   # - label: Run MacOS e2e tests for Unity 2021
@@ -135,39 +135,39 @@ steps:
   #
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
   #
-  - label: Run WebGL e2e tests for Unity 2018
-    timeout_in_minutes: 30
-    depends_on: 'cocoa-webgl-2018-fixtures'
-    agents:
-      queue: opensource-mac-cocoa-11
-    env:
-      UNITY_VERSION: "2018.4.36f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
-        upload:
-          - maze_output/**/*
-    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-    commands:
-      - scripts/ci-run-webgl-tests.sh
-
-  - label: Run WebGL e2e tests for Unity 2019
-    timeout_in_minutes: 30
-    depends_on: 'cocoa-webgl-2019-fixtures'
-    agents:
-      queue: opensource-mac-cocoa-11
-    env:
-      UNITY_VERSION: "2019.4.35f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
-        upload:
-          - maze_output/**/*
-    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-    commands:
-      - scripts/ci-run-webgl-tests.sh
+#  - label: Run WebGL e2e tests for Unity 2018
+#    timeout_in_minutes: 30
+#    depends_on: 'cocoa-webgl-2018-fixtures'
+#    agents:
+#      queue: opensource-mac-cocoa-11
+#    env:
+#      UNITY_VERSION: "2018.4.36f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
+#        upload:
+#          - maze_output/**/*
+#    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+#    commands:
+#      - scripts/ci-run-webgl-tests.sh
+#
+#  - label: Run WebGL e2e tests for Unity 2019
+#    timeout_in_minutes: 30
+#    depends_on: 'cocoa-webgl-2019-fixtures'
+#    agents:
+#      queue: opensource-mac-cocoa-11
+#    env:
+#      UNITY_VERSION: "2019.4.35f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
+#        upload:
+#          - maze_output/**/*
+#    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+#    commands:
+#      - scripts/ci-run-webgl-tests.sh
 
       # DISABLED Pending PLAT-9177
   # - label: Run WebGL e2e tests for Unity 2021
@@ -188,65 +188,65 @@ steps:
   #
   # Build Android test fixtures
   #
-  - label: ':android: Build Android test fixture for Unity 2018'
-    timeout_in_minutes: 30
-    key: 'build-android-fixture-2018'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2018.4.36f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk
-          - features/fixtures/unity.log
-    commands:
-      - rake test:android:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':android: Build Android test fixture for Unity 2019'
-    timeout_in_minutes: 30
-    key: 'build-android-fixture-2019'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2019.4.35f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk
-          - features/fixtures/unity.log
-    commands:
-      - rake test:android:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':android: Build Android test fixture for Unity 2021'
-    timeout_in_minutes: 30
-    key: 'build-android-fixture-2021'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2021.3.13f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk
-          - features/fixtures/unity.log
-    commands:
-      - rake test:android:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+#  - label: ':android: Build Android test fixture for Unity 2018'
+#    timeout_in_minutes: 30
+#    key: 'build-android-fixture-2018'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2018.4.36f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk
+#          - features/fixtures/unity.log
+#    commands:
+#      - rake test:android:build
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':android: Build Android test fixture for Unity 2019'
+#    timeout_in_minutes: 30
+#    key: 'build-android-fixture-2019'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2019.4.35f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk
+#          - features/fixtures/unity.log
+#    commands:
+#      - rake test:android:build
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':android: Build Android test fixture for Unity 2021'
+#    timeout_in_minutes: 30
+#    key: 'build-android-fixture-2021'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2021.3.13f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk
+#          - features/fixtures/unity.log
+#    commands:
+#      - rake test:android:build
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
 
   # - label: ':android: Build Android EDM test fixture for Unity 2021'
   #   timeout_in_minutes: 30
@@ -273,80 +273,80 @@ steps:
   #
   # Run Android tests
   #
-  - label: ':android: Run Android e2e tests for Unity 2018'
-    timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2018'
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: "2018.4.36f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
-          - "features/csharp"
-          - "features/android"
-
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
-
-  - label: ':android: Run Android e2e tests for Unity 2019'
-    timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2019'
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
-          - "features/csharp"
-          - "features/android"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
-
-  - label: ':android: Run Android e2e tests for Unity 2021'
-    timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2021'
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
-          - "features/csharp"
-          - "features/android"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
+#  - label: ':android: Run Android e2e tests for Unity 2018'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-android-fixture-2018'
+#    agents:
+#      queue: opensource
+#    env:
+#      UNITY_VERSION: "2018.4.36f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
+#          - "--farm=bs"
+#          - "--device=ANDROID_11_0"
+#          - "features/csharp"
+#          - "features/android"
+#
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
+#
+#  - label: ':android: Run Android e2e tests for Unity 2019'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-android-fixture-2019'
+#    agents:
+#      queue: opensource
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
+#          - "--farm=bs"
+#          - "--device=ANDROID_11_0"
+#          - "features/csharp"
+#          - "features/android"
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
+#
+#  - label: ':android: Run Android e2e tests for Unity 2021'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-android-fixture-2021'
+#    agents:
+#      queue: opensource
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
+#          - "--farm=bs"
+#          - "--device=ANDROID_11_0"
+#          - "features/csharp"
+#          - "features/android"
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
 
   # - label: ':android: Run Android EDM e2e tests for Unity 2021'
   #   timeout_in_minutes: 60
@@ -376,223 +376,223 @@ steps:
   #
   # Build iOS test fixtures
   #
-  - label: ':ios: Generate Xcode project - Unity 2018'
-    timeout_in_minutes: 30
-    key: 'generate-fixture-project-2018'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2018.4.36f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/unity.log
-          - project_2018.tgz
-    commands:
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2018.tgz  features/fixtures/maze_runner/mazerunner_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':ios: Build iOS test fixture for Unity 2018'
-    timeout_in_minutes: 30
-    key: 'build-ios-fixture-2018'
-    depends_on: 'generate-fixture-project-2018'
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2018.4.36f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-          - project_2018.tgz
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa
-          - features/fixtures/unity.log
-    commands:
-      - tar -zxf project_2018.tgz features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':ios: Generate Xcode project - Unity 2019'
-    timeout_in_minutes: 30
-    key: 'generate-fixture-project-2019'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2019.4.35f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/unity.log
-          - project_2019.tgz
-    commands:
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2019.tgz features/fixtures/maze_runner/mazerunner_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':ios: Build iOS test fixture for Unity 2019'
-    timeout_in_minutes: 30
-    key: 'build-ios-fixture-2019'
-    depends_on: 'generate-fixture-project-2019'
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2019.4.35f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-          - project_2019.tgz
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa
-          - features/fixtures/unity.log
-    commands:
-      - tar -zxf project_2019.tgz features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':ios: Generate Xcode project - Unity 2021'
-    timeout_in_minutes: 30
-    key: 'generate-fixture-project-2021'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2021.3.13f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/unity.log
-          - project_2021.tgz
-    commands:
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2021.tgz features/fixtures/maze_runner/mazerunner_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':ios: Build iOS test fixture for Unity 2021'
-    timeout_in_minutes: 30
-    key: 'build-ios-fixture-2021'
-    depends_on: 'generate-fixture-project-2021'
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2021.3.13f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-          - project_2021.tgz
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa
-          - features/fixtures/unity.log
-    commands:
-      - tar -zxf project_2021.tgz features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+#  - label: ':ios: Generate Xcode project - Unity 2018'
+#    timeout_in_minutes: 30
+#    key: 'generate-fixture-project-2018'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2018.4.36f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/unity.log
+#          - project_2018.tgz
+#    commands:
+#      - rake test:ios:generate_xcode
+#      - tar -zvcf project_2018.tgz  features/fixtures/maze_runner/mazerunner_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':ios: Build iOS test fixture for Unity 2018'
+#    timeout_in_minutes: 30
+#    key: 'build-ios-fixture-2018'
+#    depends_on: 'generate-fixture-project-2018'
+#    agents:
+#      queue: macos-12-arm-unity
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2018.4.36f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#          - project_2018.tgz
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa
+#          - features/fixtures/unity.log
+#    commands:
+#      - tar -zxf project_2018.tgz features/fixtures/maze_runner
+#      - rake test:ios:build_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':ios: Generate Xcode project - Unity 2019'
+#    timeout_in_minutes: 30
+#    key: 'generate-fixture-project-2019'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2019.4.35f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/unity.log
+#          - project_2019.tgz
+#    commands:
+#      - rake test:ios:generate_xcode
+#      - tar -zvcf project_2019.tgz features/fixtures/maze_runner/mazerunner_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':ios: Build iOS test fixture for Unity 2019'
+#    timeout_in_minutes: 30
+#    key: 'build-ios-fixture-2019'
+#    depends_on: 'generate-fixture-project-2019'
+#    agents:
+#      queue: macos-12-arm-unity
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2019.4.35f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#          - project_2019.tgz
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa
+#          - features/fixtures/unity.log
+#    commands:
+#      - tar -zxf project_2019.tgz features/fixtures/maze_runner
+#      - rake test:ios:build_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':ios: Generate Xcode project - Unity 2021'
+#    timeout_in_minutes: 30
+#    key: 'generate-fixture-project-2021'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2021.3.13f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/unity.log
+#          - project_2021.tgz
+#    commands:
+#      - rake test:ios:generate_xcode
+#      - tar -zvcf project_2021.tgz features/fixtures/maze_runner/mazerunner_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':ios: Build iOS test fixture for Unity 2021'
+#    timeout_in_minutes: 30
+#    key: 'build-ios-fixture-2021'
+#    depends_on: 'generate-fixture-project-2021'
+#    agents:
+#      queue: macos-12-arm-unity
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2021.3.13f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#          - project_2021.tgz
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa
+#          - features/fixtures/unity.log
+#    commands:
+#      - tar -zxf project_2021.tgz features/fixtures/maze_runner
+#      - rake test:ios:build_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
 
   #
   # Run iOS tests
   #
-  - label: ':ios: Run iOS e2e tests for Unity 2018'
-    timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2018'
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: "2018.4.36f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
-          - "--farm=bs"
-          - "--device=IOS_15"
-          - "--fail-fast"
-          - "features/csharp"
-          - "features/ios"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
-
-  - label: ':ios: Run iOS e2e tests for Unity 2019'
-    timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2019'
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
-          - "--farm=bs"
-          - "--device=IOS_15"
-          - "--fail-fast"
-          - "features/csharp"
-          - "features/ios"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
-
-  - label: ':ios: Run iOS e2e tests for Unity 2021'
-    timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2021'
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa"
-          - "--farm=bs"
-          - "--device=IOS_15"
-          - "--fail-fast"
-          - "features/csharp"
-          - "features/ios"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
+#  - label: ':ios: Run iOS e2e tests for Unity 2018'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-ios-fixture-2018'
+#    agents:
+#      queue: opensource
+#    env:
+#      UNITY_VERSION: "2018.4.36f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
+#          - "--farm=bs"
+#          - "--device=IOS_15"
+#          - "--fail-fast"
+#          - "features/csharp"
+#          - "features/ios"
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
+#
+#  - label: ':ios: Run iOS e2e tests for Unity 2019'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-ios-fixture-2019'
+#    agents:
+#      queue: opensource
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
+#          - "--farm=bs"
+#          - "--device=IOS_15"
+#          - "--fail-fast"
+#          - "features/csharp"
+#          - "features/ios"
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
+#
+#  - label: ':ios: Run iOS e2e tests for Unity 2021'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-ios-fixture-2021'
+#    agents:
+#      queue: opensource
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.13f1.ipa"
+#          - "--farm=bs"
+#          - "--device=IOS_15"
+#          - "--fail-fast"
+#          - "features/csharp"
+#          - "features/ios"
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
 
   #
   # Build Windows test fixtures
@@ -602,7 +602,7 @@ steps:
     key: 'windows-2018-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: windows-unity-wsl
+      queue: win-general-1-wsl
     env:
       UNITY_VERSION: "2018.4.36f1"
     command:
@@ -624,7 +624,7 @@ steps:
     key: 'windows-2019-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: windows-unity-wsl
+      queue: win-general-1-wsl
     env:
       UNITY_VERSION: "2019.4.35f1"
     command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,251 +45,250 @@ steps:
   #
   # Build MacOS and WebGL test fixtures
   #
-#  - label: Build Unity 2020 MacOS and WebGL test fixtures
-#    timeout_in_minutes: 30
-#    key: 'cocoa-webgl-2020-fixtures'
-#    depends_on: 'build-artifacts'
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2020.3.32f1"
-#      # Python2 needed for WebGL to build
-#      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#    commands:
-#      - scripts/ci-build-macos-packages.sh
-#    artifact_paths:
-#      - unity.log
-#      - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
-#      - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
+  - label: Build Unity 2020 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
+    key: 'cocoa-webgl-2020-fixtures'
+    depends_on: 'build-artifacts'
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2020.3.32f1"
+      # Python2 needed for WebGL to build
+      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+    commands:
+      - scripts/ci-build-macos-packages.sh
+    artifact_paths:
+      - unity.log
+      - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
 
 
   #
   # Run macos tests
   #
-#  - label: Run MacOS e2e csharp tests
-#    timeout_in_minutes: 60
-#    depends_on: 'cocoa-webgl-2020-fixtures'
-#    agents:
-#      queue: macos-12-arm-unity
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
-#        upload:
-#          - maze_output/**/*
-#          - Mazerunner.log
-#    commands:
-#      - scripts/ci-run-macos-tests-csharp.sh
+  - label: Run MacOS e2e csharp tests
+    timeout_in_minutes: 60
+    depends_on: 'cocoa-webgl-2020-fixtures'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
+        upload:
+          - maze_output/**/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-macos-tests-csharp.sh
 
   #
   # Run WebGL tests
   #
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
   
-#  - label: Run WebGL e2e tests for Unity 2020
-#    timeout_in_minutes: 30
-#    depends_on: 'cocoa-webgl-2020-fixtures'
-#    agents:
-#      queue: opensource-mac-cocoa-11
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
-#        upload:
-#          - maze_output/**/*
-#    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-#    commands:
-#      - scripts/ci-run-webgl-tests.sh
+  - label: Run WebGL e2e tests for Unity 2020
+    timeout_in_minutes: 30
+    depends_on: 'cocoa-webgl-2020-fixtures'
+    agents:
+      queue: opensource-mac-cocoa-11
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
+        upload:
+          - maze_output/**/*
+    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+    commands:
+      - scripts/ci-run-webgl-tests.sh
 
   
   # Build Android test fixtures
-#
-#  - label: ':android: Build Android test fixture for Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'build-android-fixture-2020'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
-#          - features/fixtures/unity.log
-#    commands:
-#      - rake test:android:build
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
+  - label: ':android: Build Android test fixture for Unity 2020'
+    timeout_in_minutes: 30
+    key: 'build-android-fixture-2020'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
+          - features/fixtures/unity.log
+    commands:
+      - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
-  # - label: ':android: Build Android EDM test fixture for Unity 2020'
-  #   timeout_in_minutes: 30
-  #   key: 'build-edm-fixture-2020'
-  #   depends_on: 'build-artifacts'
-  #   env:
-  #     UNITY_VERSION: "2020.3.32f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - Bugsnag.unitypackage
-  #       upload:
-  #         - features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk
-  #         - features/scripts/buildEdmFixture.log
-  #         - features/scripts/edmImport.log
-  #         - features/scripts/enableEdm.log
-  #   commands:
-  #     - rake test:edm:build
-  #   retry:
-  #     automatic:
-  #       - exit_status: "*"
-  #         limit: 1
+   - label: ':android: Build Android EDM test fixture for Unity 2020'
+     timeout_in_minutes: 30
+     key: 'build-edm-fixture-2020'
+     depends_on: 'build-artifacts'
+     env:
+       UNITY_VERSION: "2020.3.32f1"
+     plugins:
+       artifacts#v1.5.0:
+         download:
+           - Bugsnag.unitypackage
+         upload:
+           - features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk
+           - features/scripts/buildEdmFixture.log
+           - features/scripts/edmImport.log
+           - features/scripts/enableEdm.log
+     commands:
+       - rake test:edm:build
+     retry:
+       automatic:
+         - exit_status: "*"
+           limit: 1
 
   #
   # Run Android tests
   #
-#  - label: ':android: Run Android e2e tests for Unity 2020'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-android-fixture-2020'
-#    agents:
-#      queue: opensource
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
-#          - "--farm=bs"
-#          - "--device=ANDROID_11_0"
-#          - "features/csharp"
-#          - "features/android"
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
+  - label: ':android: Run Android e2e tests for Unity 2020'
+    timeout_in_minutes: 60
+    depends_on: 'build-android-fixture-2020'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_11_0"
+          - "features/csharp"
+          - "features/android"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
 
 
   # Run Android EDM tests
 
-  # - label: ':android: Run Android EDM e2e tests for Unity 2020'
-  #   timeout_in_minutes: 30
-  #   depends_on: 'build-edm-fixture-2020'
-  #   agents:
-  #     queue: opensource
-  #   env:
-  #     UNITY_VERSION: "2020.3.32f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - "features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
-  #       upload:
-  #         - "maze_output/**/*"
-  #     docker-compose#v3.7.0:
-  #       pull: maze-runner
-  #       run: maze-runner
-  #       command:
-  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
-  #         - "--farm=bs"
-  #         - "--device=ANDROID_11_0"
-  #         - "features/edm"
-  #   concurrency: 24
-  #   concurrency_group: browserstack-app
-  #   concurrency_method: eager
+   - label: ':android: Run Android EDM e2e tests for Unity 2020'
+     timeout_in_minutes: 30
+     depends_on: 'build-edm-fixture-2020'
+     agents:
+       queue: opensource
+     env:
+       UNITY_VERSION: "2020.3.32f1"
+     plugins:
+       artifacts#v1.5.0:
+         download:
+           - "features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
+         upload:
+           - "maze_output/**/*"
+       docker-compose#v3.7.0:
+         pull: maze-runner
+         run: maze-runner
+         command:
+           - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
+           - "--farm=bs"
+           - "--device=ANDROID_11_0"
+           - "features/edm"
+     concurrency: 24
+     concurrency_group: browserstack-app
+     concurrency_method: eager
 
   #
   # Build iOS test fixtures
   #
-#  - label: ':ios: Generate Xcode project - Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'generate-fixture-project-2020'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/unity.log
-#          - project_2020.tgz
-#    commands:
-#      - rake test:ios:generate_xcode
-#      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':ios: Build iOS test fixture for Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'build-ios-fixture-2020'
-#    depends_on: 'generate-fixture-project-2020'
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#          - project_2020.tgz
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa
-#          - features/fixtures/unity.log
-#    commands:
-#      - tar -zxf project_2020.tgz features/fixtures/maze_runner
-#      - rake test:ios:build_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  #
-#  # Run iOS tests
-#  #
-#  - label: ':ios: Run iOS e2e tests for Unity 2020'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-ios-fixture-2020'
-#    agents:
-#      queue: opensource
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
-#          - "--farm=bs"
-#          - "--device=IOS_15"
-#          - "--fail-fast"
-#          - "features/csharp"
-#          - "features/ios"
-#
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
+  - label: ':ios: Generate Xcode project - Unity 2020'
+    timeout_in_minutes: 30
+    key: 'generate-fixture-project-2020'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/unity.log
+          - project_2020.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Build iOS test fixture for Unity 2020'
+    timeout_in_minutes: 30
+    key: 'build-ios-fixture-2020'
+    depends_on: 'generate-fixture-project-2020'
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+          - project_2020.tgz
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa
+          - features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2020.tgz features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  #
+  # Run iOS tests
+  #
+  - label: ':ios: Run iOS e2e tests for Unity 2020'
+    timeout_in_minutes: 60
+    depends_on: 'build-ios-fixture-2020'
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
+          - "--farm=bs"
+          - "--device=IOS_15"
+          - "--fail-fast"
+          - "features/csharp"
+          - "features/ios"
+
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
 
   #
   # Build Windows test fixture

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -301,7 +301,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_VERSION: "2020.3.32f1"
+      UNITY_DIR: "/mnt/f/unity/2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -325,7 +325,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_VERSION: "2020.3.32f1"
+      UNITY_DIR: "/mnt/f/unity/2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,7 +28,7 @@ steps:
       queue: win-general-1
     env:
       UNITY_VERSION: "2018.4.36f1"
-      UNITY_DIR: "F:\unity\2018.4.36f1"
+      UNITY_DIR: "F:\\unity\\2018.4.36f1"
       WSLENV: UNITY_VERSION
     command:
       - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
     env:
 #      UNITY_VERSION: "2018.4.36f1"
       UNITY_DIR: "F:\\unity\\2018.4.36f1"
-      WSLENV: UNITY_VERSION
+      WSLENV: UNITY_DIR
     command:
       - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -135,27 +135,27 @@ steps:
         - exit_status: "*"
           limit: 1
 
-   - label: ':android: Build Android EDM test fixture for Unity 2020'
-     timeout_in_minutes: 30
-     key: 'build-edm-fixture-2020'
-     depends_on: 'build-artifacts'
-     env:
-       UNITY_VERSION: "2020.3.32f1"
-     plugins:
-       artifacts#v1.5.0:
-         download:
-           - Bugsnag.unitypackage
-         upload:
-           - features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk
-           - features/scripts/buildEdmFixture.log
-           - features/scripts/edmImport.log
-           - features/scripts/enableEdm.log
-     commands:
-       - rake test:edm:build
-     retry:
-       automatic:
-         - exit_status: "*"
-           limit: 1
+  - label: ':android: Build Android EDM test fixture for Unity 2020'
+    timeout_in_minutes: 30
+    key: 'build-edm-fixture-2020'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk
+          - features/scripts/buildEdmFixture.log
+          - features/scripts/edmImport.log
+          - features/scripts/enableEdm.log
+    commands:
+      - rake test:edm:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
   #
   # Run Android tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -302,6 +302,7 @@ steps:
       queue: win-general-1
     env:
       UNITY_DIR: "/mnt/f/unity/2020.3.32f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -326,6 +327,7 @@ steps:
       queue: win-general-1
     env:
       UNITY_DIR: "/mnt/f/unity/2020.3.32f1"
+      UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,7 +27,7 @@ steps:
     agents:
       queue: win-general-1
     env:
-      UNITY_VERSION: "2018.4.36f1"
+#      UNITY_VERSION: "2018.4.36f1"
       UNITY_DIR: "F:\\unity\\2018.4.36f1"
       WSLENV: UNITY_VERSION
     command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -135,27 +135,27 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':android: Build Android EDM test fixture for Unity 2020'
-    timeout_in_minutes: 30
-    key: 'build-edm-fixture-2020'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk
-          - features/scripts/buildEdmFixture.log
-          - features/scripts/edmImport.log
-          - features/scripts/enableEdm.log
-    commands:
-      - rake test:edm:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+#  - label: ':android: Build Android EDM test fixture for Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'build-edm-fixture-2020'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk
+#          - features/scripts/buildEdmFixture.log
+#          - features/scripts/edmImport.log
+#          - features/scripts/enableEdm.log
+#    commands:
+#      - rake test:edm:build
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
 
   #
   # Run Android tests
@@ -188,30 +188,30 @@ steps:
 
 
   # Run Android EDM tests
-  - label: ':android: Run Android EDM e2e tests for Unity 2020'
-    timeout_in_minutes: 30
-    depends_on: 'build-edm-fixture-2020'
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
-          - "features/edm"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
+#  - label: ':android: Run Android EDM e2e tests for Unity 2020'
+#    timeout_in_minutes: 30
+#    depends_on: 'build-edm-fixture-2020'
+#    agents:
+#      queue: opensource
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
+#          - "--farm=bs"
+#          - "--device=ANDROID_11_0"
+#          - "features/edm"
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
 
   #
   # Build iOS test fixtures

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
   - label: Ensure notifier builds on Windows (for development)
     timeout_in_minutes: 30
     agents:
-      queue: win-general-1
+      queue: windows-unity-wsl
     env:
 #      UNITY_VERSION: "2018.4.36f1"
       UNITY_DIR: "F:\\unity\\2018.4.36f1"
@@ -297,7 +297,7 @@ steps:
     key: 'windows-2020-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: win-general-1
+      queue: windows-unity-wsl
     env:
       UNITY_DIR: "/mnt/f/unity/2020.3.32f1"
       UNITY_VERSION: "2020.3.32f1"
@@ -322,7 +322,7 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'windows-2020-fixture'
     agents:
-      queue: win-general-1
+      queue: windows-general-wsl
     env:
       UNITY_DIR: "/mnt/f/unity/2020.3.32f1"
       UNITY_VERSION: "2020.3.32f1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -135,27 +135,27 @@ steps:
         - exit_status: "*"
           limit: 1
 
-#  - label: ':android: Build Android EDM test fixture for Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'build-edm-fixture-2020'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk
-#          - features/scripts/buildEdmFixture.log
-#          - features/scripts/edmImport.log
-#          - features/scripts/enableEdm.log
-#    commands:
-#      - rake test:edm:build
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
+  # - label: ':android: Build Android EDM test fixture for Unity 2020'
+  #   timeout_in_minutes: 30
+  #   key: 'build-edm-fixture-2020'
+  #   depends_on: 'build-artifacts'
+  #   env:
+  #     UNITY_VERSION: "2020.3.32f1"
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       download:
+  #         - Bugsnag.unitypackage
+  #       upload:
+  #         - features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk
+  #         - features/scripts/buildEdmFixture.log
+  #         - features/scripts/edmImport.log
+  #         - features/scripts/enableEdm.log
+  #   commands:
+  #     - rake test:edm:build
+  #   retry:
+  #     automatic:
+  #       - exit_status: "*"
+  #         limit: 1
 
   #
   # Run Android tests
@@ -188,30 +188,30 @@ steps:
 
 
   # Run Android EDM tests
-#  - label: ':android: Run Android EDM e2e tests for Unity 2020'
-#    timeout_in_minutes: 30
-#    depends_on: 'build-edm-fixture-2020'
-#    agents:
-#      queue: opensource
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
-#          - "--farm=bs"
-#          - "--device=ANDROID_11_0"
-#          - "features/edm"
-#    concurrency: 24
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
+  # - label: ':android: Run Android EDM e2e tests for Unity 2020'
+  #   timeout_in_minutes: 30
+  #   depends_on: 'build-edm-fixture-2020'
+  #   agents:
+  #     queue: opensource
+  #   env:
+  #     UNITY_VERSION: "2020.3.32f1"
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       download:
+  #         - "features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
+  #       upload:
+  #         - "maze_output/**/*"
+  #     docker-compose#v3.7.0:
+  #       pull: maze-runner
+  #       run: maze-runner
+  #       command:
+  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
+  #         - "--farm=bs"
+  #         - "--device=ANDROID_11_0"
+  #         - "features/edm"
+  #   concurrency: 24
+  #   concurrency_group: browserstack-app
+  #   concurrency_method: eager
 
   #
   # Build iOS test fixtures

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,6 +28,7 @@ steps:
       queue: win-general-1
     env:
       UNITY_VERSION: "2018.4.36f1"
+      UNITY_DIR: "F:\unity\2018.4.36f1"
       WSLENV: UNITY_VERSION
     command:
       - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
   - label: Ensure notifier builds on Windows (for development)
     timeout_in_minutes: 30
     agents:
-      queue: windows-unity-wsl
+      queue: win-general-1-wsl
     env:
       UNITY_VERSION: "2018.4.36f1"
       WSLENV: UNITY_VERSION
@@ -44,96 +44,96 @@ steps:
   #
   # Build MacOS and WebGL test fixtures
   #
-  - label: Build Unity 2020 MacOS and WebGL test fixtures
-    timeout_in_minutes: 30
-    key: 'cocoa-webgl-2020-fixtures'
-    depends_on: 'build-artifacts'
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2020.3.32f1"
-      # Python2 needed for WebGL to build
-      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-    commands:
-      - scripts/ci-build-macos-packages.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+#  - label: Build Unity 2020 MacOS and WebGL test fixtures
+#    timeout_in_minutes: 30
+#    key: 'cocoa-webgl-2020-fixtures'
+#    depends_on: 'build-artifacts'
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2020.3.32f1"
+#      # Python2 needed for WebGL to build
+#      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#    commands:
+#      - scripts/ci-build-macos-packages.sh
+#    artifact_paths:
+#      - unity.log
+#      - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
+#      - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
 
 
 
   #
   # Run macos tests
   #
-  - label: Run MacOS e2e csharp tests
-    timeout_in_minutes: 60
-    depends_on: 'cocoa-webgl-2020-fixtures'
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
-        upload:
-          - maze_output/**/*
-          - Mazerunner.log
-    commands:
-      - scripts/ci-run-macos-tests-csharp.sh
+#  - label: Run MacOS e2e csharp tests
+#    timeout_in_minutes: 60
+#    depends_on: 'cocoa-webgl-2020-fixtures'
+#    agents:
+#      queue: macos-12-arm-unity
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
+#        upload:
+#          - maze_output/**/*
+#          - Mazerunner.log
+#    commands:
+#      - scripts/ci-run-macos-tests-csharp.sh
 
   #
   # Run WebGL tests
   #
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
   
-  - label: Run WebGL e2e tests for Unity 2020
-    timeout_in_minutes: 30
-    depends_on: 'cocoa-webgl-2020-fixtures'
-    agents:
-      queue: opensource-mac-cocoa-11
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
-        upload:
-          - maze_output/**/*
-    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-    commands:
-      - scripts/ci-run-webgl-tests.sh
+#  - label: Run WebGL e2e tests for Unity 2020
+#    timeout_in_minutes: 30
+#    depends_on: 'cocoa-webgl-2020-fixtures'
+#    agents:
+#      queue: opensource-mac-cocoa-11
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
+#        upload:
+#          - maze_output/**/*
+#    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+#    commands:
+#      - scripts/ci-run-webgl-tests.sh
 
   
   # Build Android test fixtures
-  
-  - label: ':android: Build Android test fixture for Unity 2020'
-    timeout_in_minutes: 30
-    key: 'build-android-fixture-2020'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
-          - features/fixtures/unity.log
-    commands:
-      - rake test:android:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+#
+#  - label: ':android: Build Android test fixture for Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'build-android-fixture-2020'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
+#          - features/fixtures/unity.log
+#    commands:
+#      - rake test:android:build
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
 
   # - label: ':android: Build Android EDM test fixture for Unity 2020'
   #   timeout_in_minutes: 30
@@ -160,31 +160,31 @@ steps:
   #
   # Run Android tests
   #
-  - label: ':android: Run Android e2e tests for Unity 2020'
-    timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2020'
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
-          - "features/csharp"
-          - "features/android"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
+#  - label: ':android: Run Android e2e tests for Unity 2020'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-android-fixture-2020'
+#    agents:
+#      queue: opensource
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+#          - "--farm=bs"
+#          - "--device=ANDROID_11_0"
+#          - "features/csharp"
+#          - "features/android"
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
 
 
   # Run Android EDM tests
@@ -217,78 +217,78 @@ steps:
   #
   # Build iOS test fixtures
   #
-  - label: ':ios: Generate Xcode project - Unity 2020'
-    timeout_in_minutes: 30
-    key: 'generate-fixture-project-2020'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/unity.log
-          - project_2020.tgz
-    commands:
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':ios: Build iOS test fixture for Unity 2020'
-    timeout_in_minutes: 30
-    key: 'build-ios-fixture-2020'
-    depends_on: 'generate-fixture-project-2020'
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-          - project_2020.tgz
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa
-          - features/fixtures/unity.log
-    commands:
-      - tar -zxf project_2020.tgz features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  #
-  # Run iOS tests
-  #
-  - label: ':ios: Run iOS e2e tests for Unity 2020'
-    timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2020'
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
-          - "--farm=bs"
-          - "--device=IOS_15"
-          - "--fail-fast"
-          - "features/csharp"
-          - "features/ios"
-
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
+#  - label: ':ios: Generate Xcode project - Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'generate-fixture-project-2020'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/unity.log
+#          - project_2020.tgz
+#    commands:
+#      - rake test:ios:generate_xcode
+#      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':ios: Build iOS test fixture for Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'build-ios-fixture-2020'
+#    depends_on: 'generate-fixture-project-2020'
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#          - project_2020.tgz
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa
+#          - features/fixtures/unity.log
+#    commands:
+#      - tar -zxf project_2020.tgz features/fixtures/maze_runner
+#      - rake test:ios:build_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  #
+#  # Run iOS tests
+#  #
+#  - label: ':ios: Run iOS e2e tests for Unity 2020'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-ios-fixture-2020'
+#    agents:
+#      queue: opensource
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
+#          - "--farm=bs"
+#          - "--device=IOS_15"
+#          - "--fail-fast"
+#          - "features/csharp"
+#          - "features/ios"
+#
+#    concurrency: 24
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
 
   #
   # Build Windows test fixture
@@ -298,7 +298,7 @@ steps:
     key: 'windows-2020-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: windows-unity-wsl
+      queue: win-general-1-wsl
     env:
       UNITY_VERSION: "2020.3.32f1"
     plugins:
@@ -322,7 +322,7 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'windows-2020-fixture'
     agents:
-      queue: windows-general-wsl
+      queue: win-general-1-wsl
     env:
       UNITY_VERSION: "2020.3.32f1"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
   - label: Ensure notifier builds on Windows (for development)
     timeout_in_minutes: 30
     agents:
-      queue: win-general-1-wsl
+      queue: win-general-1
     env:
       UNITY_VERSION: "2018.4.36f1"
       WSLENV: UNITY_VERSION
@@ -298,7 +298,7 @@ steps:
     key: 'windows-2020-fixture'
     depends_on: 'build-artifacts'
     agents:
-      queue: win-general-1-wsl
+      queue: win-general-1
     env:
       UNITY_VERSION: "2020.3.32f1"
     plugins:
@@ -322,7 +322,7 @@ steps:
     timeout_in_minutes: 30
     depends_on: 'windows-2020-fixture'
     agents:
-      queue: win-general-1-wsl
+      queue: win-general-1
     env:
       UNITY_VERSION: "2020.3.32f1"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -188,31 +188,30 @@ steps:
 
 
   # Run Android EDM tests
-
-   - label: ':android: Run Android EDM e2e tests for Unity 2020'
-     timeout_in_minutes: 30
-     depends_on: 'build-edm-fixture-2020'
-     agents:
-       queue: opensource
-     env:
-       UNITY_VERSION: "2020.3.32f1"
-     plugins:
-       artifacts#v1.5.0:
-         download:
-           - "features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
-         upload:
-           - "maze_output/**/*"
-       docker-compose#v3.7.0:
-         pull: maze-runner
-         run: maze-runner
-         command:
-           - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
-           - "--farm=bs"
-           - "--device=ANDROID_11_0"
-           - "features/edm"
-     concurrency: 24
-     concurrency_group: browserstack-app
-     concurrency_method: eager
+  - label: ':android: Run Android EDM e2e tests for Unity 2020'
+    timeout_in_minutes: 30
+    depends_on: 'build-edm-fixture-2020'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.32f1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_11_0"
+          - "features/edm"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
 
   #
   # Build iOS test fixtures

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ def unity_directory
     if is_mac?
     "/Applications/Unity/Hub/Editor/#{ENV['UNITY_VERSION']}"
     elsif is_windows?
-      "F:\\unity\\#{ENV['UNITY_VERSION']}"
+      "C:\\Program Files\\Unity\\Hub\\Editor\\#{ENV['UNITY_VERSION']}"
     end
 
   elsif ENV.has_key? "UNITY_DIR"

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ def unity_directory
     if is_mac?
     "/Applications/Unity/Hub/Editor/#{ENV['UNITY_VERSION']}"
     elsif is_windows?
-      "C:\\Program Files\\Unity\\Hub\\Editor\\#{ENV['UNITY_VERSION']}"
+      "F:\\unity\\#{ENV['UNITY_VERSION']}"
     end
 
   elsif ENV.has_key? "UNITY_DIR"

--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
-if [ -z "$UNITY_VERSION" ] || [ -z "$UNITY_PATH" ]; then
-  echo "UNITY_VERSION or UNITY_PATH must be set."
-  exit 1
+if [ -z "$UNITY_VERSION" ]; then
+  if [ -z "$UNITY_PATH" ]; then
+    echo "UNITY_VERSION or UNITY_PATH must be set."
+    exit 1
+  fi
 fi
 
 if [[ $# != 1 ]]; then

--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 if [ -z "$UNITY_VERSION" ]; then
-  if [ -z "$UNITY_PATH" ]; then
-    echo "UNITY_VERSION or UNITY_PATH must be set."
+  if [ -z "$UNITY_DIR" ]; then
+    echo "UNITY_VERSION or UNITY_DIR must be set."
     exit 1
   fi
 fi
@@ -14,30 +14,38 @@ fi
 
 if [ "$1" == "macos" ]; then
   PLATFORM="MacOS"
-  if [ -z "$UNITY_PATH" ]; then
+  if [ -z "$UNITY_DIR" ]; then
     UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
+  else
+    UNITY_PATH="$UNITY_DIR/Unity.app/Contents/MacOS/Unity"
   fi
 elif [ "$1" == "windows" ]; then
   PLATFORM="Win64"
   set -m
-  if [ -z "$UNITY_PATH" ]; then
+  if [ -z "$UNITY_DIR" ]; then
     UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+  else
+    UNITY_PATH="$UNITY_DIR/Editor/Unity.exe"
   fi
 elif [ "$1" == "wsl" ]; then
   PLATFORM="Win64"
   set -m
-  if [ -z "$UNITY_PATH" ]; then
+  if [ -z "$UNITY_DIR" ]; then
     UNITY_PATH="/mnt/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+  else
+    UNITY_PATH="$UNITY_DIR/Editor/Unity.exe"
   fi
 elif [ "$1" == "webgl" ]; then
   PLATFORM="WebGL"
   if [ "$(uname)" == "Darwin" ]; then
-    if [ -z "$UNITY_PATH" ]; then
+    if [ -z "$UNITY_DIR" ]; then
      UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
     fi
   else
-    if [ -z "$UNITY_PATH" ]; then
+    if [ -z "$UNITY_DIR" ]; then
       UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+    else
+      UNITY_PATH="$UNITY_DIR/Editor/Unity.exe"
     fi
   fi
 else
@@ -67,7 +75,7 @@ pushd $SCRIPT_DIR
       if [ ! -f "$log_file" ]; then
         touch $log_file
       fi
-      
+
       import_log_file=`wslpath -w "$import_log_file"`
       log_file=`wslpath -w "$log_file"`
       package_path=`wslpath -w "$package_path"`

--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-if [ -z "$UNITY_VERSION" ]; then
-  echo "UNITY_VERSION must be set, to e.g. 2018.4.36f1"
+if [ -z "$UNITY_VERSION" ] || [ -z "$UNITY_PATH" ]; then
+  echo "UNITY_VERSION or UNITY_PATH must be set."
   exit 1
 fi
 

--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 if [ -z "$UNITY_VERSION" ]; then
-  echo "UNITY_VERSION must be set e.g. 2020.3.32f1"
+  echo "UNITY_VERSION must be set, to e.g. 2018.4.36f1"
   exit 1
 fi
 

--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -12,21 +12,31 @@ fi
 
 if [ "$1" == "macos" ]; then
   PLATFORM="MacOS"
-  UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
+  if [ -z "$UNITY_PATH" ]; then
+    UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
+  fi
 elif [ "$1" == "windows" ]; then
   PLATFORM="Win64"
   set -m
-  UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+  if [ -z "$UNITY_PATH" ]; then
+    UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+  fi
 elif [ "$1" == "wsl" ]; then
   PLATFORM="Win64"
   set -m
-  UNITY_PATH="/mnt/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+  if [ -z "$UNITY_PATH" ]; then
+    UNITY_PATH="/mnt/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+  fi
 elif [ "$1" == "webgl" ]; then
   PLATFORM="WebGL"
   if [ "$(uname)" == "Darwin" ]; then
-    UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
+    if [ -z "$UNITY_PATH" ]; then
+     UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
+    fi
   else
-    UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+    if [ -z "$UNITY_PATH" ]; then
+      UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+    fi
   fi
 else
   echo "Unsupported platform: $1"

--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -1,10 +1,8 @@
 #!/bin/bash -e
 
 if [ -z "$UNITY_VERSION" ]; then
-  if [ -z "$UNITY_DIR" ]; then
-    echo "UNITY_VERSION or UNITY_DIR must be set."
-    exit 1
-  fi
+  echo "UNITY_VERSION must be set e.g. 2020.3.32f1"
+  exit 1
 fi
 
 if [[ $# != 1 ]]; then

--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -16,17 +16,17 @@ if [ "$1" == "macos" ]; then
 elif [ "$1" == "windows" ]; then
   PLATFORM="Win64"
   set -m
-  UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+  UNITY_PATH="/f/unity/$UNITY_VERSION/Editor/Unity.exe"
 elif [ "$1" == "wsl" ]; then
   PLATFORM="Win64"
   set -m
-  UNITY_PATH="/mnt/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+  UNITY_PATH="/mnt/f/unity/$UNITY_VERSION/Editor/Unity.exe"
 elif [ "$1" == "webgl" ]; then
   PLATFORM="WebGL"
   if [ "$(uname)" == "Darwin" ]; then
     UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
   else
-    UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
+    UNITY_PATH="/f/unity/$UNITY_VERSION/Editor/Unity.exe"
   fi
 else
   echo "Unsupported platform: $1"

--- a/features/scripts/build_maze_runner.sh
+++ b/features/scripts/build_maze_runner.sh
@@ -16,17 +16,17 @@ if [ "$1" == "macos" ]; then
 elif [ "$1" == "windows" ]; then
   PLATFORM="Win64"
   set -m
-  UNITY_PATH="/f/unity/$UNITY_VERSION/Editor/Unity.exe"
+  UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
 elif [ "$1" == "wsl" ]; then
   PLATFORM="Win64"
   set -m
-  UNITY_PATH="/mnt/f/unity/$UNITY_VERSION/Editor/Unity.exe"
+  UNITY_PATH="/mnt/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
 elif [ "$1" == "webgl" ]; then
   PLATFORM="WebGL"
   if [ "$(uname)" == "Darwin" ]; then
     UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS/Unity"
   else
-    UNITY_PATH="/f/unity/$UNITY_VERSION/Editor/Unity.exe"
+    UNITY_PATH="/c/Program Files/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity.exe"
   fi
 else
   echo "Unsupported platform: $1"


### PR DESCRIPTION
## Goal

Move the path of the Unity install on the Windows CI servers
Bump the minor version of the Unity 2021 install


## Testing

Covered by [full ci]
