### PR TITLE
PLAT-9602 handle serialisation errors outside of delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 
 * Fix an issue where collections in metadata were not present in native Android crashes. [#685](https://github.com/bugsnag/bugsnag-unity/pull/685)
 
+* Fix an issue where errors in serialisation threw exceptions. [#693](https://github.com/bugsnag/bugsnag-unity/pull/693)
 
-## TBD
+
+### Dependency updates
 
 - Update bugsnag-cocoa from v6.25.1 to [v6.25.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6252-2023-01-18)
 

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -167,4 +167,10 @@ Feature: csharp events
     And the event "severityReason.type" equals "userSpecifiedSeverity"
     And the event "unhandled" is false
 
+  Scenario: Discard event after serialisation error
+    When I run the game in the "SerialisationError" state
+    And I wait to receive 1 error
+    And the exception "message" equals "SerialisationError"
+
+
 

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -1036,6 +1036,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e84e72df185f344be9e23af93b2cabc4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
 --- !u!1 &1160627402
 GameObject:
   m_ObjectHideFlags: 0
@@ -2094,6 +2097,7 @@ GameObject:
   - component: {fileID: 2039813473}
   - component: {fileID: 2039813475}
   - component: {fileID: 2039813474}
+  - component: {fileID: 2039813477}
   m_Layer: 0
   m_Name: Events
   m_TagString: Untagged
@@ -2340,6 +2344,18 @@ MonoBehaviour:
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
 
     Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &2039813477
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0623c2806d68426e86c8fc6ba822dd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2059449697
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/SerialisationError.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/SerialisationError.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using BugsnagUnity;
+
+public class SerialisationError : Scenario
+{
+    private class Break
+    {
+        public string BrokenString
+        {
+            get
+            {
+                throw new Exception("BrokenString");
+                return string.Empty;
+            }
+        }
+    }
+
+    public override void Run()
+    {
+        Bugsnag.AddOnError(BrokenCallback);
+
+        DoSimpleNotify("SerialisationErrorBroken"); //this should not get delivered
+
+        Bugsnag.RemoveOnError(BrokenCallback);
+
+        DoSimpleNotify("SerialisationError"); //this one should
+    }
+
+    private bool BrokenCallback(IEvent @event)
+    {
+        @event.AddMetadata("Test", "Test", new Break());
+        return true;
+    }
+}
+

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/SerialisationError.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/SerialisationError.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0623c2806d68426e86c8fc6ba822dd8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -510,13 +510,16 @@ namespace BugsnagUnity
             var report = new Report(Configuration, @event);
             if (!report.Ignored)
             {
-                PayloadManager.AddPendingPayload(report);
-                Send(report);
-                if (Configuration.IsBreadcrumbTypeEnabled(BreadcrumbType.Error))
+                //if serialisation fails, then we ignore the event
+                if (PayloadManager.AddPendingPayload(report)) 
                 {
-                    Breadcrumbs.Leave(Breadcrumb.FromReport(report));
+                    Send(report);
+                    if (Configuration.IsBreadcrumbTypeEnabled(BreadcrumbType.Error))
+                    {
+                        Breadcrumbs.Leave(Breadcrumb.FromReport(report));
+                    }
+                    SessionTracking.AddException(report);
                 }
-                SessionTracking.AddException(report);
             }
         }
 

--- a/src/BugsnagUnity/PayloadManager.cs
+++ b/src/BugsnagUnity/PayloadManager.cs
@@ -31,17 +31,26 @@ namespace BugsnagUnity
             _cacheManager = cacheManager;
         }
 
-        internal void AddPendingPayload(IPayload payload)
+        internal bool AddPendingPayload(IPayload payload)
         {
-            using (var stream = new MemoryStream())
-            using (var reader = new StreamReader(stream))
-            using (var writer = new StreamWriter(stream, new UTF8Encoding(false)) { AutoFlush = false })
+            try
             {
-                SimpleJson.SerializeObject(payload.GetSerialisablePayload(), writer);
-                writer.Flush();
-                stream.Position = 0;
-                var jsonString = reader.ReadToEnd();
-                _pendingPayloads.Add(new PendingPayload(jsonString,payload.Id));
+                using (var stream = new MemoryStream())
+                using (var reader = new StreamReader(stream))
+                using (var writer = new StreamWriter(stream, new UTF8Encoding(false)) { AutoFlush = false })
+                {
+                    SimpleJson.SerializeObject(payload.GetSerialisablePayload(), writer);
+                    writer.Flush();
+                    stream.Position = 0;
+                    var jsonString = reader.ReadToEnd();
+                    _pendingPayloads.Add(new PendingPayload(jsonString, payload.Id));
+                }
+                return true;
+            }
+            catch
+            {
+                // If payload serialisation fails ignore the payload
+                return false;
             }
         }
 

--- a/src/BugsnagUnity/SessionTracker.cs
+++ b/src/BugsnagUnity/SessionTracker.cs
@@ -101,8 +101,10 @@ namespace BugsnagUnity
             if (Client.Configuration.Endpoints.IsValid)
             {
                 var payload = new SessionReport(Client.Configuration, session);
-                Client.PayloadManager.AddPendingPayload(payload);               
-                Client.Send(payload);
+                if (Client.PayloadManager.AddPendingPayload(payload))
+                {
+                    Client.Send(payload);
+                }
             }
             else
             {


### PR DESCRIPTION
## Goal

Discard any payload that has an error during initial serialisation

## Changeset

- added try catch to PayloadManager.AddToPayload. If an exception happens then it returns false so the client can discard the payload.

## Testing

Added E2E test for all platforms