### PR TITLE
[PLAT-9860] Move Android tests over to BitBar

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -335,7 +335,7 @@ steps:
 
   - label: ':android: Run Android e2e tests for Unity 2021'
     timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2019'
+    depends_on: 'build-android-fixture-2021'
     agents:
       queue: opensource
     env:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -286,18 +286,21 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
         upload:
           - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
           - "features/csharp"
           - "features/android"
-
-    concurrency: 5
-    concurrency_group: browserstack-app
+          - "--app=features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_11"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
   - label: ':android: Run Android e2e tests for Unity 2019'
@@ -305,47 +308,59 @@ steps:
     depends_on: 'build-android-fixture-2019'
     agents:
       queue: opensource
+    env:
+      UNITY_VERSION: "2019.4.35f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
         upload:
           - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
           - "features/csharp"
           - "features/android"
-    concurrency: 5
-    concurrency_group: browserstack-app
+          - "--app=features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_11"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
   - label: ':android: Run Android e2e tests for Unity 2021'
     timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2021'
+    depends_on: 'build-android-fixture-2019'
     agents:
       queue: opensource
+    env:
+      UNITY_VERSION: "2021.3.13f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - "features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
         upload:
           - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
           - "features/csharp"
           - "features/android"
-    concurrency: 5
-    concurrency_group: browserstack-app
+          - "--app=features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_11"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
   # - label: ':android: Run Android EDM e2e tests for Unity 2021'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -159,7 +159,7 @@ steps:
 
   #
   # Run Android tests
-  # 
+  #
   - label: ':android: Run Android e2e tests for Unity 2020'
     timeout_in_minutes: 60
     depends_on: 'build-android-fixture-2020'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -181,7 +181,7 @@ steps:
           - "features/android"
           - "--app=features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
           - "--farm=bb"
-          - "--device=ANDROID_11_0"
+          - "--device=ANDROID_11"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,6 +176,7 @@ steps:
       docker-compose#v4.7.0:
         pull: android-maze-runner-bitbar
         run: android-maze-runner-bitbar
+        service-ports: true
         command:
           - "features/csharp"
           - "features/android"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,221 +3,137 @@ agents:
 
 steps:
 
-  - label: ':android: Run Android e2e tests for Unity 2020'
-    timeout_in_minutes: 60
-    #    depends_on: 'build-android-fixture-2020'
-    agents:
-      queue: opensource
+  #
+  # Build notifier.  We run tests for all Unity versions with the 2018 artifacts, as that is what we ship.
+  #
+  - label: Build released notifier artifact
+    timeout_in_minutes: 30
+    key: 'build-artifacts'
     env:
-      UNITY_VERSION: "2020.3.32f1"
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2018.4.36f1"
+    commands:
+      - bundle install
+      - bundle exec rake plugin:export
+    artifact_paths:
+      - Bugsnag.unitypackage
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: Ensure notifier builds on Windows (for development)
+    timeout_in_minutes: 30
+    agents:
+      queue: windows-unity-wsl
+    env:
+      UNITY_VERSION: "2018.4.36f1"
+      WSLENV: UNITY_VERSION
+    command:
+      - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
     plugins:
       artifacts#v1.5.0:
         upload:
-          - "maze_output/**/*"
-      docker-compose#v4.7.0:
-        pull: android-maze-runner-bitbar
-        run: android-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/android"
-          - "--app=186094565"
-          - "--farm=bb"
-          - "--device=ANDROID_11"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: 'bitbar-app'
-    concurrency_method: eager
+          - from: Bugsnag.unitypackage
+            to: Bugsnag_WindowsBuilt.unitypackage
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
-  - label: ':android: Run Android e2e tests for Unity 2020'
-    timeout_in_minutes: 60
-    #    depends_on: 'build-android-fixture-2020'
-    agents:
-      queue: opensource
+  #
+  # Build MacOS and WebGL test fixtures
+  #
+  - label: Build Unity 2020 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
+    key: 'cocoa-webgl-2020-fixtures'
+    depends_on: 'build-artifacts'
     env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2020.3.32f1"
