### PR TITLE
PLAT-10165 fixture logging improvements

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -200,7 +200,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk
-          - features/fixtures/unity.log
+          - features/fixtures/build_android_apk.log
     commands:
       - rake test:android:build
     retry:
@@ -220,7 +220,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk
-          - features/fixtures/unity.log
+          - features/fixtures/build_android_apk.log
     commands:
       - rake test:android:build
     retry:
@@ -240,7 +240,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk
-          - features/fixtures/unity.log
+          - features/fixtures/build_android_apk.log
     commands:
       - rake test:android:build
     retry:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,7 +127,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
-          - features/fixtures/unity.log
+          - features/fixtures/build_android_apk.log
     commands:
       - rake test:android:build
     retry:

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -12,7 +12,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | NotifySmokeTest.Run()                                                       | Main+<RunNextMazeCommand>d__7.MoveNext() |
+      | NotifySmokeTest.Run()                                                       | Main+<RunNextMazeCommand>d__8.MoveNext() |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
@@ -26,7 +26,7 @@ Feature: csharp events
     And custom metadata is included in the event
     And the stack frame methods should match:
       | UncaughtExceptionSmokeTest.Run()                                                                 |                                          |
-      | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | Main+<RunNextMazeCommand>d__7.MoveNext() |
+      | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | Main+<RunNextMazeCommand>d__8.MoveNext() |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
@@ -39,7 +39,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogExceptionSmokeTest:Run()                   | DebugLogExceptionSmokeTest.Run()                                            | <RunNextMazeCommand>d__7:MoveNext()                            | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) |
+      | DebugLogExceptionSmokeTest:Run()                   | DebugLogExceptionSmokeTest.Run()                                            | <RunNextMazeCommand>d__8:MoveNext()                            | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -53,7 +53,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogErrorSmokeTest:Run()                       | DebugLogErrorSmokeTest.Run()                                                | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
+      | DebugLogErrorSmokeTest:Run()                       | DebugLogErrorSmokeTest.Run()                                                | <RunNextMazeCommand>d__8:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -67,7 +67,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogWarningSmokeTest:Run()                     | DebugLogWarningSmokeTest.Run()                                              | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
+      | DebugLogWarningSmokeTest:Run()                     | DebugLogWarningSmokeTest.Run()                                              | <RunNextMazeCommand>d__8:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -81,7 +81,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogSmokeTest:Run()                            | DebugLogSmokeTest.Run()                                                     | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
+      | DebugLogSmokeTest:Run()                            | DebugLogSmokeTest.Run()                                                     | <RunNextMazeCommand>d__8:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -95,7 +95,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogAssertSmokeTest:Run()                      | DebugLogAssertSmokeTest.Run()                                               | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
+      | DebugLogAssertSmokeTest:Run()                      | DebugLogAssertSmokeTest.Run()                                               | <RunNextMazeCommand>d__8:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event

--- a/features/fixtures/maze_runner/Assets/Scripts/Logger.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Logger.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class Logger : MonoBehaviour
+{
+
+    const string LOG_PREFIX = "BUGSNAG_MAZERUNNER_LOG : ";
+
+    const string LOG_FILE_NAME = "mazerunner-unity.log";
+
+    private static string _currentLog;
+
+    public static void I(string msg)
+    {
+        Debug.Log(LOG_PREFIX + msg);
+        _currentLog = msg + "\n";
+        WriteLogFile();
+    }
+
+    private static void WriteLogFile()
+    {
+        var path = Path.Combine(Application.persistentDataPath, LOG_FILE_NAME);
+        File.WriteAllText(path, _currentLog);
+    }
+   
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Logger.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Logger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c0b994281fb547a891f2ecbfc0fadb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -72,7 +72,7 @@ public class Main : MonoBehaviour
                 else
                 {
                     numTries++;
-                    Log(string.Format("Mazerunner didnt not find the config file at path {0}  try number {1}", configPath, numTries));
+                    Log(string.Format("Maze Runner did not find the config file at path {0}  try number {1}", configPath, numTries));
                     yield return new WaitForSeconds(1);
                 }
             }

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -36,11 +36,13 @@ public class Main : MonoBehaviour
     private const string API_KEY = "a35a2a72bd230ac0aa0f52715bbdc6aa";
     private string _mazeHost;
 
