### PR TITLE
PLAT-9373 maze host config getter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'xcodeproj'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.26.0'
+  gem 'bugsnag-maze-runner', '~>7.0'
 
   # Use a specific Maze Runner branch
   #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'xcodeproj'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.11.0'
+  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.26.0'
 
   # Use a specific Maze Runner branch
   #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,7 @@
-GIT
-  remote: https://github.com/bugsnag/maze-runner
-  revision: 81f79a9b405fb63bbfc8ef6cc8f20cd1f2c3905e
-  tag: v7.2.1
-  specs:
-    bugsnag-maze-runner (7.2.1)
-      appium_lib (~> 12.0)
-      bugsnag (~> 6.24)
-      cucumber (~> 7.1)
-      cucumber-expressions (~> 6.0.0)
-      curb (~> 0.9.6)
-      optimist (~> 3.0.1)
-      os (~> 1.0.0)
-      rake (~> 12.3.3)
-      rubyzip (~> 2.3.2)
-      selenium-webdriver (~> 4.0)
-      test-unit (~> 3.5.2)
-      webrick (~> 1.7.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.6)
       rexml
     appium_lib (12.0.1)
       appium_lib_core (~> 5.0)
@@ -30,13 +11,30 @@ GEM
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 4.2, < 4.6)
     atomos (0.1.3)
-    bugsnag (6.24.2)
+    bugsnag (6.25.2)
       concurrent-ruby (~> 1.0)
+    bugsnag-maze-runner (7.26.1)
+      appium_lib (~> 12.0.0)
+      appium_lib_core (~> 5.4.0)
+      bugsnag (~> 6.24)
+      cucumber (~> 7.1)
+      cucumber-expressions (~> 6.0.0)
+      curb (~> 0.9.6)
+      dogstatsd-ruby (~> 5.5.0)
+      json_schemer (~> 0.2.24)
+      optimist (~> 3.0.1)
+      os (~> 1.0.0)
+      rack (~> 2.2)
+      rake (~> 12.3.3)
+      rubyzip (~> 2.3.2)
+      selenium-webdriver (~> 4.0)
+      test-unit (~> 3.5.2)
+      webrick (~> 1.7.0)
     builder (3.2.4)
     childprocess (4.1.0)
     claide (1.1.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     cucumber (7.1.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -70,29 +68,34 @@ GEM
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
     curb (0.9.11)
     diff-lcs (1.5.0)
+    dogstatsd-ruby (5.5.0)
+    ecma-re-validator (0.4.0)
+      regexp_parser (~> 2.2)
     eventmachine (1.2.7)
-    faye-websocket (0.11.1)
+    faye-websocket (0.11.2)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.15.5)
+    hana (1.3.7)
+    json_schemer (0.2.24)
+      ecma-re-validator (~> 0.3)
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      uri_template (~> 0.7)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
-    mini_portile2 (2.8.0)
+    mime-types-data (3.2023.0218.1)
     multi_test (0.1.2)
     nanaimo (0.3.0)
-    nokogiri (1.13.8)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
-    power_assert (2.0.1)
-    racc (1.6.0)
+    power_assert (2.0.3)
+    racc (1.6.2)
+    rack (2.2.6.4)
     rake (12.3.3)
+    regexp_parser (2.8.0)
     rexml (3.2.5)
     rouge (2.0.7)
     rubyzip (2.3.2)
@@ -101,17 +104,18 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sys-uname (1.2.2)
+    sys-uname (1.2.3)
       ffi (~> 1.1)
-    test-unit (3.5.5)
+    test-unit (3.5.7)
       power_assert
     tomlrb (2.0.3)
+    uri_template (0.7.0)
     webrick (1.7.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xcodeproj (1.21.0)
+    xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -122,15 +126,13 @@ GEM
       rouge (~> 2.0.7)
 
 PLATFORMS
-  x86_64-darwin-19
   x86_64-darwin-20
-  x86_64-linux
 
 DEPENDENCIES
-  bugsnag-maze-runner!
+  bugsnag-maze-runner (~> 7.0)
   rake
   xcodeproj
   xcpretty
 
 BUNDLED WITH
-   2.3.18
+   2.4.8

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -12,7 +12,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | NotifySmokeTest.Run()                                                       | Main+<RunNextMazeCommand>d__5.MoveNext() |
+      | NotifySmokeTest.Run()                                                       | Main+<RunNextMazeCommand>d__7.MoveNext() |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
@@ -26,7 +26,7 @@ Feature: csharp events
     And custom metadata is included in the event
     And the stack frame methods should match:
       | UncaughtExceptionSmokeTest.Run()                                                                 |                                          |
-      | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | Main+<RunNextMazeCommand>d__5.MoveNext() |
+      | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | Main+<RunNextMazeCommand>d__7.MoveNext() |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
@@ -39,7 +39,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogExceptionSmokeTest:Run()                   | DebugLogExceptionSmokeTest.Run()                                            | <RunNextMazeCommand>d__5:MoveNext()                            | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) |
+      | DebugLogExceptionSmokeTest:Run()                   | DebugLogExceptionSmokeTest.Run()                                            | <RunNextMazeCommand>d__7:MoveNext()                            | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -53,7 +53,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogErrorSmokeTest:Run()                       | DebugLogErrorSmokeTest.Run()                                                | <RunNextMazeCommand>d__5:MoveNext()              |                                                                |
+      | DebugLogErrorSmokeTest:Run()                       | DebugLogErrorSmokeTest.Run()                                                | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -67,7 +67,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogWarningSmokeTest:Run()                     | DebugLogWarningSmokeTest.Run()                                              | <RunNextMazeCommand>d__5:MoveNext()              |                                                                |
+      | DebugLogWarningSmokeTest:Run()                     | DebugLogWarningSmokeTest.Run()                                              | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -81,7 +81,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogSmokeTest:Run()                            | DebugLogSmokeTest.Run()                                                     | <RunNextMazeCommand>d__5:MoveNext()              |                                                                |
+      | DebugLogSmokeTest:Run()                            | DebugLogSmokeTest.Run()                                                     | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -95,7 +95,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogAssertSmokeTest:Run()                      | DebugLogAssertSmokeTest.Run()                                               | <RunNextMazeCommand>d__5:MoveNext()              |                                                                |
+      | DebugLogAssertSmokeTest:Run()                      | DebugLogAssertSmokeTest.Run()                                               | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -12,6 +12,12 @@ public class Command
     public string scenarioName;
 }
 