+      # Python2 needed for WebGL to build
+      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
     plugins:
       artifacts#v1.5.0:
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v4.7.0:
-        pull: android-maze-runner-bitbar
-        run: android-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/android"
-          - "--app=186094565"
-          - "--farm=bb"
-          - "--device=ANDROID_11"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: 'bitbar-app'
-    concurrency_method: eager
-
-  - label: ':android: Run Android e2e tests for Unity 2020'
-    timeout_in_minutes: 60
-    #    depends_on: 'build-android-fixture-2020'
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v4.7.0:
-        pull: android-maze-runner-bitbar
-        run: android-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/android"
-          - "--app=186094565"
-          - "--farm=bb"
-          - "--device=ANDROID_11"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: 'bitbar-app'
-    concurrency_method: eager
-
-#  #
-#  # Build notifier.  We run tests for all Unity versions with the 2018 artifacts, as that is what we ship.
-#  #
-#  - label: Build released notifier artifact
-#    timeout_in_minutes: 30
-#    key: 'build-artifacts'
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2018.4.36f1"
-#    commands:
-#      - bundle install
-#      - bundle exec rake plugin:export
-#    artifact_paths:
-#      - Bugsnag.unitypackage
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: Ensure notifier builds on Windows (for development)
-#    timeout_in_minutes: 30
-#    agents:
-#      queue: windows-unity-wsl
-#    env:
-#      UNITY_VERSION: "2018.4.36f1"
-#      WSLENV: UNITY_VERSION
-#    command:
-#      - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
-#    plugins:
-#      artifacts#v1.5.0:
-#        upload:
-#          - from: Bugsnag.unitypackage
-#            to: Bugsnag_WindowsBuilt.unitypackage
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  #
-#  # Build MacOS and WebGL test fixtures
-#  #
-#  - label: Build Unity 2020 MacOS and WebGL test fixtures
-#    timeout_in_minutes: 30
-#    key: 'cocoa-webgl-2020-fixtures'
-#    depends_on: 'build-artifacts'
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2020.3.32f1"
-#      # Python2 needed for WebGL to build
-#      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#    commands:
-#      - scripts/ci-build-macos-packages.sh
-#    artifact_paths:
-#      - unity.log
-#      - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
-#      - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
+        download:
+          - Bugsnag.unitypackage
+    commands:
+      - scripts/ci-build-macos-packages.sh
+    artifact_paths:
+      - unity.log
+      - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
 
 
   #
   # Run macos tests
   #
-#  - label: Run MacOS e2e csharp tests
-#    timeout_in_minutes: 60
-#    depends_on: 'cocoa-webgl-2020-fixtures'
-#    agents:
-#      queue: macos-12-arm-unity
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
-#        upload:
-#          - maze_output/**/*
-#          - Mazerunner.log
-#    commands:
-#      - scripts/ci-run-macos-tests-csharp.sh
+  - label: Run MacOS e2e csharp tests
+    timeout_in_minutes: 60
+    depends_on: 'cocoa-webgl-2020-fixtures'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
+        upload:
+          - maze_output/**/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-macos-tests-csharp.sh
 
   #
   # Run WebGL tests
   #
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
 
-#  - label: Run WebGL e2e tests for Unity 2020
-#    timeout_in_minutes: 30
-#    depends_on: 'cocoa-webgl-2020-fixtures'
-#    agents:
-#      queue: opensource-mac-cocoa-11
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
-#        upload:
-#          - maze_output/**/*
-#    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-#    commands:
-#      - scripts/ci-run-webgl-tests.sh
-#
-#
-#  # Build Android test fixtures
-#
-#  - label: ':android: Build Android test fixture for Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'build-android-fixture-2020'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
-#          - features/fixtures/unity.log
-#    commands:
-#      - rake test:android:build
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
+  - label: Run WebGL e2e tests for Unity 2020
+    timeout_in_minutes: 30
+    depends_on: 'cocoa-webgl-2020-fixtures'
+    agents:
+      queue: opensource-mac-cocoa-11
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
+        upload:
+          - maze_output/**/*
+    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+    commands:
+      - scripts/ci-run-webgl-tests.sh
+
+
+  # Build Android test fixtures
+
+  - label: ':android: Build Android test fixture for Unity 2020'
+    timeout_in_minutes: 30
+    key: 'build-android-fixture-2020'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
+          - features/fixtures/unity.log
+    commands:
+      - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
   # - label: ':android: Build Android EDM test fixture for Unity 2020'
   #   timeout_in_minutes: 30
