### PR TITLE
PLAT-9092 missing stacktraces in android notify events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Fix a race condition in Bugsnag.Start involving creation of gameobjects outside of the main Unity thread. [#699](https://github.com/bugsnag/bugsnag-unity/pull/699)
 
+* Fix an issue causing empty stacktraces in some Android events. [#700](https://github.com/bugsnag/bugsnag-unity/pull/700)
+
 ## 7.5.1 (2023-02-08)
 
 ### Dependency updates

--- a/features/csharp/csharp_callbacks.feature
+++ b/features/csharp/csharp_callbacks.feature
@@ -45,7 +45,6 @@ Feature: Callbacks
     And the exception "message" equals "Error 2"
     And all possible parameters have been edited in a callback
 
-  @skip_android #pending PLAT-9092
   Scenario: Callback passed directly to Notify
     When I run the game in the "CallbackInNotify" state
     And I wait to receive 1 error

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -3,7 +3,6 @@ Feature: csharp events
   Background:
     Given I clear the Bugsnag cache
 
-  @skip_android #pending PLAT-9092
   Scenario: Notify smoke test
     When I run the game in the "NotifySmokeTest" state
     And I wait to receive an error
@@ -13,8 +12,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | NotifySmokeTest.Run()                                                       |
-      | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
+      | NotifySmokeTest.Run()                                                       | Main+<RunNextMazeCommand>d__5.MoveNext() |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections;
 using System.IO;
 using System.Runtime.InteropServices;
-using BugsnagUnity;
 
 [Serializable]
 public class Command

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -139,35 +139,6 @@ public class Main : MonoBehaviour
 #endif
     }
 
-
-
-    // this method never runs and is just used to check that no notify overides are accidentally broken during refactoring
-    // if one is broken then the fixture will not compile
-    private void OverloadCheck()
-    {
-
-        Bugsnag.Notify("name", "message", "stacktrace");
-
-        Bugsnag.Notify("name", "message", "stacktrace", CallBack);
-
-        Bugsnag.Notify(new Exception());
-
-        Bugsnag.Notify(new Exception(), "stacktrace");
-
-        Bugsnag.Notify(new Exception(), "stacktrace", CallBack);
-
-        Bugsnag.Notify(new Exception(), CallBack);
-
-        Bugsnag.Notify(new Exception(), Severity.Error);
-
-        Bugsnag.Notify(new Exception(), Severity.Error, CallBack);
-    }
-
-    private bool CallBack(IEvent e)
-    {
-        return true;
-    }
-
 }
 
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.IO;
 using System.Runtime.InteropServices;
+using BugsnagUnity;
 
 [Serializable]
 public class Command
@@ -136,6 +137,35 @@ public class Main : MonoBehaviour
 #if UNITY_IOS
         ClearPersistentData();
 #endif
+    }
+
+
+
+    // this method never runs and is just used to check that no notify overides are accidentally broken during refactoring
+    // if one is broken then the fixture will not compile
+    private void OverloadCheck()
+    {
+
+        Bugsnag.Notify("name", "message", "stacktrace");
+
+        Bugsnag.Notify("name", "message", "stacktrace", CallBack);
+
+        Bugsnag.Notify(new Exception());
+
+        Bugsnag.Notify(new Exception(), "stacktrace");
+
+        Bugsnag.Notify(new Exception(), "stacktrace", CallBack);
+
+        Bugsnag.Notify(new Exception(), CallBack);
+
+        Bugsnag.Notify(new Exception(), Severity.Error);
+
+        Bugsnag.Notify(new Exception(), Severity.Error, CallBack);
+    }
+
+    private bool CallBack(IEvent e)
+    {
+        return true;
     }
 
 }

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -38,21 +38,21 @@ namespace BugsnagUnity
 
         private static IClient Client => InternalClient;
 
-        public static void Notify(string name, string message, string stackTrace) => InternalClient.Notify(name, message, stackTrace, null);
+        public static void Notify(string name, string message, string stackTrace) => Notify(name, message, stackTrace, null);
 
-        public static void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback) => InternalClient.Notify(name, message, stackTrace, callback);
+        public static void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback) => InternalClient.NotifyWithStrings(name, message, stackTrace, callback);
 
-        public static void Notify(System.Exception exception) => InternalClient.Notify(exception, 3);
+        public static void Notify(Exception exception) => InternalClient.NotifyWithException(exception);
 
