### PR TITLE
Added README to example app

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,31 @@
+# Unity Example App
+
+This Application was made to demonstrate various features of the BugSnag Unity notifier. 
+
+## Features including:
+<ul>
+    <li>Handled errors and exceptions: Events which can be handled gracefully can also be reported to BugSnag</li>
+    <li>Crashes: Events which terminate the app are sent to Bugsnag automatically. Reopen the app after a crash to send reports.</li>
+    <li>Android specific crashes: Native, segfaults, C++, JVM & ANR exceptions. Reopen the app after a crash to send reports</li>
+    <li>Cocoa sepecific crashes: Native, C++, OOM & App Hangs. Reopen the app after a crash to send reports</li>
+</ul>
+
+
+## Running the app
+
+<ol>
+    <li>Clone the repo </li> 
+```
+git clone git@github.com:bugsnag/bugsnag-unity.git --recursive
+```
+    <li>Once the project has opened in Unity</li> 
+    <li>Navigate to `Windows>Bugsnag>Configuration`</li>
+    <li>Enter your Bugsnag project API Key under the basic Configuration section of the package window</li>
+    <li>Press `Play` in the editor</li>
+    <li>Once loaded, click any of the error buttons</li>
+    <li>Confirm whether the BugSnag dashboard has received the error.</li>
+</ol>
+
+For more configuration and full information please read the documentation at 
+https://docs.bugsnag.com/platforms/unity/configuration-options/
+


### PR DESCRIPTION
Added README.md with instructions on configuration and full setup for the example app

## Goal

<!-- Why is this change necessary? -->
Currently the Bugsnag-Unity does not have a readme.md for the example, meaning several steps which may be missed when attempting to run it make it difficult to get working.

## Design

<!-- Why was this approach used? -->
Example app needed clarity
## Changeset

<!-- What changed? -->
added a readme.md file to the example app to demonstrate how to get it up and running.
## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
used https://stackedit.io/app# to test the markdown