@@ -243,36 +159,36 @@ steps:
 
   #
   # Run Android tests
-  # 186094565
-#  - label: ':android: Run Android e2e tests for Unity 2020'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-android-fixture-2020'
-#    agents:
-#      queue: opensource
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v4.7.0:
-#        pull: android-maze-runner-bitbar
-#        run: android-maze-runner-bitbar
-#        service-ports: true
-#        command:
-#          - "features/csharp"
-#          - "features/android"
-#          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
-#          - "--farm=bb"
-#          - "--device=ANDROID_11"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    concurrency: 25
-#    concurrency_group: 'bitbar-app'
-#    concurrency_method: eager
+  # 
+  - label: ':android: Run Android e2e tests for Unity 2020'
+    timeout_in_minutes: 60
+    depends_on: 'build-android-fixture-2020'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/csharp"
+          - "features/android"
+          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_11"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
 
 
   # Run Android EDM tests
@@ -304,128 +220,128 @@ steps:
 
   #
   # Build iOS test fixtures
-#  #
-#  - label: ':ios: Generate Xcode project - Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'generate-fixture-project-2020'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/unity.log
-#          - project_2020.tgz
-#    commands:
-#      - rake test:ios:generate_xcode
-#      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':ios: Build iOS test fixture for Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'build-ios-fixture-2020'
-#    depends_on: 'generate-fixture-project-2020'
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#          - project_2020.tgz
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa
-#          - features/fixtures/unity.log
-#    commands:
-#      - tar -zxf project_2020.tgz features/fixtures/maze_runner
-#      - rake test:ios:build_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  #
-#  # Run iOS tests
-#  #
-#  - label: ':ios: Run iOS e2e tests for Unity 2020'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-ios-fixture-2020'
-#    agents:
-#      queue: opensource
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
-#        upload:
-#          - "maze_output/**/*"
-#      docker-compose#v3.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        command:
-#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
-#          - "--farm=bs"
-#          - "--device=IOS_15"
-#          - "--fail-fast"
-#          - "features/csharp"
-#          - "features/ios"
-#
-#    concurrency: 5
-#    concurrency_group: browserstack-app
-#    concurrency_method: eager
-#
-#  #
-#  # Build Windows test fixture
-#
-#  - label: Build Unity 2020 Windows test fixture
-#    timeout_in_minutes: 30
-#    key: 'windows-2020-fixture'
-#    depends_on: 'build-artifacts'
-#    agents:
-#      queue: windows-unity-wsl
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - unity.log
-#          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
-#    commands:
-#      - scripts/ci-build-windows-fixture-wsl.sh
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  #
-#  # Run Windows e2e tests
-#
-#  - label: Run Windows e2e tests for Unity 2020
-#    timeout_in_minutes: 30
-#    depends_on: 'windows-2020-fixture'
-#    agents:
-#      queue: windows-general-wsl
-#    env:
-#      UNITY_VERSION: "2020.3.32f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
-#        upload:
-#          - maze_output/**/*
-#    command:
-#      - scripts/ci-run-windows-tests-wsl.sh
-#
-#  #
-#  # Conditionally trigger full pipeline
-#  #
-#  - label: 'Conditionally trigger full set of tests'
-#    timeout_in_minutes: 30
-#    command: sh -c .buildkite/pipeline_trigger.sh
+  #
+  - label: ':ios: Generate Xcode project - Unity 2020'
+    timeout_in_minutes: 30
+    key: 'generate-fixture-project-2020'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/unity.log
+          - project_2020.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Build iOS test fixture for Unity 2020'
+    timeout_in_minutes: 30
+    key: 'build-ios-fixture-2020'
+    depends_on: 'generate-fixture-project-2020'
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+          - project_2020.tgz
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa
+          - features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2020.tgz features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  #
+  # Run iOS tests
+  #
+  - label: ':ios: Run iOS e2e tests for Unity 2020'
+    timeout_in_minutes: 60
+    depends_on: 'build-ios-fixture-2020'
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
+          - "--farm=bs"
+          - "--device=IOS_15"
+          - "--fail-fast"
+          - "features/csharp"
+          - "features/ios"
+
+    concurrency: 5
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+
+  #
+  # Build Windows test fixture
+
+  - label: Build Unity 2020 Windows test fixture
+    timeout_in_minutes: 30
+    key: 'windows-2020-fixture'
+    depends_on: 'build-artifacts'
+    agents:
+      queue: windows-unity-wsl
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - unity.log
+          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
+    commands:
+      - scripts/ci-build-windows-fixture-wsl.sh
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  #
+  # Run Windows e2e tests
+
+  - label: Run Windows e2e tests for Unity 2020
+    timeout_in_minutes: 30
+    depends_on: 'windows-2020-fixture'
+    agents:
+      queue: windows-general-wsl
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
+        upload:
+          - maze_output/**/*
+    command:
+      - scripts/ci-run-windows-tests-wsl.sh
+
+  #
+  # Conditionally trigger full pipeline
+  #
+  - label: 'Conditionally trigger full set of tests'
+    timeout_in_minutes: 30
+    command: sh -c .buildkite/pipeline_trigger.sh
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -179,7 +179,7 @@ steps:
         command:
           - "features/csharp"
           - "features/android"
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
           - "--farm=bb"
           - "--device=ANDROID_11_0"
           - "--no-tunnel"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,8 +12,6 @@ steps:
       UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
         upload:
           - "maze_output/**/*"
       docker-compose#v4.7.0:
