### PR TITLE
PLAT-10216 prevent JNI call for session and event callbacks if not used

### DIFF
--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -575,7 +575,11 @@ namespace BugsnagUnity
 
         public void RemoveOnError(Func<IEvent, bool> bugsnagCallback) => Configuration.RemoveOnError(bugsnagCallback);
 
-        public void AddOnSession(Func<ISession, bool> callback) => Configuration.AddOnSession(callback);
+        public void AddOnSession(Func<ISession, bool> callback)
+        {
+            Configuration.AddOnSession(callback);
+            NativeClient.AddOnSession();
+        }
 
         public void RemoveOnSession(Func<ISession, bool> callback) => Configuration.RemoveOnSession(callback);
 

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -104,5 +104,7 @@ namespace BugsnagUnity
 
         bool ShouldAttemptDelivery();
 
+        void AddOnSession();
+
     }
 }

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -156,6 +156,11 @@ namespace BugsnagUnity
         {
             return true;
         }
+
+        public void AddOnSession()
+        {
+            NativeInterface.AddOnSession();
+        }
     }
 
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -449,5 +449,9 @@ namespace BugsnagUnity
         {
             return true;
         }
+
+        public void AddOnSession()
+        {
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -164,5 +164,9 @@ namespace BugsnagUnity
         {
             return true;
         }
+
+        public void AddOnSession()
+        {
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -211,5 +211,9 @@ namespace BugsnagUnity
         {
             return true;
         }
+
+        public void AddOnSession()
+        {
+        }
     }
 }


### PR DESCRIPTION
## Goal

prevent JNI call for session and event callbacks if not used.

If there are no C# callbacks then we shouldn't register a native Android callback. This will work around a timing issue for most people as session callbacks aren't widely used.

## Changeset

- Only add on session and on send error callbacks if they are in the c# config
- If addOnSession is called after start, then make the JNI call and register a native callback

## Testing

Manually tested and covered by existing e2e tests