### PR TITLE
Release v7.6.1

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -200,7 +200,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk
-          - features/fixtures/unity.log
+          - features/fixtures/build_android_apk.log
     commands:
       - rake test:android:build
     retry:
@@ -220,7 +220,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk
-          - features/fixtures/unity.log
+          - features/fixtures/build_android_apk.log
     commands:
       - rake test:android:build
     retry:
@@ -240,7 +240,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2021.3.13f1.apk
-          - features/fixtures/unity.log
+          - features/fixtures/build_android_apk.log
     commands:
       - rake test:android:build
     retry:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,7 +127,7 @@ steps:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/maze_runner/mazerunner_2020.3.32f1.apk
-          - features/fixtures/unity.log
+          - features/fixtures/build_android_apk.log
     commands:
       - rake test:android:build
     retry:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## TBD
+## 7.6.1 (2023-06-13)
 
 ## Bug Fixes
 
-- Prevent callback to Unity from native layers for session and event callbacks if not used. [#717](https://github.com/bugsnag/bugsnag-unity/pull/717)
+- Prevent callback to Unity from native layers for session and event callbacks if not used to avoid potential ANRs and improve performance. [#717](https://github.com/bugsnag/bugsnag-unity/pull/717)
 
 ## 7.6.0 (2023-05-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+## Bug Fixes
+
+- Prevent callback to Unity from native layers for session and event callbacks if not used. [#717](https://github.com/bugsnag/bugsnag-unity/pull/717)
+
 ## 7.6.0 (2023-05-25)
 
 - Update bugsnag-cocoa from v6.25.2 to [v6.26.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6262-2023-04-20)

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@ var target = Argument("target", "Default");
 var solution = File("./BugsnagUnity.sln");
 var configuration = Argument("configuration", "Release");
 var project = File("./src/BugsnagUnity/BugsnagUnity.csproj");
-var version = "7.6.0";
+var version = "7.6.1";
 
 Task("Restore-NuGet-Packages")
     .Does(() => NuGetRestore(solution));

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -12,7 +12,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | NotifySmokeTest.Run()                                                       | Main+<RunNextMazeCommand>d__7.MoveNext() |
+      | NotifySmokeTest.Run()                                                       | Main+<RunNextMazeCommand>d__8.MoveNext() |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
@@ -26,7 +26,7 @@ Feature: csharp events
     And custom metadata is included in the event
     And the stack frame methods should match:
       | UncaughtExceptionSmokeTest.Run()                                                                 |                                          |
-      | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | Main+<RunNextMazeCommand>d__7.MoveNext() |
+      | ScenarioRunner.RunScenario(System.String scenarioName, System.String apiKey, System.String host) | Main+<RunNextMazeCommand>d__8.MoveNext() |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
@@ -39,7 +39,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogExceptionSmokeTest:Run()                   | DebugLogExceptionSmokeTest.Run()                                            | <RunNextMazeCommand>d__7:MoveNext()                            | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) |
+      | DebugLogExceptionSmokeTest:Run()                   | DebugLogExceptionSmokeTest.Run()                                            | <RunNextMazeCommand>d__8:MoveNext()                            | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) | UnityEngine.SetupCoroutine.InvokeMoveNext(IEnumerator enumerator, IntPtr returnValueAddress) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -53,7 +53,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogErrorSmokeTest:Run()                       | DebugLogErrorSmokeTest.Run()                                                | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
+      | DebugLogErrorSmokeTest:Run()                       | DebugLogErrorSmokeTest.Run()                                                | <RunNextMazeCommand>d__8:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -67,7 +67,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogWarningSmokeTest:Run()                     | DebugLogWarningSmokeTest.Run()                                              | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
+      | DebugLogWarningSmokeTest:Run()                     | DebugLogWarningSmokeTest.Run()                                              | <RunNextMazeCommand>d__8:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -81,7 +81,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogSmokeTest:Run()                            | DebugLogSmokeTest.Run()                                                     | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
+      | DebugLogSmokeTest:Run()                            | DebugLogSmokeTest.Run()                                                     | <RunNextMazeCommand>d__8:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
@@ -95,7 +95,7 @@ Feature: csharp events
     And the event "unhandled" is false
     And custom metadata is included in the event
     And the stack frame methods should match:
-      | DebugLogAssertSmokeTest:Run()                      | DebugLogAssertSmokeTest.Run()                                               | <RunNextMazeCommand>d__7:MoveNext()              |                                                                |
+      | DebugLogAssertSmokeTest:Run()                      | DebugLogAssertSmokeTest.Run()                                               | <RunNextMazeCommand>d__8:MoveNext()              |                                                                |
       | ScenarioRunner:RunScenario(String, String, String) | ScenarioRunner.RunScenario(string scenarioName, string apiKey, string host) | ScenarioRunner:RunScenario(string,string,string) | UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr) |
     And expected device metadata is included in the event
     And expected app metadata is included in the event