@@ -42,8 +40,6 @@ steps:
       UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
         upload:
           - "maze_output/**/*"
       docker-compose#v4.7.0:
@@ -72,8 +68,6 @@ steps:
       UNITY_VERSION: "2020.3.32f1"
     plugins:
       artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
         upload:
           - "maze_output/**/*"
       docker-compose#v4.7.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -177,13 +177,16 @@ steps:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_11_0"
           - "features/csharp"
           - "features/android"
-    concurrency: 5
-    concurrency_group: browserstack-app
+          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_11_0"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,137 +3,227 @@ agents:
 
 steps:
 
-  #
-  # Build notifier.  We run tests for all Unity versions with the 2018 artifacts, as that is what we ship.
-  #
-  - label: Build released notifier artifact
-    timeout_in_minutes: 30
-    key: 'build-artifacts'
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2018.4.36f1"
-    commands:
-      - bundle install
-      - bundle exec rake plugin:export
-    artifact_paths:
-      - Bugsnag.unitypackage
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: Ensure notifier builds on Windows (for development)
-    timeout_in_minutes: 30
+  - label: ':android: Run Android e2e tests for Unity 2020'
+    timeout_in_minutes: 60
+    #    depends_on: 'build-android-fixture-2020'
     agents:
-      queue: windows-unity-wsl
+      queue: opensource
     env:
-      UNITY_VERSION: "2018.4.36f1"
-      WSLENV: UNITY_VERSION
-    command:
-      - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
-    plugins:
-      artifacts#v1.5.0:
-        upload:
-          - from: Bugsnag.unitypackage
-            to: Bugsnag_WindowsBuilt.unitypackage
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  #
-  # Build MacOS and WebGL test fixtures
-  #
-  - label: Build Unity 2020 MacOS and WebGL test fixtures
-    timeout_in_minutes: 30
-    key: 'cocoa-webgl-2020-fixtures'
-    depends_on: 'build-artifacts'
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2020.3.32f1"
-      # Python2 needed for WebGL to build
-      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
     plugins:
       artifacts#v1.5.0:
         download:
-          - Bugsnag.unitypackage
-    commands:
-      - scripts/ci-build-macos-packages.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/csharp"
+          - "features/android"
+          - "--app=186094565"
+          - "--farm=bb"
+          - "--device=ANDROID_11"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+
+  - label: ':android: Run Android e2e tests for Unity 2020'
+    timeout_in_minutes: 60
+    #    depends_on: 'build-android-fixture-2020'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/csharp"
+          - "features/android"
+          - "--app=186094565"
+          - "--farm=bb"
+          - "--device=ANDROID_11"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+
+  - label: ':android: Run Android e2e tests for Unity 2020'
+    timeout_in_minutes: 60
+    #    depends_on: 'build-android-fixture-2020'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2020.3.32f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+        upload:
+          - "maze_output/**/*"
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/csharp"
+          - "features/android"
+          - "--app=186094565"
+          - "--farm=bb"
+          - "--device=ANDROID_11"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+
+#  #
+#  # Build notifier.  We run tests for all Unity versions with the 2018 artifacts, as that is what we ship.
+#  #
+#  - label: Build released notifier artifact
+#    timeout_in_minutes: 30
+#    key: 'build-artifacts'
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2018.4.36f1"
+#    commands:
+#      - bundle install
+#      - bundle exec rake plugin:export
+#    artifact_paths:
+#      - Bugsnag.unitypackage
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: Ensure notifier builds on Windows (for development)
+#    timeout_in_minutes: 30
+#    agents:
+#      queue: windows-unity-wsl
+#    env:
+#      UNITY_VERSION: "2018.4.36f1"
+#      WSLENV: UNITY_VERSION
+#    command:
+#      - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
+#    plugins:
+#      artifacts#v1.5.0:
+#        upload:
+#          - from: Bugsnag.unitypackage
+#            to: Bugsnag_WindowsBuilt.unitypackage
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  #
+#  # Build MacOS and WebGL test fixtures
+#  #
+#  - label: Build Unity 2020 MacOS and WebGL test fixtures
+#    timeout_in_minutes: 30
+#    key: 'cocoa-webgl-2020-fixtures'
+#    depends_on: 'build-artifacts'
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2020.3.32f1"
+#      # Python2 needed for WebGL to build
+#      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#    commands:
+#      - scripts/ci-build-macos-packages.sh
+#    artifact_paths:
+#      - unity.log
+#      - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
+#      - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
 
 
 
   #
   # Run macos tests
   #
-  - label: Run MacOS e2e csharp tests
-    timeout_in_minutes: 60
-    depends_on: 'cocoa-webgl-2020-fixtures'
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
-        upload:
-          - maze_output/**/*
-          - Mazerunner.log
-    commands:
-      - scripts/ci-run-macos-tests-csharp.sh
+#  - label: Run MacOS e2e csharp tests
+#    timeout_in_minutes: 60
+#    depends_on: 'cocoa-webgl-2020-fixtures'
+#    agents:
+#      queue: macos-12-arm-unity
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - features/fixtures/maze_runner/build/MacOS-2020.3.32f1.zip
+#        upload:
+#          - maze_output/**/*
+#          - Mazerunner.log
+#    commands:
+#      - scripts/ci-run-macos-tests-csharp.sh
 
   #
   # Run WebGL tests
   #
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
 
-  - label: Run WebGL e2e tests for Unity 2020
-    timeout_in_minutes: 30
-    depends_on: 'cocoa-webgl-2020-fixtures'
-    agents:
-      queue: opensource-mac-cocoa-11
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
-        upload:
-          - maze_output/**/*
-    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-    commands:
-      - scripts/ci-run-webgl-tests.sh
-
-
-  # Build Android test fixtures
-
-  - label: ':android: Build Android test fixture for Unity 2020'
-    timeout_in_minutes: 30
-    key: 'build-android-fixture-2020'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
-          - features/fixtures/unity.log
-    commands:
-      - rake test:android:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+#  - label: Run WebGL e2e tests for Unity 2020
+#    timeout_in_minutes: 30
+#    depends_on: 'cocoa-webgl-2020-fixtures'
+#    agents:
+#      queue: opensource-mac-cocoa-11
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - features/fixtures/maze_runner/build/WebGL-2020.3.32f1.zip
+#        upload:
+#          - maze_output/**/*
+#    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+#    commands:
+#      - scripts/ci-run-webgl-tests.sh
+#
+#
+#  # Build Android test fixtures
+#
+#  - label: ':android: Build Android test fixture for Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'build-android-fixture-2020'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
+#          - features/fixtures/unity.log
+#    commands:
+#      - rake test:android:build
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
 
   # - label: ':android: Build Android EDM test fixture for Unity 2020'
   #   timeout_in_minutes: 30
@@ -159,36 +249,36 @@ steps:
 
   #
   # Run Android tests
-  #
-  - label: ':android: Run Android e2e tests for Unity 2020'
-    timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2020'
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v4.7.0:
-        pull: android-maze-runner-bitbar
-        run: android-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/android"
-          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
-          - "--farm=bb"
-          - "--device=ANDROID_11"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: 'bitbar-app'
-    concurrency_method: eager
+  # 186094565
+#  - label: ':android: Run Android e2e tests for Unity 2020'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-android-fixture-2020'
+#    agents:
+#      queue: opensource
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v4.7.0:
+#        pull: android-maze-runner-bitbar
+#        run: android-maze-runner-bitbar
+#        service-ports: true
+#        command:
+#          - "features/csharp"
+#          - "features/android"
+#          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
+#          - "--farm=bb"
+#          - "--device=ANDROID_11"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    concurrency: 25
+#    concurrency_group: 'bitbar-app'
+#    concurrency_method: eager
 
 
   # Run Android EDM tests