+[Serializable]
+public class FixtureConfig
+{
+    public string maze_address;
+}
+
 public class Main : MonoBehaviour
 {
 
@@ -25,28 +31,56 @@ public class Main : MonoBehaviour
     private static extern void ClearPersistentData();
 #endif
 
+    private string _fixtureConfigPath = Application.persistentDataPath + "/fixture_config.json";
+
     private const string API_KEY = "a35a2a72bd230ac0aa0f52715bbdc6aa";
     private string _mazeHost;
 
     public ScenarioRunner ScenarioRunner;
 
-    public void Start()
+    public IEnumerator Start()
     {
         Debug.Log("Maze Runner app started");
 
-
-        _mazeHost = "http://localhost:9339";
-
-        if (Application.platform == RuntimePlatform.IPhonePlayer ||
-            Application.platform == RuntimePlatform.Android)
-        {
-            _mazeHost = "http://bs-local.com:9339";
-        }
+        yield return GetFixtureConfig();
 
 #if UNITY_STANDALONE_OSX
         PreventCrashPopups();
 #endif
         InvokeRepeating("DoRunNextMazeCommand",0,1);
+    }
+
+    private IEnumerator GetFixtureConfig()
+    {
+        var numTries = 0;
+        while (numTries < 5)
+        {
+            if (File.Exists(_fixtureConfigPath))
+            {
+                var configJson = File.ReadAllText(_fixtureConfigPath);
+                Debug.Log("Mazerunner got fixture config json: " + configJson);
+                var config = JsonUtility.FromJson<FixtureConfig>(configJson);
+                _mazeHost = "http://" + config.maze_address;
+            }
+            else
+            {
+                Debug.Log("Mazerunner no fixture config found at path: " + _fixtureConfigPath);
+                numTries++;
+                yield return new WaitForSeconds(1);
+            }
+        }
+
+        if (string.IsNullOrEmpty(_mazeHost))
+        {
+            _mazeHost = "http://localhost:9339";
+
+            if (Application.platform == RuntimePlatform.IPhonePlayer ||
+                Application.platform == RuntimePlatform.Android)
+            {
+                _mazeHost = "http://bs-local.com:9339";
+            }
+        }
+        Debug.Log("Mazerunner host set to: " + _mazeHost);
     }
 
     private void DoRunNextMazeCommand()

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -31,7 +31,7 @@ public class Main : MonoBehaviour
     private static extern void ClearPersistentData();
 #endif
 
-    private string _fixtureConfigPath = Application.persistentDataPath + "/fixture_config.json";
+    private string _fixtureConfigFileName = "/fixture_config.json";
 
     private const string API_KEY = "a35a2a72bd230ac0aa0f52715bbdc6aa";
     private string _mazeHost;
@@ -52,21 +52,27 @@ public class Main : MonoBehaviour
 
     private IEnumerator GetFixtureConfig()
     {
-        var numTries = 0;
-        while (numTries < 5)
+        if (Application.platform == RuntimePlatform.Android ||
+            Application.platform == RuntimePlatform.IPhonePlayer)
         {
-            if (File.Exists(_fixtureConfigPath))
+            var numTries = 0;
+            while (numTries < 5)
             {
-                var configJson = File.ReadAllText(_fixtureConfigPath);
-                Debug.Log("Mazerunner got fixture config json: " + configJson);
-                var config = JsonUtility.FromJson<FixtureConfig>(configJson);
-                _mazeHost = "http://" + config.maze_address;
-            }
-            else
-            {
-                Debug.Log("Mazerunner no fixture config found at path: " + _fixtureConfigPath);
-                numTries++;
-                yield return new WaitForSeconds(1);
+                var configPath = Application.persistentDataPath + _fixtureConfigFileName;
+                if (File.Exists(configPath))
+                {
+                    var configJson = File.ReadAllText(configPath);
+                    Debug.Log("Mazerunner got fixture config json: " + configJson);
+                    var config = JsonUtility.FromJson<FixtureConfig>(configJson);
+                    _mazeHost = "http://" + config.maze_address;
+                    break;
+                }
+                else
+                {
+                    Debug.Log("Mazerunner no fixture config found at path: " + configPath);
+                    numTries++;
+                    yield return new WaitForSeconds(1);
+                }
             }
         }
 


### PR DESCRIPTION
## Goal

Get a config file pushed to Android and iOS devices by mazerunener.
Then set the mazerunner host address with the value contained within.

For more details see here: https://github.com/bugsnag/bugsnag-android/pull/1796

## Changeset

- On Android and iOS, check for the existence of the fixture config file, try 5 times over a perioud of 5 seconds. if not found then use the existing default values.

## Testing

Covered in existing ci tests