### PR TITLE
Backport Release v6.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+
+## 6.3.4 (2023-07-06)
+
+## Bug Fixes
+
+- Remove unnecessary usages of DateTimeOffset.Now to prevent iOS app hangs resulting from Unity native code accessing non-thread safe methods. [#725](https://github.com/bugsnag/bugsnag-unity/pull/725)
+
+
 ## 6.3.3 (2023-06-13)
 
 ## Bug Fixes

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@ var target = Argument("target", "Default");
 var solution = File("./BugsnagUnity.sln");
 var configuration = Argument("configuration", "Release");
 var project = File("./src/BugsnagUnity/BugsnagUnity.csproj");
-var version = "6.3.3";
+var version = "6.3.4";
 
 Task("Restore-NuGet-Packages")
     .Does(() => NuGetRestore(solution));

--- a/src/BugsnagUnity/MaximumLogTypeCounter.cs
+++ b/src/BugsnagUnity/MaximumLogTypeCounter.cs
@@ -10,19 +10,24 @@ namespace BugsnagUnity
 
         private Dictionary<LogType, int> CurrentCounts { get; }
 
-        private DateTimeOffset FlushAt { get; set; }
+        private double FlushAt { get; set; }
 
-        private TimeSpan MaximumLogsTimePeriod => Configuration.MaximumLogsTimePeriod;
+        private double MaximumLogsTimePeriod => Configuration.MaximumLogsTimePeriod.TotalSeconds;
 
         private Dictionary<LogType, int> MaximumTypePerTimePeriod => Configuration.MaximumTypePerTimePeriod;
 
         private readonly object _lock = new object();
 
+        private void SetFlushTime()
+        {
+            FlushAt = Time.ElapsedSeconds + MaximumLogsTimePeriod;
+        }
+
         public MaximumLogTypeCounter(Configuration configuration)
         {
             Configuration = configuration;
             CurrentCounts = new Dictionary<LogType, int>();
-            FlushAt = DateTimeOffset.Now.Add(Configuration.MaximumLogsTimePeriod);
+            SetFlushTime();
         }
 
         public bool ShouldSend(UnityLogMessage unityLogMessage)
@@ -47,7 +52,7 @@ namespace BugsnagUnity
                         if (unityLogMessage.CreatedAt > FlushAt)
                         {
                             CurrentCounts.Clear();
-                            FlushAt = DateTimeOffset.Now.Add(MaximumLogsTimePeriod);
+                            SetFlushTime();
                             return true;
                         }
                         return false;

--- a/src/BugsnagUnity/Payload/AppWithState.cs
+++ b/src/BugsnagUnity/Payload/AppWithState.cs
@@ -56,7 +56,7 @@ namespace BugsnagUnity.Payload
 
         internal AppWithState(Configuration configuration) : base(configuration)
         {
-            Duration = TimeSpan.FromSeconds(Time.realtimeSinceStartup);
+            Duration = TimeSpan.FromSeconds(UnityEngine.Time.realtimeSinceStartup);
         }
 
     }

--- a/src/BugsnagUnity/Time.cs
+++ b/src/BugsnagUnity/Time.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace BugsnagUnity
+{
+    // A simple timer used internally to avoid thread complications when using the unity Time API
+    internal class Time
+    {
+
+        private static object _swLock = new object();
+
+        private static Stopwatch _sw;
+
+        internal static Stopwatch Timer
+        {
+            get
+            {
+                if (_sw == null)
+                {
+                    lock (_swLock)
+                    {
+                        if (_sw == null)
+                        {
+                            _sw = Stopwatch.StartNew();
+                        }
+                    }
+                }
+                return _sw;
+            }
+        }
+
+        internal static double ElapsedSeconds => Timer.Elapsed.TotalSeconds;
+
+    }
+}
+

--- a/src/BugsnagUnity/UnityLogMessage.cs
+++ b/src/BugsnagUnity/UnityLogMessage.cs
@@ -10,10 +10,19 @@ namespace BugsnagUnity
     {
         public UnityLogMessage(string condition, string stackTrace, LogType type)
         {
-            CreatedAt = DateTime.UtcNow;
+            CreatedAt = Time.ElapsedSeconds;
             Condition = condition;
             StackTrace = stackTrace;
             Type = type;
+        }
+
+
+        public UnityLogMessage(Exception exception)
+        {
+            CreatedAt = Time.ElapsedSeconds;
+            Condition = exception.Message == null ? string.Empty : exception.Message;
+            StackTrace = exception.StackTrace == null ? string.Empty : exception.StackTrace;
+            Type = LogType.Exception;
         }
 
         public string Condition { get; }
@@ -22,6 +31,8 @@ namespace BugsnagUnity
 
         public LogType Type { get; }
 
-        public DateTime CreatedAt { get; }
+        public double CreatedAt { get; }
+
+        
     }
 }

--- a/tests/UnityEngine/Time.cs
+++ b/tests/UnityEngine/Time.cs
@@ -1,10 +1,9 @@
-﻿using System;
-namespace UnityEngine
+﻿namespace UnityEngine
 {
     public class Time
     {
 
         public static float realtimeSinceStartup { get; set; }
-       
+
     }
 }


### PR DESCRIPTION
## 6.3.4 (2023-07-06)

## Bug Fixes

- Remove unnecessary usages of DateTimeOffset.Now to prevent iOS app hangs resulting from Unity native code accessing non-thread safe methods. [#725](https://github.com/bugsnag/bugsnag-unity/pull/725)
