### PR TITLE
PLAT-9130 onsession callbacks not reflecting changes made to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+### Bug fixes
+
+* Fixed an issue where user changes made in OnSession callbacks did not make it to the generated payload [#681](https://github.com/bugsnag/bugsnag-unity/pull/681)
+
 ## 7.5.0 (2022-11-30)
 
 ### Enhancements

--- a/features/csharp/csharp_callbacks.feature
+++ b/features/csharp/csharp_callbacks.feature
@@ -53,13 +53,11 @@ Feature: Callbacks
     And the exception "message" equals "Error 1"
     And all possible parameters have been edited in a callback
 
-  @skip_windows @skip_webgl #Pending PLAT-9130
   Scenario: Session callbacks in config
     When I run the game in the "OnSessionInConfig" state
     And I wait to receive 1 session
     And all possible parameters have been edited in a session callback
 
-  @skip_windows @skip_webgl #Pending PLAT-9130
   Scenario: Session callbacks in config
     When I run the game in the "OnSessionAfterStart" state
     And I wait to receive 1 session

--- a/src/BugsnagUnity/Payload/Session.cs
+++ b/src/BugsnagUnity/Payload/Session.cs
@@ -33,7 +33,7 @@ namespace BugsnagUnity.Payload
 
         public void SetUser(string id, string email, string name)
         {
-            User = new User(id,name,email);
+            User = new User(id, email, name);
         }
 
         internal int HandledCount()

--- a/src/BugsnagUnity/Payload/SessionReport.cs
+++ b/src/BugsnagUnity/Payload/SessionReport.cs
@@ -24,16 +24,16 @@ namespace BugsnagUnity.Payload
             };
         }
 
-        public SessionReport(Configuration configuration, App app, Device device, User user, Session session)
+        public SessionReport(Configuration configuration, Session session)
         {
             SetRequestInfo(configuration);
             this.AddToPayload("notifier", NotifierInfo.Instance);
-            this.AddToPayload("app", app.Payload);
-            this.AddToPayload("device", device.Payload);
+            this.AddToPayload("app", ((App)session.App).Payload);
+            this.AddToPayload("device", ((Device)session.Device).Payload);
             var sessionObject = new Dictionary<string,object>();
             sessionObject.AddToPayload("id", session.Id);
             sessionObject.AddToPayload("startedAt", session.StartedAt);
-            sessionObject.AddToPayload("user", user.Payload);
+            sessionObject.AddToPayload("user", session.User.Payload);
             this.AddToPayload("sessions", new [] { sessionObject });
             Id = session.Id;
         }

--- a/src/BugsnagUnity/SessionTracker.cs
+++ b/src/BugsnagUnity/SessionTracker.cs
@@ -100,7 +100,7 @@ namespace BugsnagUnity
 
             if (Client.Configuration.Endpoints.IsValid)
             {
-                var payload = new SessionReport(Client.Configuration, app, device, Client.GetUser().Clone(), session);
+                var payload = new SessionReport(Client.Configuration, session);
                 Client.PayloadManager.AddPendingPayload(payload);               
                 Client.Send(payload);
             }


### PR DESCRIPTION
## Goal

Changes made to the session user in OnSession callbacks did not change anything in the sent payload.

## Changeset

Fixed a simple bug where the user object passed to the payload was different to the one run through the callback.

## Testing

Existing tests had been skipped pending this fix, they are now reactivated.