-        public static void Notify(System.Exception exception, string stacktrace) => InternalClient.Notify(exception, stacktrace, null);
+        public static void Notify(Exception exception, string stacktrace) => Notify(exception, stacktrace, null);
 
-        public static void Notify(System.Exception exception, string stacktrace, Func<IEvent, bool> callback) => InternalClient.Notify(exception, stacktrace, callback);
+        public static void Notify(Exception exception, string stacktrace, Func<IEvent, bool> callback) => InternalClient.NotifyWithStacktrace(exception, stacktrace, callback);
 
-        public static void Notify(System.Exception exception, Func<IEvent, bool> callback) => InternalClient.Notify(exception, callback, 3);
+        public static void Notify(Exception exception, Func<IEvent, bool> callback) => InternalClient.NotifyWithExceptionCallback(exception, callback);
 
-        public static void Notify(System.Exception exception, Severity severity) => InternalClient.Notify(exception, severity, 3);
+        public static void Notify(Exception exception, Severity severity) => Notify(exception, severity, null);
 
-        public static void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback) => InternalClient.Notify(exception, severity, callback, 3);
+        public static void Notify(Exception exception, Severity severity, Func<IEvent, bool> callback) => InternalClient.NotifyWithExceptionSeverityCallback(exception, severity, callback);
 
         public static List<Breadcrumb> Breadcrumbs => Client.Breadcrumbs.Retrieve();
 

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -38,21 +38,13 @@ namespace BugsnagUnity
 
         private static IClient Client => InternalClient;
 
-        public static void Notify(string name, string message, string stackTrace) => Notify(name, message, stackTrace, null);
+        public static void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback = null) => InternalClient.Notify(name, message, stackTrace, callback);
 
-        public static void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback) => InternalClient.NotifyWithStrings(name, message, stackTrace, callback);
+        public static void Notify(System.Exception exception, string stacktrace, Func<IEvent, bool> callback = null) => InternalClient.Notify(exception, stacktrace, callback);
 
-        public static void Notify(Exception exception) => InternalClient.NotifyWithException(exception);
+        public static void Notify(System.Exception exception, Func<IEvent, bool> callback = null) => InternalClient.Notify(exception, callback);
 
-        public static void Notify(Exception exception, string stacktrace) => Notify(exception, stacktrace, null);
-
-        public static void Notify(Exception exception, string stacktrace, Func<IEvent, bool> callback) => InternalClient.NotifyWithStacktrace(exception, stacktrace, callback);
-
-        public static void Notify(Exception exception, Func<IEvent, bool> callback) => InternalClient.NotifyWithExceptionCallback(exception, callback);
-
-        public static void Notify(Exception exception, Severity severity) => Notify(exception, severity, null);
-
-        public static void Notify(Exception exception, Severity severity, Func<IEvent, bool> callback) => InternalClient.NotifyWithExceptionSeverityCallback(exception, severity, callback);
+        public static void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback = null) => InternalClient.Notify(exception, severity, callback);
 
         public static List<Breadcrumb> Breadcrumbs => Client.Breadcrumbs.Retrieve();
 

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -302,7 +302,7 @@ namespace BugsnagUnity
                     var backupStackFrames = new System.Diagnostics.StackTrace(1, true).GetFrames();
                     var forceUnhandled = logType == LogType.Exception && !Configuration.ReportExceptionLogsAsHandled;
                     var exception = Error.FromUnityLogMessage(logMessage, backupStackFrames, severity, forceUnhandled);
-                    FinalNotify(new Error[] { exception }, exception.HandledState, null, logType);
+                    Notify(new Error[] { exception }, exception.HandledState, null, logType);
                 }
             }
             else if (Configuration.ShouldLeaveLogBreadcrumb(logType))
@@ -315,39 +315,29 @@ namespace BugsnagUnity
             }
         }
 
-        public void NotifyWithStrings(string name, string message, string stackTrace, Func<IEvent, bool> callback)
+        public void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback)
         {
             var exceptions = new Error[] { Error.FromStringInfo(name, message, stackTrace) };
-            FinalNotify(exceptions, HandledState.ForHandledException(), callback, LogType.Exception);
+            Notify(exceptions, HandledState.ForHandledException(), callback, LogType.Exception);
         }
 
