### PR TITLE
PLAT-10671 handle and report deserialisation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,20 @@
 
 - Update bugsnag-cocoa from v6.26.2 to [v6.27.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6272-2023-07-24)
 
+### Bug Fixes
+
+- Handle exceptions thrown during deserialisation of a cached events and sessions and log the problematic json. [#731](https://github.com/bugsnag/bugsnag-unity/pull/731)
+
 ## 7.6.2 (2023-07-06)
 
-## Bug Fixes
+### Bug Fixes
 
 - Remove unnecessary usages of DateTimeOffset.Now to prevent iOS app hangs resulting from Unity native code accessing non-thread safe methods. [#725](https://github.com/bugsnag/bugsnag-unity/pull/725)
 
 
 ## 7.6.1 (2023-06-13)
 
-## Bug Fixes
+### Bug Fixes
 
 - Prevent callback to Unity from native layers for session and event callbacks if not used to avoid potential ANRs and improve performance. [#717](https://github.com/bugsnag/bugsnag-unity/pull/717)
 

--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -501,64 +501,49 @@ namespace BugsnagUnity
 
         private IEnumerator DeliverCachedPayloads()
         {
-            var cachedSessionIds = _cacheManager.GetCachedSessionIds();
-            if (cachedSessionIds != null)
-            {
-                foreach (var sessionId in cachedSessionIds)
-                {
-                    var sessionJson = _cacheManager.GetCachedSession(sessionId);
-                    if (string.IsNullOrEmpty(sessionJson))
-                    {
-                        continue;
-                    }
-
-                    Dictionary<string, object> payloadDictionary = null;
-
-                    try
-                    {
-                        payloadDictionary = ((JsonObject)SimpleJson.DeserializeObject(sessionJson)).GetDictionary();
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.LogException(new Exception("Bugsnag Error. Deserialising a cached session for delivery failed: " + e.Message + " Cached json: " + sessionJson));
-                        continue;
-                    }
-                    var sessionReport = new SessionReport(_configuration, payloadDictionary);
-                    Deliver(sessionReport);
-                    yield return new WaitUntil(() => CachedPayloadProcessed(sessionReport.Id));
-                }
-            }
-
-            var cachedEvents = _cacheManager.GetCachedEventIds();
-            if (cachedEvents != null)
-            {
-                foreach (var eventId in cachedEvents)
-                {
-                    var eventJson = _cacheManager.GetCachedEvent(eventId);
-                    if (string.IsNullOrEmpty(eventJson))
-                    {
-                        continue;
-                    }
-
-                    Dictionary<string, object> payloadDictionary = null;
-
-                    try
-                    {
-                        payloadDictionary = ((JsonObject)SimpleJson.DeserializeObject(eventJson)).GetDictionary();
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.LogException(new Exception("Bugsnag Error. Deserialising a cached event for delivery failed: " + e.Message + " Cached json: " + eventJson));
-                        continue;
-                    }
-
-                    var eventReport = new Report(_configuration, payloadDictionary);
-                    Deliver(eventReport);
-                    yield return new WaitUntil(() => CachedPayloadProcessed(eventReport.Id));
-                }
-            }
-
+            yield return ProcessCachedItems(typeof(SessionReport));
+            yield return ProcessCachedItems(typeof(Report));
             _cacheDeliveryInProcess = false;
+        }
+
+        private IEnumerator ProcessCachedItems(Type t)
+        {
+            bool isSession = t.Equals(typeof(SessionReport));
+            var cachedPayloads = isSession ? _cacheManager.GetCachedSessionIds() : _cacheManager.GetCachedEventIds();
+            if (cachedPayloads != null)
+            {
+                foreach (var id in cachedPayloads)
+                {
+                    var payloadJson = isSession ? _cacheManager.GetCachedSession(id) : _cacheManager.GetCachedEvent(id);
+                    if (string.IsNullOrEmpty(payloadJson))
+                    {
+                        continue;
+                    }
+
+                    Dictionary<string, object> payloadDictionary = null;
+
+                    try
+                    {
+                        payloadDictionary = ((JsonObject)SimpleJson.DeserializeObject(payloadJson)).GetDictionary();
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(new Exception("Bugsnag Error. Deserialising a cached payload for delivery failed: " + e.Message + " Cached json: " + payloadJson));
+                        continue;
+                    }
+
+                    if (isSession)
+                    {
+                        Deliver(new SessionReport(_configuration, payloadDictionary));
+                    }
+                    else
+                    {
+                        Deliver(new Report(_configuration, payloadDictionary));
+                    }
+                    
+                    yield return new WaitUntil(() => CachedPayloadProcessed(id));
+                }
+            }
         }
 
         private bool CachedPayloadProcessed(string id)

--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -511,7 +511,19 @@ namespace BugsnagUnity
                     {
                         continue;
                     }
-                    var sessionReport = new SessionReport(_configuration, ((JsonObject)SimpleJson.DeserializeObject(sessionJson)).GetDictionary());
+
+                    Dictionary<string, object> payloadDictionary = null;
+
+                    try
+                    {
+                        payloadDictionary = ((JsonObject)SimpleJson.DeserializeObject(sessionJson)).GetDictionary();
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(new Exception("Bugsnag Error. Deserialising a cached session for delivery failed: " + e.Message + " Cached json: " + sessionJson));
+                        continue;
+                    }
+                    var sessionReport = new SessionReport(_configuration, payloadDictionary);
                     Deliver(sessionReport);
                     yield return new WaitUntil(() => CachedPayloadProcessed(sessionReport.Id));
                 }
@@ -527,7 +539,20 @@ namespace BugsnagUnity
                     {
                         continue;
                     }
-                    var eventReport = new Report(_configuration, ((JsonObject)SimpleJson.DeserializeObject(eventJson)).GetDictionary());
+
+                    Dictionary<string, object> payloadDictionary = null;
+
+                    try
+                    {
+                        payloadDictionary = ((JsonObject)SimpleJson.DeserializeObject(eventJson)).GetDictionary();
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(new Exception("Bugsnag Error. Deserialising a cached event for delivery failed: " + e.Message + " Cached json: " + eventJson));
+                        continue;
+                    }
+
+                    var eventReport = new Report(_configuration, payloadDictionary);
                     Deliver(eventReport);
                     yield return new WaitUntil(() => CachedPayloadProcessed(eventReport.Id));
                 }


### PR DESCRIPTION
## Goal

Handle exceptions thrown during deserialisation of a cached events and sessions and log the problematic json so we can debug the issue.

## Changeset

- Added exception handling and logging in Delivery.

## Testing

Not explicitly tested, but existing tests will confirm that it has not broken anything.