### PR TITLE
fix formatting of stacktraces containing wrapper entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@
 
 * Fix an issue where stack frames containing (wrapper some/wrapper) entries were incorrectly formatted. [#713](https://github.com/bugsnag/bugsnag-unity/pull/713)
 
-### Bug fixes
-
 * Fix an issue where Config.GenerateAnonymousId was not respected. [#704](https://github.com/bugsnag/bugsnag-unity/pull/704)
 
 ## 7.5.2 (2023-03-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ### Bug fixes
 
+* Fix an issue where stack frames containing (wrapper some/wrapper) entries were incorrectly formatted. [#713](https://github.com/bugsnag/bugsnag-unity/pull/713)
+
+### Bug fixes
+
 * Fix an issue where Config.GenerateAnonymousId was not respected. [#704](https://github.com/bugsnag/bugsnag-unity/pull/704)
 
 ## 7.5.2 (2023-03-08)

--- a/src/BugsnagUnity/Payload/StackTraceLine.cs
+++ b/src/BugsnagUnity/Payload/StackTraceLine.cs
@@ -72,7 +72,7 @@ namespace BugsnagUnity.Payload
     public class StackTraceLine : Dictionary<string, object>, IStackframe
     {
         private static Regex StackTraceLineRegex { get; } = new Regex(@"(?:\s*at\s)?(?<method>(?:\(.*\)\s)?[^()]+)(?<methodargs>\([^()]*?\))(?:\s(?:\[.*\]\s*in\s|\(at\s*\s*)(?<file>.*):(?<linenumber>\d+))?");
-        private static Regex StackTraceAndroidJavaLineRegex { get; } = new Regex(@"^\s*(?<method>[a-z][^()]+)\((?<file>[^:]*)?(?::(?<linenumber>\d+))?\)");
+        private static Regex StackTraceAndroidJavaLineRegex { get; } = new Regex(@"^\s*(?:at\s)?(?<method>[a-z][^()]+)\((?<file>[^:]*)?(?::(?<linenumber>\d+))?\)");
 
 
         public static StackTraceLine FromLogMessage(string message)

--- a/src/BugsnagUnity/Payload/StackTraceLine.cs
+++ b/src/BugsnagUnity/Payload/StackTraceLine.cs
@@ -46,10 +46,6 @@ namespace BugsnagUnity.Payload
 
                 if (frame != null)
                 {
-                    if (frame.Method.StartsWith("at "))
-                    {
-                        frame.Method = frame.Method.Remove(0, 3);
-                    }
                     frames.Add(frame);
                 }
             }
@@ -75,21 +71,13 @@ namespace BugsnagUnity.Payload
     /// </summary>
     public class StackTraceLine : Dictionary<string, object>, IStackframe
     {
-        private static Regex StackTraceLineRegex { get; } = new Regex(@"(?<method>[^()]+)(?<methodargs>\([^()]*?\))(?:\s(?:\[.*\]\s*in\s|\(at\s*\s*)(?<file>.*):(?<linenumber>\d+))?");
+        private static Regex StackTraceLineRegex { get; } = new Regex(@"(?:at\s)?(?<method>(?:\(.*\)\s)?[^()]+)(?<methodargs>\([^()]*?\))(?:\s(?:\[.*\]\s*in\s|\(at\s*\s*)(?<file>.*):(?<linenumber>\d+))?");
         private static Regex StackTraceAndroidJavaLineRegex { get; } = new Regex(@"^\s*(?<method>[a-z][^()]+)\((?<file>[^:]*)?(?::(?<linenumber>\d+))?\)");
 
 
         public static StackTraceLine FromLogMessage(string message)
-        {
-
-            var wrapperMatch = new Regex(@"at \(wrapper \S+\)").Match(message);
-            if (wrapperMatch.Success)
-            {
-                message = message.Replace(wrapperMatch.Value, string.Empty);
-            }
-
+        {          
             Match match = StackTraceLineRegex.Match(message);
-
             if (match.Success)
             {              
                 int? lineNumber = null;
@@ -100,10 +88,6 @@ namespace BugsnagUnity.Payload
                 }
                 string method = string.Join("", new string[]{match.Groups["method"].Value.Trim(),
                                                      match.Groups["methodargs"].Value});
-                if (wrapperMatch.Success)
-                {
-                    method = wrapperMatch.Value + method;
-                }
                 return new StackTraceLine(match.Groups["file"].Value,
                                           lineNumber, method);
             }

--- a/src/BugsnagUnity/Payload/StackTraceLine.cs
+++ b/src/BugsnagUnity/Payload/StackTraceLine.cs
@@ -71,15 +71,15 @@ namespace BugsnagUnity.Payload
     /// </summary>
     public class StackTraceLine : Dictionary<string, object>, IStackframe
     {
-        private static Regex StackTraceLineRegex { get; } = new Regex(@"(?:at\s)?(?<method>(?:\(.*\)\s)?[^()]+)(?<methodargs>\([^()]*?\))(?:\s(?:\[.*\]\s*in\s|\(at\s*\s*)(?<file>.*):(?<linenumber>\d+))?");
+        private static Regex StackTraceLineRegex { get; } = new Regex(@"(?:\s*at\s)?(?<method>(?:\(.*\)\s)?[^()]+)(?<methodargs>\([^()]*?\))(?:\s(?:\[.*\]\s*in\s|\(at\s*\s*)(?<file>.*):(?<linenumber>\d+))?");
         private static Regex StackTraceAndroidJavaLineRegex { get; } = new Regex(@"^\s*(?<method>[a-z][^()]+)\((?<file>[^:]*)?(?::(?<linenumber>\d+))?\)");
 
 
         public static StackTraceLine FromLogMessage(string message)
-        {          
+        {
             Match match = StackTraceLineRegex.Match(message);
             if (match.Success)
-            {              
+            {
                 int? lineNumber = null;
                 int parsedValue;
                 if (System.Int32.TryParse(match.Groups["linenumber"].Value, out parsedValue))

--- a/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
+++ b/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
@@ -99,10 +99,10 @@ namespace BugsnagUnity.Payload.Tests
         public void ParseUnknownManagedToNative()
         {
             var stackframe = Payload.StackTraceLine.FromLogMessage("at (wrapper managed-to-native) Program.NativeMethod(Program/StructToMarshal)");
-            Assert.AreEqual("at (wrapper managed-to-native)Program.NativeMethod(Program/StructToMarshal)", stackframe.Method);
+            Assert.AreEqual("(wrapper managed-to-native) Program.NativeMethod(Program/StructToMarshal)", stackframe.Method);
 
             stackframe = Payload.StackTraceLine.FromLogMessage("at (wrapper scoop-de-woop) SomeClass.SomeMethod(Program / Something else)");
-            Assert.AreEqual("at (wrapper scoop-de-woop)SomeClass.SomeMethod(Program / Something else)", stackframe.Method);
+            Assert.AreEqual("(wrapper scoop-de-woop) SomeClass.SomeMethod(Program / Something else)", stackframe.Method);
 
         }
     }

--- a/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
+++ b/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
@@ -99,10 +99,10 @@ namespace BugsnagUnity.Payload.Tests
         public void ParseUnknownManagedToNative()
         {
             var stackframe = Payload.StackTraceLine.FromLogMessage("at (wrapper managed-to-native) Program.NativeMethod(Program/StructToMarshal)");
-            Assert.AreEqual("(wrapper managed-to-native)Program.NativeMethod(Program/StructToMarshal)", stackframe.Method);
+            Assert.AreEqual("at (wrapper managed-to-native)Program.NativeMethod(Program/StructToMarshal)", stackframe.Method);
 
-            stackframe = Payload.StackTraceLine.FromLogMessage("at (wrapper scoop - de - woop) SomeClass.SomeMethod(Program / Something else)");
-            Assert.AreEqual("(wrapper scoop - de - woop)SomeClass.SomeMethod(Program / Something else)", stackframe.Method);
+            stackframe = Payload.StackTraceLine.FromLogMessage("at (wrapper scoop-de-woop) SomeClass.SomeMethod(Program / Something else)");
+            Assert.AreEqual("at (wrapper scoop-de-woop)SomeClass.SomeMethod(Program / Something else)", stackframe.Method);
 
         }
     }

--- a/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
+++ b/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
@@ -115,5 +115,14 @@ namespace BugsnagUnity.Payload.Tests
             Assert.AreEqual("(wrapper scoop-de-woop) SomeClass.SomeMethod(Program / Something else)", stackframe.Method);
 
         }
+
+        [Test]
+        public void ParseAndroidMethod()
+        {
+            var stackframe = Payload.StackTraceLine.FromAndroidJavaMessage("at com.example.lib.BugsnagCrash.throwJvmException(BugsnagCrash.java:14)");
+            Assert.AreEqual("com.example.lib.BugsnagCrash.throwJvmException()", stackframe.Method);
+            Assert.AreEqual("BugsnagCrash.java",stackframe.File);
+            Assert.AreEqual(14, stackframe.LineNumber);
+        }
     }
 }

--- a/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
+++ b/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
@@ -7,6 +7,16 @@ namespace BugsnagUnity.Payload.Tests
     [TestFixture]
     class StackFrameParsingTests
     {
+
+        [Test]
+        public void ParseMethodWithAt()
+        {
+            var stackframe = Payload.StackTraceLine.FromLogMessage(
+              "at UnityEngine.Events.InvokableCall.Invoke () [0x00010] in /Users/bokken/build/output/unity/unity/Runtime/Export/UnityEvent/UnityEvent.cs:178"
+            );
+            Assert.AreEqual("UnityEngine.Events.InvokableCall.Invoke()", stackframe.Method);
+        }
+
         [Test]
         public void ParseMethodNameWithColon()
         {

--- a/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
+++ b/tests/BugsnagUnity.Tests/StackFrameParsingTests.cs
@@ -94,5 +94,16 @@ namespace BugsnagUnity.Payload.Tests
             Assert.AreEqual(null, stackframe.LineNumber);
             Assert.AreEqual(null, stackframe.File);
         }
+
+        [Test]
+        public void ParseUnknownManagedToNative()
+        {
+            var stackframe = Payload.StackTraceLine.FromLogMessage("at (wrapper managed-to-native) Program.NativeMethod(Program/StructToMarshal)");
+            Assert.AreEqual("(wrapper managed-to-native)Program.NativeMethod(Program/StructToMarshal)", stackframe.Method);
+
+            stackframe = Payload.StackTraceLine.FromLogMessage("at (wrapper scoop - de - woop) SomeClass.SomeMethod(Program / Something else)");
+            Assert.AreEqual("(wrapper scoop - de - woop)SomeClass.SomeMethod(Program / Something else)", stackframe.Method);
+
+        }
     }
 }


### PR DESCRIPTION
## Goal

Some Unity stacktraces contain lines like the following
`at (wrapper managed-to-native) Program.NativeMethod(Program/StructToMarshal)`
Our trace formatter was confused by this and stripping out useful information, ending up with something like this:
`at(wrapper managed-to-native):0`

Now it will match the wrapper info and produce a frame like so:
`(wrapper managed-to-native)Program.NativeMethod(Program/StructToMarshal)`

## Changeset

Add a regex check for any wrapper type before a method name. If matched, then it temporarly removes it, allows the normal method parser to do it's work, and then reattaches the wrapper name to the beginning of the line.

## Testing

Added a unit test