### PR TITLE
Release v6.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.3.3 (2023-06-13)
+
+## Bug Fixes
+
+- Prevent callback to Unity from native layers for session and event callbacks if not used to avoid potential ANRs and improve performance. [#717](https://github.com/bugsnag/bugsnag-unity/pull/717)
+
 ## 6.3.2 (2022-05-27)
 
 ### Bug fixes

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@ var target = Argument("target", "Default");
 var solution = File("./BugsnagUnity.sln");
 var configuration = Argument("configuration", "Release");
 var project = File("./src/BugsnagUnity/BugsnagUnity.csproj");
-var version = "6.3.2";
+var version = "6.3.3";
 
 Task("Restore-NuGet-Packages")
     .Does(() => NuGetRestore(solution));


### PR DESCRIPTION
## 6.3.3 (2023-06-13)

## Bug Fixes

- Prevent callback to Unity from native layers for session and event callbacks if not used to avoid potential ANRs and improve performance. [#717](https://github.com/bugsnag/bugsnag-unity/pull/717)