### PR TITLE
Windows session flake fix

### DIFF
--- a/features/csharp/csharp_sessions.feature
+++ b/features/csharp/csharp_sessions.feature
@@ -152,6 +152,7 @@ Feature: Session Tracking
     And I wait to receive 2 sessions
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
+    And I sort the sessions by the payload field "sessions.0.startedAt"
     # Session 1
     Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
     And the session payload field "sessions.0.id" is stored as the value "session_id_1"

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/NewSession.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/NewSession.cs
@@ -15,11 +15,6 @@ public class NewSession : Scenario
     {
         Bugsnag.StartSession();
         Bugsnag.Notify(new System.Exception("Error 1"));
-        Invoke("DoSecondSession",5);
-    }
-
-    private void DoSecondSession()
-    {
         Bugsnag.StartSession();
         Bugsnag.Notify(new System.Exception("Error 2"));
     }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/NewSession.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/NewSession.cs
@@ -15,6 +15,11 @@ public class NewSession : Scenario
     {
         Bugsnag.StartSession();
         Bugsnag.Notify(new System.Exception("Error 1"));
+        Invoke("DoSecondSession",5);
+    }
+
+    private void DoSecondSession()
+    {
         Bugsnag.StartSession();
         Bugsnag.Notify(new System.Exception("Error 2"));
     }


### PR DESCRIPTION
## Goal

Windows session flake fix.

I was unable to repro this locally, but i think i have a good idea of the issue.
The sessions were sometimes arriving out of order because they are sent at almost the exact same time. So i added a line in the feature to sort the sessions by startedat time