-        public void NotifyWithStacktrace(Exception exception, string stacktrace, Func<IEvent, bool> callback)
+        public void Notify(System.Exception exception, string stacktrace, Func<IEvent, bool> callback)
         {
             var exceptions = new Errors(exception, stacktrace).ToArray();
-            FinalNotify(exceptions, HandledState.ForHandledException(), callback, LogType.Exception);
+            Notify(exceptions, HandledState.ForHandledException(), callback, LogType.Exception);
         }
 
-        public void NotifyWithException(Exception exception)
-        {
-            Notify(exception, HandledState.ForHandledException(), null);
-        }
-
-        public void NotifyWithExceptionCallback(Exception exception, Func<IEvent, bool> callback)
+        public void Notify(System.Exception exception, Func<IEvent, bool> callback)
         {
             Notify(exception, HandledState.ForHandledException(), callback);
         }
 
-        public void NotifyWithExceptionSeverity(Exception exception, Severity severity)
-        {
-            Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), null);
-        }
-
-        public void NotifyWithExceptionSeverityCallback(Exception exception, Severity severity, Func<IEvent, bool> callback)
+        public void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback)
         {
             Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), callback);
         }
 
-        void Notify(Exception exception, HandledState handledState, Func<IEvent, bool> callback)
+        void Notify(System.Exception exception, HandledState handledState, Func<IEvent, bool> callback)
         {
             // we need to generate a substitute stacktrace here as if we are not able
             // to generate one from the exception that we are given then we are not able
@@ -361,10 +351,10 @@ namespace BugsnagUnity
                     handledState = HandledState.ForUnhandledException();
                 }
             }
-            FinalNotify(errors, handledState, callback, null);
+            Notify(errors, handledState, callback, null);
         }
 
-        private void FinalNotify(Error[] exceptions, HandledState handledState, Func<IEvent, bool> callback, LogType? logType)
+        private void Notify(Error[] exceptions, HandledState handledState, Func<IEvent, bool> callback, LogType? logType)
         {
             if (!ShouldSendRequests() || EventContainsDiscardedClass(exceptions) || !Configuration.Endpoints.IsValid)
             {

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
-using System.ComponentModel;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -82,7 +81,7 @@ namespace BugsnagUnity
                     if (shouldSend)
                     {
                         var handledState = _config.ReportExceptionLogsAsHandled ? HandledState.ForLoggedException() : HandledState.ForUnhandledException();
-                        _client.Notify(exception, handledState, null, 3);
+                        _client.Notify(exception, handledState, null);
                     }
                 }
                 if (_oldLogHandler != null)
@@ -180,7 +179,7 @@ namespace BugsnagUnity
         private void InitLogHandlers()
         {
             Application.logMessageReceivedThreaded += MultiThreadedNotify;
-            Application.logMessageReceived += Notify;
+            Application.logMessageReceived += NotifyFromUnityLog;
         }
 
         private void InitCounters()
@@ -277,19 +276,11 @@ namespace BugsnagUnity
             // Discard messages from the main thread as they will be reported separately
             if (!ReferenceEquals(Thread.CurrentThread, MainThread))
             {
-                Notify(condition, stackTrace, logType);
+                NotifyFromUnityLog(condition, stackTrace, logType);
             }
         }
 
-        /// <summary>
-        /// Notify a Unity log message if it the client has been configured to
-        /// notify at the specified level, if not leave a breadcrumb with the log
-        /// message.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="stackTrace"></param>
-        /// <param name="logType"></param>
-        void Notify(string condition, string stackTrace, LogType logType)
+        private void NotifyFromUnityLog(string condition, string stackTrace, LogType logType)
         {
             if (!Configuration.EnabledErrorTypes.UnityLog)
             {
@@ -311,7 +302,7 @@ namespace BugsnagUnity
                     var backupStackFrames = new System.Diagnostics.StackTrace(1, true).GetFrames();
                     var forceUnhandled = logType == LogType.Exception && !Configuration.ReportExceptionLogsAsHandled;
                     var exception = Error.FromUnityLogMessage(logMessage, backupStackFrames, severity, forceUnhandled);
-                    Notify(new Error[] { exception }, exception.HandledState, null, logType);
+                    FinalNotify(new Error[] { exception }, exception.HandledState, null, logType);
                 }
             }
             else if (Configuration.ShouldLeaveLogBreadcrumb(logType))
