### PR TITLE
PLAT-9086 inaccurate Session.Handled and Unhandled counts on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 * Fix an issue where android metadata was not deserialised as the correct type, which could cause exceptions when processing metadata. [#652](https://github.com/bugsnag/bugsnag-unity/pull/652)
 
+* Fix an issue where android sessions had inaccurate Session.Handled and Unhandled counts. [#684](https://github.com/bugsnag/bugsnag-unity/pull/684)
+
 ## 7.4.0 (2022-10-26)
 
 ### Dependency updates

--- a/features/csharp/csharp_sessions.feature
+++ b/features/csharp/csharp_sessions.feature
@@ -98,7 +98,6 @@ Feature: Session Tracking
     And the session "user.email" is null
     And the session "user.name" is null
 
-  @skip_android #pending PLAT-9086
   Scenario: Multiple event counts in one session
     When I run the game in the "MultipleEventCounts" state
     And I wait to receive a session
@@ -124,7 +123,6 @@ Feature: Session Tracking
     And the exception "message" equals "PausedSessionEvent"
     And the event "session" is null
 
-  @skip_android   #pending PLAT-9086
   Scenario: When a session is resumed the error uses the previous session information
     When I run the game in the "ResumedSession" state
     And I wait to receive a session
@@ -146,7 +144,6 @@ Feature: Session Tracking
     And the error payload field "session.startedAt" equals the stored value "session_startedAt"
     And the error payload field "events.0.session.events.handled" equals 2
 
-  @skip_android   #pending PLAT-9086
   Scenario: When a new session is started the error uses different session information
     When I run the game in the "NewSession" state
     And I wait to receive 2 sessions

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -595,7 +595,7 @@ namespace BugsnagUnity
             var timeLong = AndroidJNI.CallLongMethod(javaStartedAt, AndroidJNIHelper.GetMethodID(DateClass, "getTime"), new jvalue[] { });
             var unityDateTime = new DateTime(1970, 1, 1).AddMilliseconds(timeLong);
 
-            return new Session(id, unityDateTime, unhandledCount, handledCount);
+            return new Session(id, unityDateTime, handledCount, unhandledCount );
 
         }
 


### PR DESCRIPTION
## Goal

Sessions had inaccurate Session.Handled and Unhandled counts on android

## Changeset

A constructor in the native interface had a typo and arguments were being passed in the wrong order

## Testing

Existing session tests have been re-enabled