### PR TITLE
prevent native calls for session and event callbacks if not used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'xcpretty'
 gem 'xcodeproj'
 
 # Use official Maze Runner release
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.4'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.27.0'
 
 # Use a specific Maze Runner branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -378,6 +378,12 @@ void bugsnag_markLaunchCompleted() {
   [Bugsnag markLaunchCompleted];
 }
 
+void bugsnag_registerForSessionCallbacksAfterStart(bool (*callback)(void *session)){
+    [Bugsnag addOnSessionBlock:^BOOL (BugsnagSession *session) {    
+        return callback((__bridge void *)session);
+    }];
+}
+
 void *bugsnag_createConfiguration(char *apiKey) {
     return (void *)CFBridgingRetain([[BugsnagConfiguration alloc] initWithApiKey:@(apiKey)]);
 }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -539,7 +539,11 @@ namespace BugsnagUnity
 
         public void RemoveOnError(Func<IEvent, bool> bugsnagCallback) => Configuration.RemoveOnError(bugsnagCallback);
 
-        public void AddOnSession(Func<ISession, bool> callback) => Configuration.AddOnSession(callback);
+        public void AddOnSession(Func<ISession, bool> callback)
+        {
+            Configuration.AddOnSession(callback);
+            NativeClient.RegisterForOnSessionCallbacks();
+        }
 
         public void RemoveOnSession(Func<ISession, bool> callback) => Configuration.RemoveOnSession(callback);
 

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -102,5 +102,10 @@ namespace BugsnagUnity
 
         IDictionary<string, object> GetNativeMetadata();
 
+        /// <summary>
+        /// Subscribes the Unity layer for session callbacks. Not many users use session callbacks, so we are only subscribing to the native side if necessary as an optimisation.
+        /// </summary>
+        void RegisterForOnSessionCallbacks();
+
     }
 }

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -154,6 +154,11 @@ namespace BugsnagUnity
         {
             NativeInterface.ClearFeatureFlags();
         }
+
+        public void RegisterForOnSessionCallbacks()
+        {
+            NativeInterface.RegisterForOnSessionCallbacks();
+        }
     }
 
 }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -49,13 +49,15 @@ namespace BugsnagUnity
 
 
 
-
-
+        private Configuration _configuration;
 
         private bool CanRunOnBackgroundThread;
 
         private static bool Unity2019OrNewer;
         private Thread MainThread;
+
+        private bool _registeredForSessionCallbacks;
+
 
         private class OnSessionCallback : AndroidJavaProxy
         {
@@ -119,6 +121,7 @@ namespace BugsnagUnity
 
         public NativeInterface(Configuration cfg)
         {
+            _configuration = cfg;
             AndroidJavaObject config = CreateNativeConfig(cfg);
             Unity2019OrNewer = IsUnity2019OrNewer();
             MainThread = Thread.CurrentThread;
@@ -289,8 +292,15 @@ namespace BugsnagUnity
             }
 
             //Register for callbacks
-            obj.Call("addOnSession", new OnSessionCallback(config));
-            obj.Call("addOnSend", new OnSendErrorCallback(config));
+            if (config.GetOnSessionCallbacks() != null && config.GetOnSessionCallbacks().Count > 0)
+            {
+                obj.Call("addOnSession", new OnSessionCallback(config));
+                _registeredForSessionCallbacks = true;
+            }
+            if (config.GetOnSendErrorCallbacks() != null && config.GetOnSendErrorCallbacks().Count > 0)
+            {
+                obj.Call("addOnSend", new OnSendErrorCallback(config));
+            }
 
 
             // set endpoints
@@ -1047,6 +1057,20 @@ namespace BugsnagUnity
         public void ClearFeatureFlags()
         {
             AndroidJNI.CallVoidMethod(GetClientRef(), ClearFeatureFlagsMethod, null);
+        }
+
+        public void RegisterForOnSessionCallbacks()
+        {
+            if (_registeredForSessionCallbacks || _configuration == null)
+            {
+                return;
+            }
+            var addOnSessionmethodId = AndroidJNI.GetMethodID(ClientClass, "addOnSession", "(Lcom/bugsnag/android/OnSessionCallback;)V");
+            var callback = new OnSessionCallback(_configuration);
+            object[] args = new object[] { callback };
+            jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(args);
+            AndroidJNI.CallVoidMethod(GetClientRef(), addOnSessionmethodId, jargs);
+            _registeredForSessionCallbacks = true;
         }
 
     }

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -37,6 +37,9 @@ namespace BugsnagUnity
         [DllImport(Import)]
         internal static extern void bugsnag_registerForSessionCallbacks(IntPtr configuration, Func<IntPtr, bool> callback);
 
+        [DllImport(Import)]
+        internal static extern void bugsnag_registerForSessionCallbacksAfterStart(Func<IntPtr, bool> callback);
+
         internal delegate void SessionInformation(IntPtr instance, string sessionId, string startedAt, int handled, int unhandled);
         [DllImport(Import)]
         internal static extern void bugsnag_retrieveCurrentSession(IntPtr instance, SessionInformation callback);

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -163,7 +163,11 @@ namespace BugsnagUnity
         {
             return _featureFlags;
         }
-       
+
+        public void RegisterForOnSessionCallbacks()
+        {
+            // Not Used on this platform
+        }
 
     }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -203,5 +203,10 @@ namespace BugsnagUnity
         {
         }
 
+        public void RegisterForOnSessionCallbacks()
+        {
+            // Not Used on this platform
+        }
+
     }
 }


### PR DESCRIPTION
## Goal

prevent JNI call for session and event callbacks if not used.

If there are no C# callbacks then we shouldn't register a native Android callback. This will work around a timing issue for most people as session callbacks aren't widely used.

## Changeset

- Only add on session and on send error callbacks if they are in the c# config
- If addOnSession is called after start, then make the JNI call and register a native callback

## Testing

Manually tested and covered by existing e2e tests