--- a/features/fixtures/maze_runner/Assets/Scripts/Logger.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Logger.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class Logger : MonoBehaviour
+{
+
+    const string LOG_PREFIX = "BUGSNAG_MAZERUNNER_LOG : ";
+
+    const string LOG_FILE_NAME = "mazerunner-unity.log";
+
+    private static string _currentLog;
+
+    public static void I(string msg)
+    {
+        Debug.Log(LOG_PREFIX + msg);
+        _currentLog = msg + "\n";
+        WriteLogFile();
+    }
+
+    private static void WriteLogFile()
+    {
+        var path = Path.Combine(Application.persistentDataPath, LOG_FILE_NAME);
+        File.WriteAllText(path, _currentLog);
+    }
+   
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Logger.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Logger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c0b994281fb547a891f2ecbfc0fadb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidBackgroundJVMSmokeTest.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidBackgroundJVMSmokeTest.cs
@@ -10,6 +10,7 @@ public class AndroidBackgroundJVMSmokeTest : Scenario
         base.PrepareConfig(apiKey, host);
         Configuration.SetUser("1", "2", "3");
         Configuration.ProjectPackages = new string[] { "test.test.test" };
+        Configuration.AddOnSession((s) => { return true; });
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosNativeException.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosNativeException.cs
@@ -5,6 +5,7 @@ public class IosNativeException : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
+        Configuration.AddOnSession((s) => { return true; });
     }
 
     public override void Run()

--- a/features/scripts/build_android.sh
+++ b/features/scripts/build_android.sh
@@ -15,7 +15,7 @@ popd
 pushd "$script_path/../fixtures"
 
 # Run unity and immediately exit afterwards, log all output
-DEFAULT_CLI_ARGS="-quit -batchmode -nographics -logFile unity.log"
+DEFAULT_CLI_ARGS="-quit -batchmode -nographics -logFile build_android_apk.log"
 
 project_path=`pwd`/maze_runner
 

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -390,6 +390,12 @@ void bugsnag_markLaunchCompleted() {
   [Bugsnag markLaunchCompleted];
 }
 
+void bugsnag_registerForSessionCallbacksAfterStart(bool (*callback)(void *session)){
+    [Bugsnag addOnSessionBlock:^BOOL (BugsnagSession *session) {    
+        return callback((__bridge void *)session);
+    }];
+}
+
 void *bugsnag_createConfiguration(char *apiKey) {
     return (void *)CFBridgingRetain([[BugsnagConfiguration alloc] initWithApiKey:@(apiKey)]);
 }

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -290,6 +290,10 @@ namespace BugsnagUnity
             {
                 return;
             }
+            if (condition.StartsWith("BUGSNAG_MAZERUNNER_LOG"))
+            {
+                return;
+            }
             if (Configuration.AutoDetectErrors && logType.IsGreaterThanOrEqualTo(Configuration.NotifyLogLevel))
             {
                 var logMessage = new UnityLogMessage(condition, stackTrace, logType);

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -579,7 +579,11 @@ namespace BugsnagUnity
 
         public void RemoveOnError(Func<IEvent, bool> bugsnagCallback) => Configuration.RemoveOnError(bugsnagCallback);
 
-        public void AddOnSession(Func<ISession, bool> callback) => Configuration.AddOnSession(callback);
+        public void AddOnSession(Func<ISession, bool> callback)
+        {
+            Configuration.AddOnSession(callback);
+            NativeClient.RegisterForOnSessionCallbacks();
+        }
 
         public void RemoveOnSession(Func<ISession, bool> callback) => Configuration.RemoveOnSession(callback);
 

--- a/src/BugsnagUnity/INativeClient.cs
+++ b/src/BugsnagUnity/INativeClient.cs
@@ -104,5 +104,10 @@ namespace BugsnagUnity
 
         bool ShouldAttemptDelivery();
 
+        /// <summary>
+        /// Subscribes the Unity layer for session callbacks. Not many users use session callbacks, so we are only subscribing to the native side if necessary as an optimisation.
+        /// </summary>
+        void RegisterForOnSessionCallbacks();
+
     }
 }

--- a/src/BugsnagUnity/Native/Android/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Android/NativeClient.cs
@@ -156,6 +156,11 @@ namespace BugsnagUnity
         {
             return true;
         }
+
+        public void RegisterForOnSessionCallbacks()
+        {
+            NativeInterface.RegisterForOnSessionCallbacks();
+        }
     }
 
 }

--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -37,6 +37,9 @@ namespace BugsnagUnity
         [DllImport(Import)]
         internal static extern void bugsnag_registerForSessionCallbacks(IntPtr configuration, Func<IntPtr, bool> callback);
 
+        [DllImport(Import)]
+        internal static extern void bugsnag_registerForSessionCallbacksAfterStart(Func<IntPtr, bool> callback);
+
         internal delegate void SessionInformation(IntPtr instance, string sessionId, string startedAt, int handled, int unhandled);
         [DllImport(Import)]
         internal static extern void bugsnag_retrieveCurrentSession(IntPtr instance, SessionInformation callback);

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -164,5 +164,10 @@ namespace BugsnagUnity
         {
             return true;
         }
+
+        public void RegisterForOnSessionCallbacks()
+        {
+            // Not Used on this platform
+        }
     }
 }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -211,5 +211,10 @@ namespace BugsnagUnity
         {
             return true;
         }
+
+        public void RegisterForOnSessionCallbacks()
+        {
+            // Not Used on this platform
+        }
     }
 }


### PR DESCRIPTION
## 7.6.1 (2023-06-13)

## Bug Fixes

- Prevent callback to Unity from native layers for session and event callbacks if not used to avoid potential ANRs and improve performance. [#717](https://github.com/bugsnag/bugsnag-unity/pull/717)