### PR TITLE
skip android and cocoa session persistence test

### DIFF
--- a/features/csharp/csharp_persistence.feature
+++ b/features/csharp/csharp_persistence.feature
@@ -3,7 +3,7 @@ Feature: Unity Persistence
   Background:
     Given I clear the Bugsnag cache
 
-  @skip_windows @skip_macos @skip_webgl #pending PLAT-8632
+  @skip_windows @skip_webgl @skip_cocoa @skip_android #pending PLAT-8632
   Scenario: Receive a persisted session
     When I set the HTTP status code for the next requests to "408"
     And I run the game in the "PersistSession" state


### PR DESCRIPTION
## Goal

skip android and cocoa session persistence testing as the unity layer is not involved.

