### PR TITLE
PLAT-9336 Handle errors in delivery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'xcodeproj'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.2.1'
+  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.10.1'
 
   # Use a specific Maze Runner branch
   #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/features/csharp/csharp_persistence.feature
+++ b/features/csharp/csharp_persistence.feature
@@ -6,7 +6,9 @@ Feature: Unity Persistence
   @skip_windows @skip_macos @skip_webgl #pending PLAT-8632
   Scenario: Receive a persisted session
     When I run the game in the "PersistSession" state
+    And I set the HTTP status code for the next requests to "408"
     And I wait for requests to fail
+    And I discard the oldest session
     And I close the Unity app
     And On Mobile I relaunch the app
     And I run the game in the "PersistSessionReport" state
@@ -19,7 +21,9 @@ Feature: Unity Persistence
 
   Scenario: Receive a persisted event
     When I run the game in the "PersistEvent" state
+    And I set the HTTP status code for the next requests to "408"
     And I wait for requests to fail
+    And I discard the oldest error
     And I close the Unity app
     And On Mobile I relaunch the app
     And I run the game in the "PersistEventReport" state
@@ -33,7 +37,9 @@ Feature: Unity Persistence
 
   Scenario: Receive a persisted event with on send callback
     When I run the game in the "PersistEvent" state
+    And I set the HTTP status code for the next requests to "408"
     And I wait for requests to fail
+    And I discard the oldest error
     And I close the Unity app
     And On Mobile I relaunch the app
     And I run the game in the "PersistEventReportCallback" state
@@ -50,7 +56,12 @@ Feature: Unity Persistence
 
   Scenario: Max Persisted Events
     When I run the game in the "MaxPersistEvents" state
+    And I set the HTTP status code for the next requests to "408,408,408,408"
     And I wait for requests to fail
+    And I discard the oldest error
+    And I discard the oldest error
+    And I discard the oldest error
+    And I discard the oldest error
     And I close the Unity app
     And On Mobile I relaunch the app
     And I run the game in the "ReportMaxPersistedEvents" state
@@ -60,7 +71,12 @@ Feature: Unity Persistence
   @skip_cocoa @skip_android #These platforms handle sessions separately and will have separate tests
   Scenario: Max Persisted Sessions
     When I run the game in the "MaxPersistSessions" state
+    And I set the HTTP status code for the next requests to "408,408,408,408"
     And I wait for requests to fail
+    And I discard the oldest session
+    And I discard the oldest session
+    And I discard the oldest session
+    And I discard the oldest session
     And I close the Unity app
     And On Mobile I relaunch the app
     And I run the game in the "ReportMaxPersistedSessions" state

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -115,11 +115,6 @@ public class Scenario : MonoBehaviour
         Bugsnag.ClearFeatureFlag("flag2");
     }
 
-    public void SetInvalidEndpoints()
-    {
-        Configuration.Endpoints = new EndpointConfiguration("https://notify.def-not-bugsnag.com", "https://notify.def-not-bugsnag.com");
-    }
-
     public bool SimpleEventCallback(IEvent @event)
     {
         EditAllAppData(@event);

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/MaxPersistEvents.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/MaxPersistEvents.cs
@@ -8,8 +8,8 @@ public class MaxPersistEvents : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        SetInvalidEndpoints();
         Configuration.MaxPersistedEvents = 3;
+        Configuration.AutoTrackSessions = false;
         if (Application.platform == RuntimePlatform.IPhonePlayer)
         {
             Configuration.EnabledErrorTypes.OOMs = false;

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/MaxPersistSessions.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/MaxPersistSessions.cs
@@ -8,7 +8,6 @@ public class MaxPersistSessions : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        SetInvalidEndpoints();
         Configuration.MaxPersistedSessions = 3;
         Configuration.AutoTrackSessions = false;
     }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEvent.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEvent.cs
@@ -5,8 +5,8 @@ public class PersistEvent : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        SetInvalidEndpoints();
         Configuration.Context = "Error 1";
+        Configuration.AutoTrackSessions = false;
         if (Application.platform == RuntimePlatform.IPhonePlayer)
         {
             Configuration.EnabledErrorTypes.OOMs = false;

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReportCallback.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReportCallback.cs
@@ -7,6 +7,7 @@ public class PersistEventReportCallback : Scenario
     {
         base.PrepareConfig(apiKey, host);
         Configuration.Context = "Error 2";
+        Configuration.AutoTrackSessions = false;
         Configuration.AddOnSendError((@event) => {
 
             @event.App.BinaryArch = "Persist BinaryArch";

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistSession.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistSession.cs
@@ -4,7 +4,6 @@ public class PersistSession : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        SetInvalidEndpoints();
         Configuration.AddOnSession((session) =>
         {
             session.App.ReleaseStage = "Session 1";

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Switch/SwitchMaxCacheSize.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Switch/SwitchMaxCacheSize.cs
@@ -8,7 +8,6 @@ public class SwitchMaxCacheSize : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        SetInvalidEndpoints();
         Configuration.SwitchCacheMaxSize = 2097155;
         Configuration.AutoTrackSessions = false;
     }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Switch/SwitchPersistEvent.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Switch/SwitchPersistEvent.cs
@@ -4,11 +4,5 @@ using UnityEngine;
 
 public class SwitchPersistEvent : Scenario
 {
-    public override void PrepareConfig(string apiKey, string host)
-    {
-        base.PrepareConfig(apiKey, host);
-        SetInvalidEndpoints();
-    }
-
-
+   
 }

--- a/src/BugsnagUnity/PayloadManager.cs
+++ b/src/BugsnagUnity/PayloadManager.cs
@@ -92,17 +92,16 @@ namespace BugsnagUnity
             RemovePendingPayload(reportId);
         }
 
-        internal void PayloadSendSuccess(IPayload payload)
+        internal void RemovePayload(IPayload payload)
         {
             RemovePendingPayload(payload.Id);
-            switch (payload.PayloadType)
+            if (payload.PayloadType == PayloadType.Session)
             {
-                case PayloadType.Session:
-                    RemoveCachedSession(payload.Id);
-                    break;
-                case PayloadType.Event:
-                    RemoveCachedEvent(payload.Id);
-                    break;
+                RemoveCachedSession(payload.Id);
+            }
+            else
+            {
+                RemoveCachedEvent(payload.Id);
             }
         }
 


### PR DESCRIPTION
## Goal

Discard a payload if an error occurs during delivery that is outside the retry rules set out in the notifier spec.
This is important so that no events get stuck in a retry loop.

## Changeset

- Extended the PushToServer coroutine to handle network errors and any exceptions raised during serialisation of the body.

## Testing

Existing E2E tests were enhanced to use the recently added `I set the HTTP status code for the next requests to` step