### PR TITLE
PLAT-9618 deserialise unhandled

### DIFF
--- a/features/csharp/csharp_persistence.feature
+++ b/features/csharp/csharp_persistence.feature
@@ -31,9 +31,11 @@ Feature: Unity Persistence
     And I run the game in the "PersistEventReport" state
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
+    And the error is valid for the error reporting API sent by the Unity notifier
     And the event "context" equals "Error 1"
     And the exception "message" equals "Error 1"
     And I discard the oldest error
+    And the error is valid for the error reporting API sent by the Unity notifier
     And the event "context" equals "Error 2"
     And the exception "message" equals "Error 2"
 

--- a/src/BugsnagUnity/Payload/Event.cs
+++ b/src/BugsnagUnity/Payload/Event.cs
@@ -57,6 +57,18 @@ namespace BugsnagUnity.Payload
 
             var eventObject = (Dictionary<string, object>)serialisedPayload["event"];
 
+            if (eventObject["unhandled"] != null)
+            {
+                Add("unhandled", eventObject["unhandled"]);
+            }
+            if (eventObject["severity"] != null)
+            {
+                Add("severity", eventObject["severity"]);
+            }
+            if (eventObject["severityReason"] != null)
+            {
+                Add("severityReason", eventObject["severityReason"]);
+            }
             _metadata = new Metadata();
             _metadata.MergeMetadata((Dictionary<string, object>)eventObject["metaData"]);
 


### PR DESCRIPTION
## Goal

The event field `unhandled` was not getting set when persisted events were deserialised, meaning that it was null on delivery and not showing in the dashboard.

## Changeset

Added proper deserialization code to the persisted Event constructor  

## Testing

Added extra step to the Scenario `Receive a persisted event` at  `csharp_persistence.feature:23`