+    private const int MAX_CONFIG_GET_TRIES = 15;
+
     public ScenarioRunner ScenarioRunner;
 
     public IEnumerator Start()
     {
-        Debug.Log("Maze Runner app started");
+        Log("Maze Runner app started");
 
         yield return GetFixtureConfig();
 
@@ -56,21 +58,21 @@ public class Main : MonoBehaviour
             Application.platform == RuntimePlatform.IPhonePlayer)
         {
             var numTries = 0;
-            while (numTries < 5)
+            while (numTries < MAX_CONFIG_GET_TRIES)
             {
                 var configPath = Application.persistentDataPath + _fixtureConfigFileName;
                 if (File.Exists(configPath))
                 {
                     var configJson = File.ReadAllText(configPath);
-                    Debug.Log("Mazerunner got fixture config json: " + configJson);
+                    Log("Mazerunner got fixture config json: " + configJson);
                     var config = JsonUtility.FromJson<FixtureConfig>(configJson);
                     _mazeHost = "http://" + config.maze_address;
                     break;
                 }
                 else
                 {
-                    Debug.Log("Mazerunner no fixture config found at path: " + configPath);
                     numTries++;
+                    Log(string.Format("Mazerunner didnt not find the config file at path {0}  try number {1}", configPath, numTries));
                     yield return new WaitForSeconds(1);
                 }
             }
@@ -78,6 +80,7 @@ public class Main : MonoBehaviour
 
         if (string.IsNullOrEmpty(_mazeHost))
         {
+            Log("Host not set from config file, using hard coded");
             _mazeHost = "http://localhost:9339";
 
             if (Application.platform == RuntimePlatform.IPhonePlayer ||
@@ -86,7 +89,7 @@ public class Main : MonoBehaviour
                 _mazeHost = "http://bs-local.com:9339";
             }
         }
-        Debug.Log("Mazerunner host set to: " + _mazeHost);
+        Log("Mazerunner host set to: " + _mazeHost);
     }
 
     private void DoRunNextMazeCommand()
@@ -97,7 +100,7 @@ public class Main : MonoBehaviour
     IEnumerator RunNextMazeCommand()
     {
         var url = _mazeHost + "/command";
-        Console.WriteLine("RunNextMazeCommand called, requesting command from: {0}", url);
+        Log("Requesting maze command from: " + url);
         using (UnityWebRequest request = UnityWebRequest.Get(url))
         {
             yield return request.SendWebRequest();
@@ -109,23 +112,23 @@ public class Main : MonoBehaviour
                 !request.isNetworkError;
 #endif
 
-            Console.WriteLine("result is " + result);
+            Log("result is " + result);
             if (result)
             {
                 var response = request.downloadHandler?.text;
-                Console.WriteLine("Raw response: " + response);
+                Log("Raw response: " + response);
                 if (response == null || response == "null" || response == "No commands to provide")
                 {
-                    Console.WriteLine("No Maze Runner command to process at present");
+                    Log("No Maze Runner command to process at present");
                 }
                 else
                 { 
                     var command = JsonUtility.FromJson<Command>(response);
                     if (command != null)
                     {
-                        Console.WriteLine("Received Maze Runner command:");
-                        Console.WriteLine("Action: " + command.action);
-                        Console.WriteLine("Scenario: " + command.scenarioName);
+                        Log("Received Maze Runner command:");
+                        Log("Action: " + command.action);
+                        Log("Scenario: " + command.scenarioName);
 
                         if ("clear_cache".Equals(command.action))
                         {
@@ -176,6 +179,11 @@ public class Main : MonoBehaviour
 #if UNITY_IOS
         ClearPersistentData();
 #endif
+    }
+
+    private static void Log(string msg)
+    {
+        Logger.I(msg);
     }
 
 }

--- a/features/scripts/build_android.sh
+++ b/features/scripts/build_android.sh
@@ -15,7 +15,7 @@ popd
 pushd "$script_path/../fixtures"
 
 # Run unity and immediately exit afterwards, log all output
-DEFAULT_CLI_ARGS="-quit -batchmode -nographics -logFile unity.log"
+DEFAULT_CLI_ARGS="-quit -batchmode -nographics -logFile build_android_apk.log"
 
 project_path=`pwd`/maze_runner
 

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -290,6 +290,10 @@ namespace BugsnagUnity
             {
                 return;
             }
+            if (condition.StartsWith("BUGSNAG_MAZERUNNER_LOG"))
+            {
+                return;
+            }
             if (Configuration.AutoDetectErrors && logType.IsGreaterThanOrEqualTo(Configuration.NotifyLogLevel))
             {
                 var logMessage = new UnityLogMessage(condition, stackTrace, logType);


### PR DESCRIPTION
## Goal

- Improve Logging so that it's easier to debug flakes
- Allow longer for mazerunner to insert config file
- Pull simplified log file from device as artifact 

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->