### PR TITLE
PLAT-9660 upm release script changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ bundle exec maze-runner features/handled_errors.feature
 
 Once the UnityPackage release is confirmed a UPM release should be deployed
 
-1. Make sure that the released package used in the github release is present in the root of the repo.
+1. Make sure that the package used in the github release is present in the root of the repo.
 
 2. Build the upm package by running the `build-upm-package.sh` script in the upm-tools directory. You should pass the version number of the release like so `./build-upm-package.sh 7.x.x`. You must run the script from within the upm-tools folder. This will build the upm package in a directory called `upm-package`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ bundle exec maze-runner features/handled_errors.feature
 
 Once the UnityPackage release is confirmed a UPM release should be deployed
 
-1. Checkout the release commit on `master`
+1. Make sure that the released package used in the github release is present in the root of the repo.
 
 2. Build the upm package by running the `build-upm-package.sh` script in the upm-tools directory. You should pass the version number of the release like so `./build-upm-package.sh 7.x.x`. You must run the script from within the upm-tools folder. This will build the upm package in a directory called `upm-package`
 

--- a/upm-tools/build-edm-package.sh
+++ b/upm-tools/build-edm-package.sh
@@ -15,3 +15,4 @@ cp EDM/BugsnagAndroidDependencies.xml.meta "$PACKAGE_DIR/Editor"
 
 # Change the readme title to reference EDM4U
 sed -i '' "s/Bugsnag SDK for Unity/Bugsnag SDK for Unity Including EDM4U Support/g" "$PACKAGE_DIR/README.md"
+sed -i '' "s/bugsnag-unity-upm.git/bugsnag-unity-upm-edm4u.git/g" "$PACKAGE_DIR/README.md"

--- a/upm-tools/build-upm-package.sh
+++ b/upm-tools/build-upm-package.sh
@@ -23,19 +23,12 @@ then
   exit 1
 fi
 
-#Build the plugin
-echo "Building the sdk"
-
-cd ..
-
-rake plugin:export
-
-cd upm-tools
-
+#Check for the release package
+echo "Checking for the release package"
 
 # make sure the package of the release is present after building
 if [ ! -f "$PACKAGE_FILE" ]; then
-    echo "$PACKAGE_FILE not found, please check for build errors."
+    echo "$PACKAGE_FILE not found, please provide a release package."
     exit 1
 fi
 


### PR DESCRIPTION
## Goal

Before this change, the upm package buildscript would rebuild the bugsnag notifier rather than use the exact package that was used in the github release. This could result in the upm release not being the same as the github release.

Now the buildscript will never build the notifier, it expects you to provide the same package that has been uploaded in the github release.


## Changeset

- Updated the build-upm-package.sh script to expect a provided package.
- Updated the edm4u script to auto replace the correct upm git url in the readme.
- Updated the release instructsions in the contributing.md file 

## Testing

Manually tested