### PR TITLE
PLAT-9060 transfer device and app data as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fix an issue where Cocoa Device and App data was serialised incorectly causing invalid cast exceptions in callbacks [#680](https://github.com/bugsnag/bugsnag-unity/pull/680)
+
+
+
+
 ## 7.5.0 (2022-11-30)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix an issue where Cocoa Device and App data was serialised incorectly causing invalid cast exceptions in callbacks [#680](https://github.com/bugsnag/bugsnag-unity/pull/680)
+* Fix an issue where Cocoa Device and App data was serialized incorrectly causing invalid cast exceptions in callbacks [#680](https://github.com/bugsnag/bugsnag-unity/pull/680)
 
 
 

--- a/features/csharp/csharp_config.feature
+++ b/features/csharp/csharp_config.feature
@@ -3,56 +3,6 @@ Feature: csharp events
   Background:
     Given I clear the Bugsnag cache
 
-#IS LAUNCHING SECTION --------------------------------------------------------------------
-# These duplicate isLaunching tests will be merged after the bug PLAT-9060 is fixed
-  #macos tests to accommodate bug
-  @cocoa_only
-  Scenario: Launch duration set to 0
-    When I run the game in the "InfiniteLaunchDuration" state
-    And I wait to receive an error
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "InfiniteLaunchDuration"
-    And the event "app.isLaunching" equals "true"
-
-  @cocoa_only
-  Scenario: Call mark launch complete
-    When I run the game in the "MarkLaunchComplete" state
-    And I wait to receive 2 errors
-    And I sort the errors by the payload field "events.0.exceptions.0.message"
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
-    And the event "app.isLaunching" equals "true"
-    And I discard the oldest error
-    And the exception "message" equals "Error 2"
-    And the event "app.isLaunching" equals "false"
-
-  @cocoa_only
-  Scenario: Set long launch time
-    When I run the game in the "LongLaunchTime" state
-    And I wait to receive 2 errors
-    And I sort the errors by the payload field "events.0.exceptions.0.message"
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
-    And the event "app.isLaunching" equals "true"
-    And I discard the oldest error
-    And the exception "message" equals "Error 2"
-    And the event "app.isLaunching" equals "false"
-
-  @cocoa_only
-  Scenario: Set short launch time
-    When I run the game in the "ShortLaunchTime" state
-    And I wait to receive 2 errors
-    And I sort the errors by the payload field "events.0.exceptions.0.message"
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
-    And the event "app.isLaunching" equals "true"
-    And I discard the oldest error
-    And the exception "message" equals "Error 2"
-    And the event "app.isLaunching" equals "false"
-
-
-#Correct tests to be enabled when PLAT-9061 is fixed
-  @skip_cocoa
   Scenario: Launch duration set to 0
     When I run the game in the "InfiniteLaunchDuration" state
     And I wait to receive an error
@@ -60,7 +10,6 @@ Feature: csharp events
     And the exception "message" equals "InfiniteLaunchDuration"
     And the event "app.isLaunching" is true
 
-  @skip_cocoa
   Scenario: Call mark launch complete
     When I run the game in the "MarkLaunchComplete" state
     And I wait to receive 2 errors
@@ -95,9 +44,6 @@ Feature: csharp events
     And I discard the oldest error
     And the exception "message" equals "Error 2"
     And the event "app.isLaunching" is false
-
-
-#END SECTION -----------------------------------------------------------------------------
 
   Scenario: Auto notify false
     When I run the game in the "AutoNotifyFalse" state

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -211,29 +211,71 @@ public class Scenario : MonoBehaviour
 
     private void EditAllAppData(IEvent @event)
     {
+
+        // the unused vars for each property and there to check that the stored payload (retrieved from the native layers) contains the correct types
+        // if the incorrect type is stored then we will get an InvalidCast Exception
+
+        string binaryArch = @event.App.BinaryArch;
         @event.App.BinaryArch = "BinaryArch";
+
+        string bundleVersion = @event.App.BundleVersion;
         @event.App.BundleVersion = "BundleVersion";
+
+        string codeBundleId = @event.App.CodeBundleId;
         @event.App.CodeBundleId = "CodeBundleId";
+
+        string dsymUuid = @event.App.DsymUuid;
         @event.App.DsymUuid = "DsymUuid";
+
+        string id = @event.App.Id;
         @event.App.Id = "Id";
+
+        string releaseStage = @event.App.ReleaseStage;
         @event.App.ReleaseStage = "ReleaseStage";
+
+        string type = @event.App.Type;
         @event.App.Type = "Type";
+
+        string version = @event.App.Version;
         @event.App.Version = "Version";
+
+        bool? inForeground = @event.App.InForeground;
         @event.App.InForeground = false;
+
+        bool? isLaunching = @event.App.IsLaunching;
         @event.App.IsLaunching = false;
     }
 
     private void EditAllDeviceData(IEvent @event)
     {
+        string version = @event.Device.Id;
         @event.Device.Id = "Id";
+
+        bool? jailBroken = @event.Device.Jailbroken;
         @event.Device.Jailbroken = true;
+
+        string locale = @event.Device.Locale;
         @event.Device.Locale = "Locale";
+
+        string manufacturer = @event.Device.Manufacturer;
         @event.Device.Manufacturer = "Manufacturer";
+
+        string model = @event.Device.Model;
         @event.Device.Model = "Model";
+
+        string osName = @event.Device.OsName;
         @event.Device.OsName = "OsName";
+
+        string osVersion = @event.Device.OsVersion;
         @event.Device.OsVersion = "OsVersion";
+
+        long? freeDisk = @event.Device.FreeDisk;
         @event.Device.FreeDisk = 123;
+
+        long? freeMemory = @event.Device.FreeMemory;
         @event.Device.FreeMemory = 456;
+
+        string orientation = @event.Device.Orientation;
         @event.Device.Orientation = "Orientation";
     }
 

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -748,19 +748,23 @@ void bugsnag_retrieveLastRunInfo(const void *lastRuninfo, void (*callback)(const
 
 }
 
-void bugsnag_retrieveDeviceData(const void *deviceData, void (*callback)(const void *instance, const char *key, const char *value)) {
-  BugsnagDeviceWithState *device = [Bugsnag.client generateDeviceWithState:BSGGetSystemInfo()];
-  callback(deviceData, "freeDisk", device.freeDisk.stringValue.UTF8String);
-  callback(deviceData, "freeMemory", device.freeMemory.stringValue.UTF8String);
-  callback(deviceData, "id", device.id.UTF8String);
-  callback(deviceData, "jailbroken", strdup(device.jailbroken ? "1" : "0"));
-  callback(deviceData, "locale", device.locale.UTF8String);
-  callback(deviceData, "manufacturer", device.manufacturer.UTF8String);
-  callback(deviceData, "model", device.model.UTF8String);
-  callback(deviceData, "modelNumber", device.modelNumber.UTF8String);
-  callback(deviceData, "osBuild", device.runtimeVersions[@"osBuild"].UTF8String);
-  callback(deviceData, "osName", device.osName.UTF8String);
-  callback(deviceData, "osVersion", device.osVersion.UTF8String);
+char * bugsnag_retrieveDeviceData(const void *deviceData, void (*callback)(const void *instance, const char *key, const char *value)) {
+    BugsnagDeviceWithState *device = [Bugsnag.client generateDeviceWithState:BSGGetSystemInfo()];
+    NSDictionary *deviceDictionary = @{
+        @"freeDisk" : device.freeDisk,
+        @"freeMemory" : device.freeMemory,
+        @"id" : device.id,
+        @"jailbroken" : device.jailbroken ? @"true" : @"false",
+        @"locale" : device.locale,
+        @"manufacturer" : device.manufacturer,
+        @"model" : device.model,
+        @"modelNumber" : device.modelNumber,
+        @"osBuild" : device.runtimeVersions[@"osBuild"],
+        @"osName" : device.osName,
+        @"osVersion" : device.osVersion,
+    };
+
+    return getJson(deviceDictionary);
 }
 
 void bugsnag_populateUser(struct bugsnag_user *user) {

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -725,12 +725,17 @@ void bugsnag_retrieveBreadcrumbs(const void *managedBreadcrumbs, void (*breadcru
 }
 
 void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *instance, const char *key, const char *value)) {
-  BugsnagAppWithState *app = [Bugsnag.client generateAppWithState:BSGGetSystemInfo()];
-  callback(appData, "bundleVersion", app.bundleVersion.UTF8String);
-  callback(appData, "id", app.id.UTF8String);
-  callback(appData, "isLaunching", strdup(app.isLaunching ? "true" : "false"));
-  callback(appData, "type", app.type.UTF8String);
-  callback(appData, "version", app.version.UTF8String);
+    BugsnagAppWithState *app = [Bugsnag.client generateAppWithState:BSGGetSystemInfo()];
+
+    NSDictionary *appDictionary = @{
+        "bundleVersion" : app.bundleVersion,
+        "id" : app.id,
+        "isLaunching" : app.isLaunching,
+        "type" : app.type,
+        "version" : app.version
+    };
+
+    return getJson(appDictionary);
 }
 
 void bugsnag_retrieveLastRunInfo(const void *lastRuninfo, void (*callback)(const void *instance, bool crashed, bool crashedDuringLaunch, int consecutiveLaunchCrashes)) {

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -726,15 +726,13 @@ void bugsnag_retrieveBreadcrumbs(const void *managedBreadcrumbs, void (*breadcru
 
 char * bugsnag_retrieveAppData() {
     BugsnagAppWithState *app = [Bugsnag.client generateAppWithState:BSGGetSystemInfo()];
-
-    NSDictionary *appDictionary = @{
-        @"bundleVersion" : app.bundleVersion,
-        @"id" : app.id,
-        @"isLaunching" : app.isLaunching ? @"true" : @"false",
-        @"type" : app.type,
-        @"version" : app.version
-    };
-
+     NSDictionary *appDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
+        app.bundleVersion, @"bundleVersion",
+        app.id, @"id",
+        app.isLaunching ? @"true" : @"false", @"isLaunching",
+        app.type, @"type",
+        app.version, @"version",
+        nil];
     return getJson(appDictionary);
 }
 
@@ -750,20 +748,19 @@ void bugsnag_retrieveLastRunInfo(const void *lastRuninfo, void (*callback)(const
 
 char * bugsnag_retrieveDeviceData(const void *deviceData, void (*callback)(const void *instance, const char *key, const char *value)) {
     BugsnagDeviceWithState *device = [Bugsnag.client generateDeviceWithState:BSGGetSystemInfo()];
-    NSDictionary *deviceDictionary = @{
-        @"freeDisk" : device.freeDisk,
-        @"freeMemory" : device.freeMemory,
-        @"id" : device.id,
-        @"jailbroken" : device.jailbroken ? @"true" : @"false",
-        @"locale" : device.locale,
-        @"manufacturer" : device.manufacturer,
-        @"model" : device.model,
-        @"modelNumber" : device.modelNumber,
-        @"osBuild" : device.runtimeVersions[@"osBuild"],
-        @"osName" : device.osName,
-        @"osVersion" : device.osVersion,
-    };
-
+    NSDictionary *deviceDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
+        device.freeDisk, @"freeDisk",
+        device.freeMemory, @"freeMemory",
+        device.id, @"id",
+        device.jailbroken ? @"true" : @"false", @"jailbroken",
+        device.locale, @"locale",
+        device.manufacturer, @"manufacturer",
+        device.model, @"model",
+        device.modelNumber, @"modelNumber",
+        device.runtimeVersions[@"osBuild"], @"osBuild",
+        device.osName, @"osName",
+        device.osVersion,@ "osVersion",
+        nil];
     return getJson(deviceDictionary);
 }
 

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -724,15 +724,15 @@ void bugsnag_retrieveBreadcrumbs(const void *managedBreadcrumbs, void (*breadcru
   }];
 }
 
-void bugsnag_retrieveAppData(const void *appData, void (*callback)(const void *instance, const char *key, const char *value)) {
+char * bugsnag_retrieveAppData() {
     BugsnagAppWithState *app = [Bugsnag.client generateAppWithState:BSGGetSystemInfo()];
 
     NSDictionary *appDictionary = @{
-        "bundleVersion" : app.bundleVersion,
-        "id" : app.id,
-        "isLaunching" : app.isLaunching,
-        "type" : app.type,
-        "version" : app.version
+        @"bundleVersion" : app.bundleVersion,
+        @"id" : app.id,
+        @"isLaunching" : app.isLaunching ? @"true" : @"false",
+        @"type" : app.type,
+        @"version" : app.version
     };
 
     return getJson(appDictionary);

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -224,35 +224,18 @@ namespace BugsnagUnity
 
         public void PopulateApp(App app)
         {
-            GCHandle handle = GCHandle.Alloc(app);
-
-            try
+            var result = NativeCode.bugsnag_retrieveAppData();
+            var dictionary = ((JsonObject)SimpleJson.DeserializeObject(result)).GetDictionary();
+            foreach (var pair in dictionary)
             {
-                NativeCode.bugsnag_retrieveAppData(GCHandle.ToIntPtr(handle), PopulateAppData);
-            }
-            finally
-            {
-                if (handle != null)
-                {
-                    handle.Free();
-                }
+                app.Payload.AddToPayload(pair.Key,pair.Value);
             }
         }
 
         public void PopulateAppWithState(AppWithState app)
         {
             PopulateApp(app);
-        }
-
-        [MonoPInvokeCallback(typeof(Action<IntPtr, string, string>))]
-        static void PopulateAppData(IntPtr instance, string key, string value)
-        {
-            var handle = GCHandle.FromIntPtr(instance);
-            if (handle.Target is App app)
-            {
-                app.Add(key, value);
-            }
-        }
+        }     
 
         public void PopulateDevice(Device device)
         {

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -228,7 +228,20 @@ namespace BugsnagUnity
             var dictionary = ((JsonObject)SimpleJson.DeserializeObject(result)).GetDictionary();
             foreach (var pair in dictionary)
             {
-                app.Payload.AddToPayload(pair.Key,pair.Value);
+                if (pair.Key == "isLaunching")
+                {
+                    if (pair.Value != null)
+                    {
+                        var stringValue = (pair.Value as string).ToLower();
+                        app.Payload.AddToPayload(pair.Key, stringValue == "true");
+
+                    }
+
+                }
+                else
+                {
+                    app.Payload.AddToPayload(pair.Key, pair.Value);
+                }
             }
         }
 

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -29,7 +29,7 @@ namespace BugsnagUnity
         internal static extern void bugsnag_retrieveLastRunInfo(IntPtr instance, Action<IntPtr, bool, bool, int> populate);
 
         [DllImport(Import)]
-        internal static extern void bugsnag_retrieveDeviceData(IntPtr instance, Action<IntPtr, string, string> populate);
+        internal static extern string bugsnag_retrieveDeviceData();
 
         [DllImport(Import)]
         internal static extern void bugsnag_registerForOnSendCallbacks(IntPtr configuration, Func<IntPtr, bool> callback);

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -23,7 +23,7 @@ namespace BugsnagUnity
         internal static extern void bugsnag_removeMetadata(IntPtr configuration, string tab);
 
         [DllImport(Import)]
-        internal static extern void bugsnag_retrieveAppData(IntPtr instance, Action<IntPtr, string, string> populate);
+        internal static extern string bugsnag_retrieveAppData();
 
         [DllImport(Import)]
         internal static extern void bugsnag_retrieveLastRunInfo(IntPtr instance, Action<IntPtr, bool, bool, int> populate);

--- a/src/BugsnagUnity/Native/Cocoa/NativePayloadClassWrapper.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativePayloadClassWrapper.cs
@@ -26,8 +26,12 @@ namespace BugsnagUnity
 
         internal bool? GetNativeBool(string key)
         {
-            var result = NativeCode.bugsnag_getValueAsString(NativePointer, key);
-            return result == null ? null : (bool?)bool.Parse(result);
+            var result = NativeCode.bugsnag_getValueAsString(NativePointer, key).ToLower();
+            if (result == null)
+            {
+                return null;
+            }
+            return result == "1" || result == "true";
         }
 
         internal void SetNativeBool(string name, bool? value)


### PR DESCRIPTION
## Goal

Native App and Device data was being serialised as the correct types, causing InvalidCastExceptions in callbacks.
This change converts and passes the data as json, reducing the complexity of the code and retaining the original data types. 

## Changeset

Changed the methods `bugsnag_retrieveDeviceData` and `bugsnag_retrieveAppData` to get JSON from the native layer instead of using complex and costly MonoPInvoke callbacks.

## Testing

csharp_config.feature contained some tests that were modified just for Cocoa to pass. These have been removed and now cocoa runs against the same tests as all other platforms.