### PR TITLE
PLAT-9670 make Start main thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fix a race condition in Bugsnag.Start involving creation of gameobjects outside of the main Unity thread. [#699](https://github.com/bugsnag/bugsnag-unity/pull/699)
+
 ## 7.5.1 (2023-02-08)
 
 ### Dependency updates

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -108,6 +108,7 @@ namespace BugsnagUnity
 
         public Client(INativeClient nativeClient)
         {
+            InitMainthreadDispatcher();
             NativeClient = nativeClient;
             CacheManager = new CacheManager(Configuration);
             PayloadManager = new PayloadManager(CacheManager);
@@ -120,8 +121,6 @@ namespace BugsnagUnity
             InitMetadata();
             InitFeatureFlags();
             InitCounters();
-            ListenForSceneLoad();
-            InitLogHandlers();
             if (_isUnity2019OrHigher)
             {
                 SetupAdvancedExceptionInterceptor();
@@ -131,6 +130,13 @@ namespace BugsnagUnity
             CheckForMisconfiguredEndpointsWarning();
             AddBugsnagLoadedBreadcrumb();
             _delivery.StartDeliveringCachedPayloads();
+            ListenForSceneLoad();
+            InitLogHandlers();
+        }
+
+        private void InitMainthreadDispatcher()
+        {
+            MainThreadDispatchBehaviour.Instance();
         }
 
         private bool IsUnity2019OrHigher()


### PR DESCRIPTION
## Goal

Bugsnag Client was registering for log messages before initializing MainThreadDispatchBehaviour.
If a log message is received from a background thread before MainThreadDispatchBehaviour.Instance() has been called on the main thread Bugsnag would try to create a GameObject from a background thread causing an exception

## Changeset

- Made sure to initialise the MainThreadDispatchBehaviour before any action that could trigger creation from another thread happens

## Testing

Manually tested