@@ -220,128 +310,128 @@ steps:
 
   #
   # Build iOS test fixtures
-  #
-  - label: ':ios: Generate Xcode project - Unity 2020'
-    timeout_in_minutes: 30
-    key: 'generate-fixture-project-2020'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/unity.log
-          - project_2020.tgz
-    commands:
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':ios: Build iOS test fixture for Unity 2020'
-    timeout_in_minutes: 30
-    key: 'build-ios-fixture-2020'
-    depends_on: 'generate-fixture-project-2020'
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-          - project_2020.tgz
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa
-          - features/fixtures/unity.log
-    commands:
-      - tar -zxf project_2020.tgz features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  #
-  # Run iOS tests
-  #
-  - label: ':ios: Run iOS e2e tests for Unity 2020'
-    timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2020'
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
-        upload:
-          - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
-        command:
-          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
-          - "--farm=bs"
-          - "--device=IOS_15"
-          - "--fail-fast"
-          - "features/csharp"
-          - "features/ios"
-
-    concurrency: 5
-    concurrency_group: browserstack-app
-    concurrency_method: eager
-
-  #
-  # Build Windows test fixture
-
-  - label: Build Unity 2020 Windows test fixture
-    timeout_in_minutes: 30
-    key: 'windows-2020-fixture'
-    depends_on: 'build-artifacts'
-    agents:
-      queue: windows-unity-wsl
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - unity.log
-          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
-    commands:
-      - scripts/ci-build-windows-fixture-wsl.sh
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  #
-  # Run Windows e2e tests
-
-  - label: Run Windows e2e tests for Unity 2020
-    timeout_in_minutes: 30
-    depends_on: 'windows-2020-fixture'
-    agents:
-      queue: windows-general-wsl
-    env:
-      UNITY_VERSION: "2020.3.32f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
-        upload:
-          - maze_output/**/*
-    command:
-      - scripts/ci-run-windows-tests-wsl.sh
-
-  #
-  # Conditionally trigger full pipeline
-  #
-  - label: 'Conditionally trigger full set of tests'
-    timeout_in_minutes: 30
-    command: sh -c .buildkite/pipeline_trigger.sh
+#  #
+#  - label: ':ios: Generate Xcode project - Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'generate-fixture-project-2020'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/unity.log
+#          - project_2020.tgz
+#    commands:
+#      - rake test:ios:generate_xcode
+#      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':ios: Build iOS test fixture for Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'build-ios-fixture-2020'
+#    depends_on: 'generate-fixture-project-2020'
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#          - project_2020.tgz
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa
+#          - features/fixtures/unity.log
+#    commands:
+#      - tar -zxf project_2020.tgz features/fixtures/maze_runner
+#      - rake test:ios:build_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  #
+#  # Run iOS tests
+#  #
+#  - label: ':ios: Run iOS e2e tests for Unity 2020'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-ios-fixture-2020'
+#    agents:
+#      queue: opensource
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
+#        upload:
+#          - "maze_output/**/*"
+#      docker-compose#v3.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        command:
+#          - "--app=/app/features/fixtures/maze_runner/mazerunner_2020.3.32f1.ipa"
+#          - "--farm=bs"
+#          - "--device=IOS_15"
+#          - "--fail-fast"
+#          - "features/csharp"
+#          - "features/ios"
+#
+#    concurrency: 5
+#    concurrency_group: browserstack-app
+#    concurrency_method: eager
+#
+#  #
+#  # Build Windows test fixture
+#
+#  - label: Build Unity 2020 Windows test fixture
+#    timeout_in_minutes: 30
+#    key: 'windows-2020-fixture'
+#    depends_on: 'build-artifacts'
+#    agents:
+#      queue: windows-unity-wsl
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - unity.log
+#          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
+#    commands:
+#      - scripts/ci-build-windows-fixture-wsl.sh
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  #
+#  # Run Windows e2e tests
+#
+#  - label: Run Windows e2e tests for Unity 2020
+#    timeout_in_minutes: 30
+#    depends_on: 'windows-2020-fixture'
+#    agents:
+#      queue: windows-general-wsl
+#    env:
+#      UNITY_VERSION: "2020.3.32f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - features/fixtures/maze_runner/build/Windows-2020.3.32f1.zip
+#        upload:
+#          - maze_output/**/*
+#    command:
+#      - scripts/ci-run-windows-tests-wsl.sh
+#
+#  #
+#  # Conditionally trigger full pipeline
+#  #
+#  - label: 'Conditionally trigger full set of tests'
+#    timeout_in_minutes: 30
+#    command: sh -c .buildkite/pipeline_trigger.sh
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -173,9 +173,9 @@ steps:
           - "features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk"
         upload:
           - "maze_output/**/*"