@@ -324,64 +315,44 @@ namespace BugsnagUnity
             }
         }
 
-        public void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback)
+        public void NotifyWithStrings(string name, string message, string stackTrace, Func<IEvent, bool> callback)
         {
             var exceptions = new Error[] { Error.FromStringInfo(name, message, stackTrace) };
-            Notify(exceptions, HandledState.ForHandledException(), callback, LogType.Exception);
+            FinalNotify(exceptions, HandledState.ForHandledException(), callback, LogType.Exception);
         }
 
-        public void Notify(System.Exception exception, string stacktrace, Func<IEvent, bool> callback)
+        public void NotifyWithStacktrace(Exception exception, string stacktrace, Func<IEvent, bool> callback)
         {
             var exceptions = new Errors(exception, stacktrace).ToArray();
-            Notify(exceptions, HandledState.ForHandledException(), callback, LogType.Exception);
+            FinalNotify(exceptions, HandledState.ForHandledException(), callback, LogType.Exception);
         }
 
-        public void Notify(System.Exception exception)
+        public void NotifyWithException(Exception exception)
         {
-            Notify(exception, 3);
+            Notify(exception, HandledState.ForHandledException(), null);
         }
 
-        internal void Notify(System.Exception exception, int level)
+        public void NotifyWithExceptionCallback(Exception exception, Func<IEvent, bool> callback)
         {
-            Notify(exception, HandledState.ForHandledException(), null, level);
+            Notify(exception, HandledState.ForHandledException(), callback);
         }
 
-        public void Notify(System.Exception exception, Func<IEvent, bool> callback)
+        public void NotifyWithExceptionSeverity(Exception exception, Severity severity)
         {
-            Notify(exception, callback, 3);
+            Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), null);
         }
 
-        internal void Notify(System.Exception exception, Func<IEvent, bool> callback, int level)
+        public void NotifyWithExceptionSeverityCallback(Exception exception, Severity severity, Func<IEvent, bool> callback)
         {
-            Notify(exception, HandledState.ForHandledException(), callback, level);
+            Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), callback);
         }
 
-        public void Notify(System.Exception exception, Severity severity)
-        {
-            Notify(exception, severity, 3);
-        }
-
-        internal void Notify(System.Exception exception, Severity severity, int level)
-        {
-            Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), null, level);
-        }
-
-        public void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback)
-        {
-            Notify(exception, severity, callback, 3);
-        }
-
-        internal void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback, int level)
-        {
-            Notify(exception, HandledState.ForUserSpecifiedSeverity(severity), callback, level);
-        }
-
-        void Notify(System.Exception exception, HandledState handledState, Func<IEvent, bool> callback, int level)
+        void Notify(Exception exception, HandledState handledState, Func<IEvent, bool> callback)
         {
             // we need to generate a substitute stacktrace here as if we are not able
             // to generate one from the exception that we are given then we are not able
             // to do this inside of the IEnumerator generator code
-            var substitute = new System.Diagnostics.StackTrace(level, true).GetFrames();
+            var substitute = new System.Diagnostics.StackTrace(true).GetFrames();
             var errors = new Errors(exception, substitute).ToArray();
             foreach (var error in errors)
             {
@@ -390,10 +361,10 @@ namespace BugsnagUnity
                     handledState = HandledState.ForUnhandledException();
                 }
             }
-            Notify(errors, handledState, callback, null);
+            FinalNotify(errors, handledState, callback, null);
         }
 
