### PR TITLE
remove dependancy on UnityDir

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ steps:
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2018.4.36f1"
+      UNITY
     commands:
       - bundle install
       - bundle exec rake plugin:export
@@ -22,24 +23,24 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: Ensure notifier builds on Windows (for development)
-    timeout_in_minutes: 30
-    agents:
-      queue: windows-unity-wsl
-    env:
-      UNITY_VERSION: "2018.4.36f1"
-      WSLENV: UNITY_VERSION
-    command:
-      - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
-    plugins:
-      artifacts#v1.5.0:
-        upload:
-          - from: Bugsnag.unitypackage
-            to: Bugsnag_WindowsBuilt.unitypackage
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+  # - label: Ensure notifier builds on Windows (for development)
+  #   timeout_in_minutes: 30
+  #   agents:
+  #     queue: windows-unity-wsl
+  #   env:
+  #     UNITY_VERSION: "2018.4.36f1"
+  #     WSLENV: UNITY_VERSION
+  #   command:
+  #     - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       upload:
+  #         - from: Bugsnag.unitypackage
+  #           to: Bugsnag_WindowsBuilt.unitypackage
+  #   retry:
+  #     automatic:
+  #       - exit_status: "*"
+  #         limit: 1
 
   # Build Android test fixtures
   - label: ':android: Build Android test fixture for Unity 2020'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,6 @@ steps:
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2018.4.36f1"
-      UNITY
     commands:
       - bundle install
       - bundle exec rake plugin:export

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -2,17 +2,15 @@
   <PropertyGroup>
     <TargetFramework>net35</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <UnityDir Condition="$(UnityDir) == '' and Exists('C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll')">C:\Program Files\Unity\Editor\Data\Managed</UnityDir>
-    <UnityDir Condition="$(UnityDir) == '' and Exists('\Applications\Unity\Unity.app\Contents\Managed\UnityEngine.dll')">\Applications\Unity\Unity.app\Contents\Managed</UnityDir>
     <Version Condition="$(Version) == ''">1.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="UnityEngine">
-      <HintPath>$(UnityDir)\UnityEngine.dll</HintPath>
+      <HintPath>/Applications/Unity/Hub/Editor/$(UNITY_VERSION)/Unity.app/Contents/Managed/UnityEngine.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="UnityEditor">
-      <HintPath>$(UnityDir)\UnityEditor.dll</HintPath>
+      <HintPath>/Applications/Unity/Hub/Editor/$(UNITY_VERSION)/Unity.app/Contents/Managed/UnityEditor.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
## Goal

- Remove all dep on the env var UnityDir as we want ot only use UNITY_VERSION.
- Disable unnecessary windows build step, can be enabled when required.

