### PR TITLE
PLAT-10728 null guard against possible null exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 7.6.3 (2023-08-03)
 
+### Bug Fixes
+
+- Add null guard in the Bugsnag exception handler. [#734](https://github.com/bugsnag/bugsnag-unity/pull/734)
+
+
+## 7.6.3 (2023-08-03)
+
 - Update bugsnag-cocoa from v6.26.2 to [v6.27.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6272-2023-07-24)
 
 ### Bug Fixes

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -72,6 +72,10 @@ namespace BugsnagUnity
 
             public void LogException(System.Exception exception, UnityEngine.Object context)
             {
+                if (exception == null)
+                {
+                    return;
+                }
                 if (_config.AutoDetectErrors && LogType.Exception.IsGreaterThanOrEqualTo(_config.NotifyLogLevel))
                 {
                     var unityLogMessage = new UnityLogMessage(exception);


### PR DESCRIPTION
## Goal

A user reported an exception thrown in the UnityLogMessage constructor. 
The only possible explination would be a null exception passed to Debug.LogException.

## Changeset

Added a null guard to ignore null exceptions.

## Testing

Manually tested, E2E not possible