-        void Notify(Error[] exceptions, HandledState handledState, Func<IEvent, bool> callback, LogType? logType)
+        private void FinalNotify(Error[] exceptions, HandledState handledState, Func<IEvent, bool> callback, LogType? logType)
         {
             if (!ShouldSendRequests() || EventContainsDiscardedClass(exceptions) || !Configuration.Endpoints.IsValid)
             {
@@ -401,7 +372,7 @@ namespace BugsnagUnity
             }
 
 
-            if (!object.ReferenceEquals(Thread.CurrentThread, MainThread))
+            if (!ReferenceEquals(Thread.CurrentThread, MainThread))
             {
                 try
                 {

--- a/src/BugsnagUnity/IClient.cs
+++ b/src/BugsnagUnity/IClient.cs
@@ -17,17 +17,13 @@ namespace BugsnagUnity
 
         void Send(IPayload payload);
 
-        void NotifyWithException(System.Exception exception);
+        void Notify(System.Exception exception, Func<IEvent, bool> callback);
 
-        void NotifyWithExceptionCallback(System.Exception exception, Func<IEvent, bool> callback);
+        void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback);
 
-        void NotifyWithExceptionSeverity(System.Exception exception, Severity severity);
+        void Notify(System.Exception exception, string stacktrace, Func<IEvent, bool> callback);
 
-        void NotifyWithExceptionSeverityCallback(System.Exception exception, Severity severity, Func<IEvent, bool> callback);
-
-        void NotifyWithStacktrace(System.Exception exception, string stacktrace, Func<IEvent, bool> callback);
-
-        void NotifyWithStrings(string name, string message, string stackTrace, Func<IEvent, bool> callback);
+        void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback);
 
         /// <summary>
         /// Used to signal to the Bugsnag client that the focused state of the

--- a/src/BugsnagUnity/IClient.cs
+++ b/src/BugsnagUnity/IClient.cs
@@ -17,17 +17,17 @@ namespace BugsnagUnity
 
         void Send(IPayload payload);
 
-        void Notify(System.Exception exception);
+        void NotifyWithException(System.Exception exception);
 
-        void Notify(System.Exception exception, Func<IEvent, bool> callback);
+        void NotifyWithExceptionCallback(System.Exception exception, Func<IEvent, bool> callback);
 
-        void Notify(System.Exception exception, Severity severity);
+        void NotifyWithExceptionSeverity(System.Exception exception, Severity severity);
 
-        void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback);
+        void NotifyWithExceptionSeverityCallback(System.Exception exception, Severity severity, Func<IEvent, bool> callback);
 
-        void Notify(System.Exception exception, string stacktrace, Func<IEvent, bool> callback);
+        void NotifyWithStacktrace(System.Exception exception, string stacktrace, Func<IEvent, bool> callback);
 
-        void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback);
+        void NotifyWithStrings(string name, string message, string stackTrace, Func<IEvent, bool> callback);
 
         /// <summary>
         /// Used to signal to the Bugsnag client that the focused state of the

--- a/tests/BugsnagUnity.Tests/OverloadCheck.cs
+++ b/tests/BugsnagUnity.Tests/OverloadCheck.cs
@@ -1,0 +1,33 @@
+﻿using System;
+namespace BugsnagUnity.Tests
+{
+    public class OverloadCheck
+    {
+
+        // this method never runs and is just used to check that no notify overides are accidentally broken during refactoring
+        // if one is broken then the notifier will not compile
+        private void Check()
+        {
+            Bugsnag.Notify("name", "message", "stacktrace");
+
+            Bugsnag.Notify("name", "message", "stacktrace", CallBack);
+
+            Bugsnag.Notify(new Exception());
+
+            Bugsnag.Notify(new Exception(), "stacktrace");
+
+            Bugsnag.Notify(new Exception(), "stacktrace", CallBack);
+
+            Bugsnag.Notify(new Exception(), CallBack);
+
+            Bugsnag.Notify(new Exception(), Severity.Error);
+
+            Bugsnag.Notify(new Exception(), Severity.Error, CallBack);
+        }
+
+        private bool CallBack(IEvent e)
+        {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Goal

If a C# exception is not thrown then it contains no stacktrace. 

When Bugsnag.Notify(System.Exception) is called with an unthrown exception, we generate a backup stacktrace using `System.Diagnostics.StackTrace().GetFrames();`

Previously, when generating this trace we stripped the top 3 frames so that internal frames from the notifier would not be reported. 

The pipeline now automatically marks any frame from our notifier as out of project, and in some cases we were stripping frames that should not be stripped due to compiler optimisations.

In this PR we remove the stripping and allow the pipeline to decide what is and isn't in project.

## Changes to grouping

I was initially concerned that this change would break grouping for existing events but i have tested and this change will only break grouping for events where there are no InProject frames and Notify is called with an unthrown exception which is acceptable.

## Changeset

- Removed hardcoded frame stripping.
- Removed unecessary Notify overloads in Client.cs and Bugsnag.cs

## Testing

- Re-enabled existing Android tests that were disabled due to this issue.
- Existing tests should cover this change
- Added overload check to BugsnagUnity.Tests