### PR TITLE
Release v7.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 7.5.2 (2023-03-08)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fix a race condition in Bugsnag.Start involving creation of gameobjects outside of the main Unity thread. [#699](https://github.com/bugsnag/bugsnag-unity/pull/699)
+
 ## 7.5.1 (2023-02-08)
 
 ### Dependency updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Fix a race condition in Bugsnag.Start involving creation of gameobjects outside of the main Unity thread. [#699](https://github.com/bugsnag/bugsnag-unity/pull/699)
 
+* Fix an issue causing empty stacktraces in some Android events. [#700](https://github.com/bugsnag/bugsnag-unity/pull/700)
+
 ## 7.5.1 (2023-02-08)
 
 ### Dependency updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@
 
 * Fix an issue causing empty stacktraces in some Android events. [#700](https://github.com/bugsnag/bugsnag-unity/pull/700)
 
+### Dependency updates
+
+* Update bugsnag-android from v5.28.3 to [v5.28.4](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5284-2023-02-08)
+
 ## 7.5.1 (2023-02-08)
 
 ### Dependency updates
 
 - Update bugsnag-cocoa from v6.25.1 to [v6.25.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6252-2023-01-18)
-* Update bugsnag-android from v5.28.3 to [v5.28.4](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5284-2023-02-08)
 
 ### Bug fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ bundle exec maze-runner features/handled_errors.feature
 
 Once the UnityPackage release is confirmed a UPM release should be deployed
 
-1. Checkout the release commit on `master`
+1. Make sure that the package used in the github release is present in the root of the repo.
 
 2. Build the upm package by running the `build-upm-package.sh` script in the upm-tools directory. You should pass the version number of the release like so `./build-upm-package.sh 7.x.x`. You must run the script from within the upm-tools folder. This will build the upm package in a directory called `upm-package`
 

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@ var target = Argument("target", "Default");
 var solution = File("./BugsnagUnity.sln");
 var configuration = Argument("configuration", "Release");
 var project = File("./src/BugsnagUnity/BugsnagUnity.csproj");
-var version = "7.5.1";
+var version = "7.5.2";
 
 Task("Restore-NuGet-Packages")
     .Does(() => NuGetRestore(solution));

--- a/features/csharp/csharp_callbacks.feature
+++ b/features/csharp/csharp_callbacks.feature
@@ -45,7 +45,6 @@ Feature: Callbacks
     And the exception "message" equals "Error 2"
     And all possible parameters have been edited in a callback
 
-  @skip_android #pending PLAT-9092
   Scenario: Callback passed directly to Notify
     When I run the game in the "CallbackInNotify" state
     And I wait to receive 1 error

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -3,7 +3,6 @@ Feature: csharp events
   Background:
     Given I clear the Bugsnag cache
 
-  @skip_android #pending PLAT-9092
   Scenario: Notify smoke test
     When I run the game in the "NotifySmokeTest" state
     And I wait to receive an error
@@ -13,8 +12,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | NotifySmokeTest.Run()                                                       |
-      | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) |
+      | NotifySmokeTest.Run()                                                       | Main+<RunNextMazeCommand>d__5.MoveNext() |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -38,21 +38,13 @@ namespace BugsnagUnity
 
         private static IClient Client => InternalClient;
 
-        public static void Notify(string name, string message, string stackTrace) => InternalClient.Notify(name, message, stackTrace, null);
+        public static void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback = null) => InternalClient.Notify(name, message, stackTrace, callback);
 
-        public static void Notify(string name, string message, string stackTrace, Func<IEvent, bool> callback) => InternalClient.Notify(name, message, stackTrace, callback);
+        public static void Notify(System.Exception exception, string stacktrace, Func<IEvent, bool> callback = null) => InternalClient.Notify(exception, stacktrace, callback);
 
-        public static void Notify(System.Exception exception) => InternalClient.Notify(exception, 3);
+        public static void Notify(System.Exception exception, Func<IEvent, bool> callback = null) => InternalClient.Notify(exception, callback);
 
-        public static void Notify(System.Exception exception, string stacktrace) => InternalClient.Notify(exception, stacktrace, null);
-
-        public static void Notify(System.Exception exception, string stacktrace, Func<IEvent, bool> callback) => InternalClient.Notify(exception, stacktrace, callback);
-
-        public static void Notify(System.Exception exception, Func<IEvent, bool> callback) => InternalClient.Notify(exception, callback, 3);
-
-        public static void Notify(System.Exception exception, Severity severity) => InternalClient.Notify(exception, severity, 3);
-
-        public static void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback) => InternalClient.Notify(exception, severity, callback, 3);
+        public static void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback = null) => InternalClient.Notify(exception, severity, callback);
 
         public static List<Breadcrumb> Breadcrumbs => Client.Breadcrumbs.Retrieve();
 

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -108,6 +108,7 @@ namespace BugsnagUnity
 
         public Client(INativeClient nativeClient)
         {
+            InitMainthreadDispatcher();
             NativeClient = nativeClient;
             CacheManager = new CacheManager(Configuration);
             PayloadManager = new PayloadManager(CacheManager);
@@ -120,8 +121,6 @@ namespace BugsnagUnity
             InitMetadata();
             InitFeatureFlags();
             InitCounters();
-            ListenForSceneLoad();
-            InitLogHandlers();
             if (_isUnity2019OrHigher)
             {
                 SetupAdvancedExceptionInterceptor();
@@ -131,6 +130,13 @@ namespace BugsnagUnity
             CheckForMisconfiguredEndpointsWarning();
             AddBugsnagLoadedBreadcrumb();
             _delivery.StartDeliveringCachedPayloads();
+            ListenForSceneLoad();
+            InitLogHandlers();
+        }
+
+        private void InitMainthreadDispatcher()
+        {
+            MainThreadDispatchBehaviour.Instance();
         }
 
         private bool IsUnity2019OrHigher()

--- a/src/BugsnagUnity/IClient.cs
+++ b/src/BugsnagUnity/IClient.cs
@@ -17,11 +17,7 @@ namespace BugsnagUnity
 
         void Send(IPayload payload);
 
-        void Notify(System.Exception exception);
-
         void Notify(System.Exception exception, Func<IEvent, bool> callback);
-
-        void Notify(System.Exception exception, Severity severity);
 
         void Notify(System.Exception exception, Severity severity, Func<IEvent, bool> callback);
 

--- a/tests/BugsnagUnity.Tests/OverloadCheck.cs
+++ b/tests/BugsnagUnity.Tests/OverloadCheck.cs
@@ -1,0 +1,33 @@
+﻿using System;
+namespace BugsnagUnity.Tests
+{
+    public class OverloadCheck
+    {
+
+        // this method never runs and is just used to check that no notify overides are accidentally broken during refactoring
+        // if one is broken then the notifier will not compile
+        private void Check()
+        {
+            Bugsnag.Notify("name", "message", "stacktrace");
+
+            Bugsnag.Notify("name", "message", "stacktrace", CallBack);
+
+            Bugsnag.Notify(new Exception());
+
+            Bugsnag.Notify(new Exception(), "stacktrace");
+
+            Bugsnag.Notify(new Exception(), "stacktrace", CallBack);
+
+            Bugsnag.Notify(new Exception(), CallBack);
+
+            Bugsnag.Notify(new Exception(), Severity.Error);
+
+            Bugsnag.Notify(new Exception(), Severity.Error, CallBack);
+        }
+
+        private bool CallBack(IEvent e)
+        {
+            return true;
+        }
+    }
+}

--- a/upm-tools/build-edm-package.sh
+++ b/upm-tools/build-edm-package.sh
@@ -15,3 +15,4 @@ cp EDM/BugsnagAndroidDependencies.xml.meta "$PACKAGE_DIR/Editor"
 
 # Change the readme title to reference EDM4U
 sed -i '' "s/Bugsnag SDK for Unity/Bugsnag SDK for Unity Including EDM4U Support/g" "$PACKAGE_DIR/README.md"
+sed -i '' "s/bugsnag-unity-upm.git/bugsnag-unity-upm-edm4u.git/g" "$PACKAGE_DIR/README.md"

--- a/upm-tools/build-upm-package.sh
+++ b/upm-tools/build-upm-package.sh
@@ -23,19 +23,12 @@ then
   exit 1
 fi
 
-#Build the plugin
-echo "Building the sdk"
-
-cd ..
-
-rake plugin:export
-
-cd upm-tools
-
+#Check for the release package
+echo "Checking for the release package"
 
 # make sure the package of the release is present after building
 if [ ! -f "$PACKAGE_FILE" ]; then
-    echo "$PACKAGE_FILE not found, please check for build errors."
+    echo "$PACKAGE_FILE not found, please provide a release package."
     exit 1
 fi
 


### PR DESCRIPTION
## 7.5.2 (2023-03-08)

### Bug fixes

* Fix a race condition in Bugsnag.Start involving creation of gameobjects outside of the main Unity thread. [#699](https://github.com/bugsnag/bugsnag-unity/pull/699)

* Fix an issue causing empty stacktraces in some Android events. [#700](https://github.com/bugsnag/bugsnag-unity/pull/700)

### Dependency updates

* Update bugsnag-android from v5.28.3 to [v5.28.4](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5284-2023-02-08)