-      docker-compose#v3.7.0:
-        pull: maze-runner
-        run: maze-runner
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
         command:
           - "features/csharp"
           - "features/android"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ x-common-environment: &common-environment
   BUILDKITE_STEP_KEY:
   MAZE_BUGSNAG_API_KEY:
   TEST_FIXTURE_SYMBOL_DIR:
+  UNITY_VERSION:
 
 services:
   maze-runner:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,23 @@
 version: '3.6'
-services:
 
+x-common-environment: &common-environment
+  DEBUG:
+  BUILDKITE:
+  BUILDKITE_BRANCH:
+  BUILDKITE_BUILD_CREATOR:
+  BUILDKITE_BUILD_NUMBER:
+  BUILDKITE_BUILD_URL:
+  BUILDKITE_LABEL:
+  BUILDKITE_MESSAGE:
+  BUILDKITE_PIPELINE_NAME:
+  BUILDKITE_PIPELINE_SLUG:
+  BUILDKITE_REPO:
+  BUILDKITE_RETRY_COUNT:
+  BUILDKITE_STEP_KEY:
+  MAZE_BUGSNAG_API_KEY:
+  TEST_FIXTURE_SYMBOL_DIR:
+
+services:
   maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
     environment:
@@ -14,3 +31,17 @@ services:
       - ./test:/app/test
       - ./features/:/app/features
       - ./maze_output:/app/maze_output
+
+  android-maze-runner-bitbar:
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
+    environment:
+      <<: *common-environment
+      BITBAR_USERNAME:
+      BITBAR_ACCESS_KEY:
+    ports:
+      - "9000-9499:9339"
+    volumes:
+      - ./test:/app/test
+      - ./features/:/app/features
+      - ./maze_output:/app/maze_output
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -105,8 +105,8 @@ Feature: csharp events
     When I run the game in the "InnerException" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the event "exceptions.0.message" equals "Outer"
-    And the event "exceptions.1.message" equals "Inner"
+    And the event "exceptions.0.message" equals "Inner"
+    And the event "exceptions.1.message" equals "Outer"
     And the event "exceptions.2" is null
 
   Scenario: Reporting an uncaught exception in an async method

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -105,8 +105,8 @@ Feature: csharp events
     When I run the game in the "InnerException" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the event "exceptions.0.message" equals "Inner"
-    And the event "exceptions.1.message" equals "Outer"
+    And the event "exceptions.0.message" equals "Outer"
+    And the event "exceptions.1.message" equals "Inner"
     And the event "exceptions.2" is null
 
   Scenario: Reporting an uncaught exception in an async method

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -1,7 +1,7 @@
 require 'cgi'
 
 When('On Mobile I relaunch the app') do
-  next unless %w[android ios].include? Maze::Helper.get_current_platform 
+  next unless %w[android ios].include? Maze::Helper.get_current_platform
   Maze.driver.launch_app
   sleep 3
 end
@@ -136,14 +136,7 @@ Then('the error is valid for the error reporting API sent by the Unity notifier'
     Maze.config.os
   end
 
-  notifier_name = case os
-                  when 'ios'
-                    'Unity Bugsnag Notifier'
-                  when 'android'
-                    'Android Bugsnag Notifier'
-                  else
-                    'Unity Bugsnag Notifier'
-                  end
+  notifier_name = 'Unity Bugsnag Notifier'
 
   check_error_reporting_api notifier_name
 end


### PR DESCRIPTION
## Goal

Update tests and CI to move them from Browserstack over to BitBar.

## Testing

Covered by `[full ci]`