### PR TITLE
PLAT-10763 add unity 2022 to ci

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -140,7 +140,7 @@ steps:
           - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
         upload:
           - maze_output/**/*
-          - Mazerunner.log
+          - '*-mazerunner.log'
           - maze_output/metrics.csv
     commands:
       - scripts/ci-run-macos-tests-csharp.sh
@@ -158,7 +158,7 @@ steps:
           - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
         upload:
           - maze_output/**/*
-          - Mazerunner.log
+          - '*-mazerunner.log'
           - maze_output/metrics.csv
     commands:
       - scripts/ci-run-macos-tests-csharp.sh
@@ -176,7 +176,7 @@ steps:
           - features/fixtures/maze_runner/build/MacOS-2020.3.48f1.zip
         upload:
           - maze_output/**/*
-          - Mazerunner.log
+          - '*-mazerunner.log'
           - maze_output/metrics.csv
     commands:
       - scripts/ci-run-macos-tests-csharp.sh
@@ -212,7 +212,7 @@ steps:
           - features/fixtures/maze_runner/build/MacOS-2022.3.2f1.zip
         upload:
           - maze_output/**/*
-          - Mazerunner.log
+          - '*-mazerunner.log'
     commands:
       - scripts/ci-run-macos-tests-csharp.sh
 

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -2,7 +2,6 @@ agents:
   queue: macos-12-arm-unity
 
 steps:
-
   # Note:
   #  The basic pipeline handles Unity 2020, but doesn't include the building of test fixtures for WebGL, macOS and
   #  Windows.  They are included here instead.
@@ -11,8 +10,8 @@ steps:
   #
   - label: Build Unity 2018 MacOS and WebGL test fixtures
     timeout_in_minutes: 30
-    key: 'cocoa-webgl-2018-fixtures'
-    depends_on: 'build-artifacts'
+    key: "cocoa-webgl-2018-fixtures"
+    depends_on: "build-artifacts"
     env:
       DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2018.4.36f1"
@@ -35,8 +34,8 @@ steps:
 
   - label: Build Unity 2019 MacOS and WebGL test fixtures
     timeout_in_minutes: 30
-    key: 'cocoa-webgl-2019-fixtures'
-    depends_on: 'build-artifacts'
+    key: "cocoa-webgl-2019-fixtures"
+    depends_on: "build-artifacts"
     env:
       DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2019.4.35f1"
@@ -59,8 +58,8 @@ steps:
 
   - label: Build Unity 2020 MacOS and WebGL test fixtures
     timeout_in_minutes: 30
-    key: 'cocoa-webgl-2020-fixtures'
-    depends_on: 'build-artifacts'
+    key: "cocoa-webgl-2020-fixtures"
+    depends_on: "build-artifacts"
     env:
       DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2020.3.48f1"
@@ -83,8 +82,8 @@ steps:
 
   - label: Build Unity 2021 MacOS and WebGL test fixtures
     timeout_in_minutes: 30
-    key: 'cocoa-webgl-2021-fixtures'
-    depends_on: 'build-artifacts'
+    key: "cocoa-webgl-2021-fixtures"
+    depends_on: "build-artifacts"
     env:
       DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2021.3.27f1"
@@ -108,7 +107,7 @@ steps:
   #
   - label: Run MacOS e2e tests for Unity 2018
     timeout_in_minutes: 60
-    depends_on: 'cocoa-webgl-2018-fixtures'
+    depends_on: "cocoa-webgl-2018-fixtures"
     agents:
       queue: macos-12-arm-unity
     env:
@@ -126,7 +125,7 @@ steps:
 
   - label: Run MacOS e2e tests for Unity 2019
     timeout_in_minutes: 60
-    depends_on: 'cocoa-webgl-2019-fixtures'
+    depends_on: "cocoa-webgl-2019-fixtures"
     agents:
       queue: macos-12-arm-unity
     env:
@@ -144,7 +143,7 @@ steps:
 
   - label: Run MacOS e2e csharp tests
     timeout_in_minutes: 60
-    depends_on: 'cocoa-webgl-2020-fixtures'
+    depends_on: "cocoa-webgl-2020-fixtures"
     agents:
       queue: macos-12-arm-unity
     env:
@@ -185,7 +184,7 @@ steps:
   #
   - label: Run WebGL e2e tests for Unity 2018
     timeout_in_minutes: 30
-    depends_on: 'cocoa-webgl-2018-fixtures'
+    depends_on: "cocoa-webgl-2018-fixtures"
     agents:
       queue: opensource-mac-cocoa-11
     env:
@@ -203,7 +202,7 @@ steps:
 
   - label: Run WebGL e2e tests for Unity 2019
     timeout_in_minutes: 30
-    depends_on: 'cocoa-webgl-2019-fixtures'
+    depends_on: "cocoa-webgl-2019-fixtures"
     agents:
       queue: opensource-mac-cocoa-11
     env:
@@ -221,7 +220,7 @@ steps:
 
   - label: Run WebGL e2e tests for Unity 2020
     timeout_in_minutes: 30
-    depends_on: 'cocoa-webgl-2020-fixtures'
+    depends_on: "cocoa-webgl-2020-fixtures"
     agents:
       queue: opensource-mac-cocoa-11
     env:
@@ -257,10 +256,10 @@ steps:
   #
   # Build Android test fixtures
   #
-  - label: ':android: Build Android test fixture for Unity 2018'
+  - label: ":android: Build Android test fixture for Unity 2018"
     timeout_in_minutes: 30
-    key: 'build-android-fixture-2018'
-    depends_on: 'build-artifacts'
+    key: "build-android-fixture-2018"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2018.4.36f1"
     plugins:
@@ -277,10 +276,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':android: Build Android test fixture for Unity 2019'
+  - label: ":android: Build Android test fixture for Unity 2019"
     timeout_in_minutes: 30
-    key: 'build-android-fixture-2019'
-    depends_on: 'build-artifacts'
+    key: "build-android-fixture-2019"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2019.4.35f1"
     plugins:
@@ -297,10 +296,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':android: Build Android test fixture for Unity 2021'
+  - label: ":android: Build Android test fixture for Unity 2021"
     timeout_in_minutes: 30
-    key: 'build-android-fixture-2021'
-    depends_on: 'build-artifacts'
+    key: "build-android-fixture-2021"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2021.3.27f1"
     plugins:
@@ -317,10 +316,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':android: Build Android test fixture for Unity 2022'
+  - label: ":android: Build Android test fixture for Unity 2022"
     timeout_in_minutes: 30
-    key: 'build-android-fixture-2022'
-    depends_on: 'build-artifacts'
+    key: "build-android-fixture-2022"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2022.3.2f1"
     plugins:
@@ -362,9 +361,9 @@ steps:
   #
   # Run Android tests
   #
-  - label: ':bitbar: :android: Run Android e2e tests for Unity 2018'
+  - label: ":bitbar: :android: Run Android e2e tests for Unity 2018"
     timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2018'
+    depends_on: "build-android-fixture-2018"
     agents:
       queue: opensource
     env:
@@ -390,12 +389,12 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
 
-  - label: ':bitbar: :android: Run Android e2e tests for Unity 2019'
+  - label: ":bitbar: :android: Run Android e2e tests for Unity 2019"
     timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2019'
+    depends_on: "build-android-fixture-2019"
     agents:
       queue: opensource
     env:
@@ -421,12 +420,12 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
 
-  - label: ':bitbar: :android: Run Android e2e tests for Unity 2021'
+  - label: ":bitbar: :android: Run Android e2e tests for Unity 2021"
     timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2021'
+    depends_on: "build-android-fixture-2021"
     agents:
       queue: opensource
     env:
@@ -452,12 +451,12 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
 
-  - label: ':bitbar: :android: Run Android e2e tests for Unity 2022'
+  - label: ":bitbar: :android: Run Android e2e tests for Unity 2022"
     timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2022'
+    depends_on: "build-android-fixture-2022"
     agents:
       queue: opensource
     env:
@@ -483,7 +482,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
 
   # - label: ':android: Run Android EDM e2e tests for Unity 2021'
@@ -514,10 +513,10 @@ steps:
   #
   # Build iOS test fixtures
   #
-  - label: ':ios: Generate Xcode project - Unity 2018'
+  - label: ":ios: Generate Xcode project - Unity 2018"
     timeout_in_minutes: 30
-    key: 'generate-fixture-project-2018'
-    depends_on: 'build-artifacts'
+    key: "generate-fixture-project-2018"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2018.4.36f1"
     plugins:
@@ -535,10 +534,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':ios: Build iOS test fixture for Unity 2018'
+  - label: ":ios: Build iOS test fixture for Unity 2018"
     timeout_in_minutes: 30
-    key: 'build-ios-fixture-2018'
-    depends_on: 'generate-fixture-project-2018'
+    key: "build-ios-fixture-2018"
+    depends_on: "generate-fixture-project-2018"
     agents:
       queue: macos-12-arm-unity
     env:
@@ -560,10 +559,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':ios: Generate Xcode project - Unity 2019'
+  - label: ":ios: Generate Xcode project - Unity 2019"
     timeout_in_minutes: 30
-    key: 'generate-fixture-project-2019'
-    depends_on: 'build-artifacts'
+    key: "generate-fixture-project-2019"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2019.4.35f1"
     plugins:
@@ -581,10 +580,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':ios: Build iOS test fixture for Unity 2019'
+  - label: ":ios: Build iOS test fixture for Unity 2019"
     timeout_in_minutes: 30
-    key: 'build-ios-fixture-2019'
-    depends_on: 'generate-fixture-project-2019'
+    key: "build-ios-fixture-2019"
+    depends_on: "generate-fixture-project-2019"
     agents:
       queue: macos-12-arm-unity
     env:
@@ -606,10 +605,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':ios: Generate Xcode project - Unity 2021'
+  - label: ":ios: Generate Xcode project - Unity 2021"
     timeout_in_minutes: 30
-    key: 'generate-fixture-project-2021'
-    depends_on: 'build-artifacts'
+    key: "generate-fixture-project-2021"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2021.3.27f1"
     plugins:
@@ -627,10 +626,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':ios: Build iOS test fixture for Unity 2021'
+  - label: ":ios: Build iOS test fixture for Unity 2021"
     timeout_in_minutes: 30
-    key: 'build-ios-fixture-2021'
-    depends_on: 'generate-fixture-project-2021'
+    key: "build-ios-fixture-2021"
+    depends_on: "generate-fixture-project-2021"
     agents:
       queue: macos-12-arm-unity
     env:
@@ -652,10 +651,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':ios: Generate Xcode project - Unity 2022'
+  - label: ":ios: Generate Xcode project - Unity 2022"
     timeout_in_minutes: 30
-    key: 'generate-fixture-project-2022'
-    depends_on: 'build-artifacts'
+    key: "generate-fixture-project-2022"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2022.3.2f1"
     plugins:
@@ -673,10 +672,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':ios: Build iOS test fixture for Unity 2022'
+  - label: ":ios: Build iOS test fixture for Unity 2022"
     timeout_in_minutes: 30
-    key: 'build-ios-fixture-2022'
-    depends_on: 'generate-fixture-project-2022'
+    key: "build-ios-fixture-2022"
+    depends_on: "generate-fixture-project-2022"
     agents:
       queue: macos-12-arm-unity
     env:
@@ -701,9 +700,9 @@ steps:
   #
   # Run iOS tests
   #
-  - label: ':bitbar: :ios: Run iOS e2e tests for Unity 2018'
+  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2018"
     timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2018'
+    depends_on: "build-ios-fixture-2018"
     agents:
       queue: opensource
     env:
@@ -729,12 +728,12 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
 
-  - label: ':bitbar: :ios: Run iOS e2e tests for Unity 2019'
+  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2019"
     timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2019'
+    depends_on: "build-ios-fixture-2019"
     agents:
       queue: opensource
     plugins:
@@ -758,12 +757,12 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
 
-  - label: ':bitbar: :ios: Run iOS e2e tests for Unity 2021'
+  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2021"
     timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2021'
+    depends_on: "build-ios-fixture-2021"
     agents:
       queue: opensource
     plugins:
@@ -787,12 +786,12 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
 
-- label: ':bitbar: :ios: Run iOS e2e tests for Unity 2022'
+  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2022"
     timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2022'
+    depends_on: "build-ios-fixture-2022"
     agents:
       queue: opensource
     plugins:
@@ -816,7 +815,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
 
   #
@@ -824,8 +823,8 @@ steps:
   #
   - label: Build Unity 2018 Windows test fixture
     timeout_in_minutes: 30
-    key: 'windows-2018-fixture'
-    depends_on: 'build-artifacts'
+    key: "windows-2018-fixture"
+    depends_on: "build-artifacts"
     agents:
       queue: windows-unity-wsl
     env:
@@ -846,8 +845,8 @@ steps:
 
   - label: Build Unity 2019 Windows test fixture
     timeout_in_minutes: 30
-    key: 'windows-2019-fixture'
-    depends_on: 'build-artifacts'
+    key: "windows-2019-fixture"
+    depends_on: "build-artifacts"
     agents:
       queue: windows-unity-wsl
     env:
@@ -868,8 +867,8 @@ steps:
 
   - label: Build Unity 2020 Windows test fixture
     timeout_in_minutes: 30
-    key: 'windows-2020-fixture'
-    depends_on: 'build-artifacts'
+    key: "windows-2020-fixture"
+    depends_on: "build-artifacts"
     agents:
       queue: windows-unity-wsl
     env:
@@ -890,8 +889,8 @@ steps:
 
   - label: Build Unity 2021 Windows test fixture
     timeout_in_minutes: 30
-    key: 'windows-2021-fixture'
-    depends_on: 'build-artifacts'
+    key: "windows-2021-fixture"
+    depends_on: "build-artifacts"
     agents:
       queue: windows-unity-wsl
     env:
@@ -915,7 +914,7 @@ steps:
   #
   - label: Run Windows e2e tests for Unity 2018
     timeout_in_minutes: 30
-    depends_on: 'windows-2018-fixture'
+    depends_on: "windows-2018-fixture"
     agents:
       queue: windows-general-wsl
     env:
@@ -932,7 +931,7 @@ steps:
 
   - label: Run Windows e2e tests for Unity 2019
     timeout_in_minutes: 30
-    depends_on: 'windows-2019-fixture'
+    depends_on: "windows-2019-fixture"
     agents:
       queue: windows-general-wsl
     env:
@@ -949,7 +948,7 @@ steps:
 
   - label: Run Windows e2e tests for Unity 2020
     timeout_in_minutes: 30
-    depends_on: 'windows-2020-fixture'
+    depends_on: "windows-2020-fixture"
     agents:
       queue: windows-general-wsl
     env:
@@ -967,7 +966,7 @@ steps:
 
   - label: Run Windows e2e tests for Unity 2021
     timeout_in_minutes: 30
-    depends_on: 'windows-2021-fixture'
+    depends_on: "windows-2021-fixture"
     agents:
       queue: windows-general-wsl
     env:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -317,6 +317,26 @@ steps:
         - exit_status: "*"
           limit: 1
 
+  - label: ':android: Build Android test fixture for Unity 2022'
+    timeout_in_minutes: 30
+    key: 'build-android-fixture-2022'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2022.3.2f1.apk
+          - features/fixtures/build_android_apk.log
+    commands:
+      - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
   # - label: ':android: Build Android EDM test fixture for Unity 2021'
   #   timeout_in_minutes: 30
   #   key: 'build-edm-fixture-2021'
@@ -435,6 +455,37 @@ steps:
     concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
+  - label: ':bitbar: :android: Run Android e2e tests for Unity 2022'
+    timeout_in_minutes: 60
+    depends_on: 'build-android-fixture-2022'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2022.3.2f1.apk"
+        upload:
+          - "maze_output/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner-bitbar
+        run: maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/csharp"
+          - "features/android"
+          - "--app=features/fixtures/maze_runner/mazerunner_2022.3.2f1.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+
   # - label: ':android: Run Android EDM e2e tests for Unity 2021'
   #   timeout_in_minutes: 60
   #   depends_on: 'build-edm-fixture-2021'
@@ -491,7 +542,7 @@ steps:
     agents:
       queue: macos-12-arm-unity
     env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2018.4.36f1"
     plugins:
       artifacts#v1.5.0:
@@ -537,7 +588,7 @@ steps:
     agents:
       queue: macos-12-arm-unity
     env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2019.4.35f1"
     plugins:
       artifacts#v1.5.0:
@@ -583,7 +634,7 @@ steps:
     agents:
       queue: macos-12-arm-unity
     env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2021.3.27f1"
     plugins:
       artifacts#v1.5.0:
@@ -595,6 +646,52 @@ steps:
           - features/fixtures/unity.log
     commands:
       - tar -zxf project_2021.tgz features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Generate Xcode project - Unity 2022'
+    timeout_in_minutes: 30
+    key: 'generate-fixture-project-2022'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/unity.log
+          - project_2022.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2022.tgz features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Build iOS test fixture for Unity 2022'
+    timeout_in_minutes: 30
+    key: 'build-ios-fixture-2022'
+    depends_on: 'generate-fixture-project-2022'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+          - project_2022.tgz
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2022.3.2f1.ipa
+          - features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2022.tgz features/fixtures/maze_runner
       - rake test:ios:build_xcode
     retry:
       automatic:
@@ -684,6 +781,35 @@ steps:
           - "features/csharp"
           - "features/ios"
           - "--app=features/fixtures/maze_runner/mazerunner_2021.3.27f1.ipa"
+          - "--farm=bb"
+          - "--device=IOS_12|IOS_13|IOS_14|IOS_15"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+
+- label: ':bitbar: :ios: Run iOS e2e tests for Unity 2022'
+    timeout_in_minutes: 60
+    depends_on: 'build-ios-fixture-2022'
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2022.3.2f1.ipa"
+        upload:
+          - "maze_output/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner-bitbar
+        run: maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/csharp"
+          - "features/ios"
+          - "--app=features/fixtures/maze_runner/mazerunner_2022.3.2f1.ipa"
           - "--farm=bb"
           - "--device=IOS_12|IOS_13|IOS_14|IOS_15"
           - "--no-tunnel"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -14,7 +14,7 @@ steps:
     key: 'cocoa-webgl-2018-fixtures'
     depends_on: 'build-artifacts'
     env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2018.4.36f1"
       # Python2 needed for WebGL to build
       EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
@@ -38,7 +38,7 @@ steps:
     key: 'cocoa-webgl-2019-fixtures'
     depends_on: 'build-artifacts'
     env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2019.4.35f1"
       # Python2 needed for WebGL to build
       EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
@@ -62,7 +62,7 @@ steps:
     key: 'cocoa-webgl-2020-fixtures'
     depends_on: 'build-artifacts'
     env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2020.3.48f1"
       # Python2 needed for WebGL to build
       EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
@@ -86,7 +86,7 @@ steps:
     key: 'cocoa-webgl-2021-fixtures'
     depends_on: 'build-artifacts'
     env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2021.3.27f1"
     plugins:
       artifacts#v1.5.0:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -961,6 +961,28 @@ steps:
         - exit_status: "*"
           limit: 1
 
+  - label: Build Unity 2022 Windows test fixture
+    timeout_in_minutes: 30
+    key: "windows-2022-fixture"
+    depends_on: "build-artifacts"
+    agents:
+      queue: windows-unity-wsl
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    commands:
+      - scripts/ci-build-windows-fixture-wsl.sh
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - unity.log
+          - features/fixtures/maze_runner/build/Windows-2022.3.2f1.zip
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
   #
   # Run Windows e2e tests
   #
@@ -1027,6 +1049,23 @@ steps:
       artifacts#v1.5.0:
         download:
           - features/fixtures/maze_runner/build/Windows-2021.3.27f1.zip
+        upload:
+          - maze_output/**/*
+          - maze_output/metrics.csv
+    commands:
+      - scripts/ci-run-windows-tests-wsl.sh
+
+  - label: Run Windows e2e tests for Unity 2022
+    timeout_in_minutes: 30
+    depends_on: "windows-2022-fixture"
+    agents:
+      queue: windows-general-wsl
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/Windows-2022.3.2f1.zip
         upload:
           - maze_output/**/*
           - maze_output/metrics.csv

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -181,22 +181,23 @@ steps:
     commands:
       - scripts/ci-run-macos-tests-csharp.sh
 
-  - label: Run MacOS e2e tests for Unity 2021
-    timeout_in_minutes: 60
-    depends_on: 'cocoa-webgl-2021-fixtures'
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      UNITY_VERSION: "2021.3.27f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/MacOS-2021.3.27f1.zip
-        upload:
-          - maze_output/**/*
-          - Mazerunner.log
-    commands:
-      - scripts/ci-run-macos-tests-csharp.sh
+   # DISABLED Pending PLAT-9177
+  # - label: Run MacOS e2e tests for Unity 2021
+  #   timeout_in_minutes: 60
+  #   depends_on: 'cocoa-webgl-2021-fixtures'
+  #   agents:
+  #     queue: macos-12-arm-unity
+  #   env:
+  #     UNITY_VERSION: "2021.3.27f1"
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       download:
+  #         - features/fixtures/maze_runner/build/MacOS-2021.3.27f1.zip
+  #       upload:
+  #         - maze_output/**/*
+  #         - Mazerunner.log
+  #   commands:
+  #     - scripts/ci-run-macos-tests-csharp.sh
 
   - label: Run MacOS e2e tests for Unity 2022
     timeout_in_minutes: 60
@@ -275,20 +276,21 @@ steps:
     commands:
       - scripts/ci-run-webgl-tests.sh
 
-  - label: Run WebGL e2e tests for Unity 2021
-    timeout_in_minutes: 30
-    depends_on: 'cocoa-webgl-2021-fixtures'
-    env:
-      UNITY_VERSION: "2021.3.27f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/WebGL-2021.3.27f1.zip
-        upload:
-          - maze_output/**/*
-    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-    commands:
-      - scripts/ci-run-webgl-tests.sh
+   # DISABLED Pending PLAT-9177
+  # - label: Run WebGL e2e tests for Unity 2021
+  #   timeout_in_minutes: 30
+  #   depends_on: 'cocoa-webgl-2021-fixtures'
+  #   env:
+  #     UNITY_VERSION: "2021.3.27f1"
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       download:
+  #         - features/fixtures/maze_runner/build/WebGL-2021.3.27f1.zip
+  #       upload:
+  #         - maze_output/**/*
+  #   # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+  #   commands:
+  #     - scripts/ci-run-webgl-tests.sh
 
   - label: Run WebGL e2e tests for Unity 2022
     timeout_in_minutes: 30

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -102,6 +102,28 @@ steps:
         - exit_status: "*"
           limit: 1
 
+  - label: Build Unity 2022 MacOS and WebGL test fixtures
+    timeout_in_minutes: 30
+    key: "cocoa-webgl-2022-fixtures"
+    depends_on: "build-artifacts"
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+    commands:
+      - scripts/ci-build-macos-packages.sh
+    artifact_paths:
+      - unity.log
+      - features/fixtures/maze_runner/build/MacOS-2022.3.2f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2022.3.2f1.zip
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
   #
   # Run macOS desktop tests
   #
@@ -159,23 +181,39 @@ steps:
     commands:
       - scripts/ci-run-macos-tests-csharp.sh
 
-      # DISABLED Pending PLAT-9177
-  # - label: Run MacOS e2e tests for Unity 2021
-  #   timeout_in_minutes: 60
-  #   depends_on: 'cocoa-webgl-2021-fixtures'
-  #   agents:
-  #     queue: macos-12-arm-unity
-  #   env:
-  #     UNITY_VERSION: "2021.3.27f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - features/fixtures/maze_runner/build/MacOS-2021.3.27f1.zip
-  #       upload:
-  #         - maze_output/**/*
-  #         - Mazerunner.log
-  #   commands:
-  #     - scripts/ci-run-macos-tests-csharp.sh
+  - label: Run MacOS e2e tests for Unity 2021
+    timeout_in_minutes: 60
+    depends_on: 'cocoa-webgl-2021-fixtures'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      UNITY_VERSION: "2021.3.27f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/MacOS-2021.3.27f1.zip
+        upload:
+          - maze_output/**/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-macos-tests-csharp.sh
+
+  - label: Run MacOS e2e tests for Unity 2022
+    timeout_in_minutes: 60
+    depends_on: 'cocoa-webgl-2022-fixtures'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/MacOS-2022.3.2f1.zip
+        upload:
+          - maze_output/**/*
+          - Mazerunner.log
+    commands:
+      - scripts/ci-run-macos-tests-csharp.sh
 
   #
   # Run WebGL tests
@@ -237,21 +275,35 @@ steps:
     commands:
       - scripts/ci-run-webgl-tests.sh
 
-      # DISABLED Pending PLAT-9177
-  # - label: Run WebGL e2e tests for Unity 2021
-  #   timeout_in_minutes: 30
-  #   depends_on: 'cocoa-webgl-2021-fixtures'
-  #   env:
-  #     UNITY_VERSION: "2021.3.27f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - features/fixtures/maze_runner/build/WebGL-2021.3.27f1.zip
-  #       upload:
-  #         - maze_output/**/*
-  #   # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-  #   commands:
-  #     - scripts/ci-run-webgl-tests.sh
+  - label: Run WebGL e2e tests for Unity 2021
+    timeout_in_minutes: 30
+    depends_on: 'cocoa-webgl-2021-fixtures'
+    env:
+      UNITY_VERSION: "2021.3.27f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2021.3.27f1.zip
+        upload:
+          - maze_output/**/*
+    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+    commands:
+      - scripts/ci-run-webgl-tests.sh
+
+  - label: Run WebGL e2e tests for Unity 2022
+    timeout_in_minutes: 30
+    depends_on: 'cocoa-webgl-2022-fixtures'
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - features/fixtures/maze_runner/build/WebGL-2022.3.2f1.zip
+        upload:
+          - maze_output/**/*
+    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
+    commands:
+      - scripts/ci-run-webgl-tests.sh
 
   #
   # Build Android test fixtures

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -163,7 +163,7 @@ steps:
     commands:
       - scripts/ci-run-macos-tests-csharp.sh
 
-  - label: Run MacOS e2e csharp tests
+  - label: Run MacOS e2e tests for Unity 2020
     timeout_in_minutes: 60
     depends_on: "cocoa-webgl-2020-fixtures"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
     timeout_in_minutes: 30
     key: "build-artifacts"
     env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2018.4.36f1"
     commands:
       - bundle install
@@ -173,7 +173,7 @@ steps:
     key: "build-ios-fixture-2020"
     depends_on: "generate-fixture-project-2020"
     env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: "2020.3.48f1"
     plugins:
       artifacts#v1.5.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,7 +44,102 @@ steps:
         - exit_status: "*"
           limit: 1
 
-#
+  - label: ':android: Build Android test fixture for Unity 2022'
+    timeout_in_minutes: 30
+    key: 'build-android-fixture-2022'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2022.3.2f1.apk
+          - features/fixtures/build_android_apk.log
+    commands:
+      - rake test:android:build
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':bitbar: :android: Run Android e2e tests for Unity 2022'
+    timeout_in_minutes: 60
+    depends_on: 'build-android-fixture-2022'
+    agents:
+      queue: opensource
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2022.3.2f1.apk"
+        upload:
+          - "maze_output/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner-bitbar
+        run: maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/csharp"
+          - "features/android"
+          - "--app=features/fixtures/maze_runner/mazerunner_2022.3.2f1.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+
+  - label: ':ios: Generate Xcode project - Unity 2022'
+    timeout_in_minutes: 30
+    key: 'generate-fixture-project-2022'
+    depends_on: 'build-artifacts'
+    env:
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+        upload:
+          - features/fixtures/unity.log
+          - project_2022.tgz
+    commands:
+      - rake test:ios:generate_xcode
+      - tar -zvcf project_2022.tgz features/fixtures/maze_runner/mazerunner_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
+
+  - label: ':ios: Build iOS test fixture for Unity 2022'
+    timeout_in_minutes: 30
+    key: 'build-ios-fixture-2022'
+    depends_on: 'generate-fixture-project-2022'
+    agents:
+      queue: macos-12-arm-unity
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+      UNITY_VERSION: "2022.3.2f1"
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - Bugsnag.unitypackage
+          - project_2022.tgz
+        upload:
+          - features/fixtures/maze_runner/mazerunner_2022.3.2f1.ipa
+          - features/fixtures/unity.log
+    commands:
+      - tar -zxf project_2022.tgz features/fixtures/maze_runner
+      - rake test:ios:build_xcode
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 #  # - label: Ensure notifier builds on Windows (for development)
 #  #   timeout_in_minutes: 30
 #  #   agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,13 +2,12 @@ agents:
   queue: macos-12-arm-unity
 
 steps:
-
   #
   # Build notifier.  We run tests for all Unity versions with the 2018 artifacts, as that is what we ship.
   #
   - label: Build released notifier artifact
     timeout_in_minutes: 30
-    key: 'build-artifacts'
+    key: "build-artifacts"
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2018.4.36f1"
@@ -42,10 +41,10 @@ steps:
   #         limit: 1
 
   # Build Android test fixtures
-  - label: ':android: Build Android test fixture for Unity 2020'
+  - label: ":android: Build Android test fixture for Unity 2020"
     timeout_in_minutes: 30
-    key: 'build-android-fixture-2020'
-    depends_on: 'build-artifacts'
+    key: "build-android-fixture-2020"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2020.3.48f1"
     plugins:
@@ -87,9 +86,9 @@ steps:
   #
   # Run Android tests
   #
-  - label: ':bitbar: :android: Run Android e2e tests for Unity 2020'
+  - label: ":bitbar: :android: Run Android e2e tests for Unity 2020"
     timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2020'
+    depends_on: "build-android-fixture-2020"
     agents:
       queue: opensource
     env:
@@ -115,9 +114,8 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
-
 
   # Run Android EDM tests
 
@@ -149,10 +147,10 @@ steps:
   #
   # Build iOS test fixtures
   #
-  - label: ':ios: Generate Xcode project - Unity 2020'
+  - label: ":ios: Generate Xcode project - Unity 2020"
     timeout_in_minutes: 30
-    key: 'generate-fixture-project-2020'
-    depends_on: 'build-artifacts'
+    key: "generate-fixture-project-2020"
+    depends_on: "build-artifacts"
     env:
       UNITY_VERSION: "2020.3.48f1"
     plugins:
@@ -170,10 +168,10 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':ios: Build iOS test fixture for Unity 2020'
+  - label: ":ios: Build iOS test fixture for Unity 2020"
     timeout_in_minutes: 30
-    key: 'build-ios-fixture-2020'
-    depends_on: 'generate-fixture-project-2020'
+    key: "build-ios-fixture-2020"
+    depends_on: "generate-fixture-project-2020"
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
       UNITY_VERSION: "2020.3.48f1"
@@ -196,9 +194,9 @@ steps:
   #
   # Run iOS tests
   #
-  - label: ':bitbar: :ios: Run iOS e2e tests for Unity 2020'
+  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2020"
     timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2020'
+    depends_on: "build-ios-fixture-2020"
     agents:
       queue: opensource
     plugins:
@@ -223,12 +221,12 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: "bitbar-app"
     concurrency_method: eager
 
   #
   # Conditionally trigger full pipeline
   #
-  - label: 'Conditionally trigger full set of tests'
+  - label: "Conditionally trigger full set of tests"
     timeout_in_minutes: 30
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,40 +22,38 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: Build Unity 2022 MacOS and WebGL test fixtures
-    timeout_in_minutes: 30
-    key: 'cocoa-webgl-2022-fixtures'
-    depends_on: 'build-artifacts'
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2022.3.2f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-    commands:
-      - scripts/ci-build-macos-packages.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2022.3.2f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2022.3.2f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
+  # - label: Ensure notifier builds on Windows (for development)
+  #   timeout_in_minutes: 30
+  #   agents:
+  #     queue: windows-unity-wsl
+  #   env:
+  #     UNITY_VERSION: "2018.4.36f1"
+  #     WSLENV: UNITY_VERSION
+  #   command:
+  #     - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       upload:
+  #         - from: Bugsnag.unitypackage
+  #           to: Bugsnag_WindowsBuilt.unitypackage
+  #   retry:
+  #     automatic:
+  #       - exit_status: "*"
+  #         limit: 1
 
-  - label: ':android: Build Android test fixture for Unity 2022'
+  # Build Android test fixtures
+  - label: ':android: Build Android test fixture for Unity 2020'
     timeout_in_minutes: 30
-    key: 'build-android-fixture-2022'
+    key: 'build-android-fixture-2020'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2022.3.2f1"
+      UNITY_VERSION: "2020.3.48f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
-          - features/fixtures/maze_runner/mazerunner_2022.3.2f1.apk
+          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk
           - features/fixtures/build_android_apk.log
     commands:
       - rake test:android:build
@@ -64,17 +62,42 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  - label: ':bitbar: :android: Run Android e2e tests for Unity 2022'
+  # - label: ':android: Build Android EDM test fixture for Unity 2020'
+  #   timeout_in_minutes: 30
+  #   key: 'build-edm-fixture-2020'
+  #   depends_on: 'build-artifacts'
+  #   env:
+  #     UNITY_VERSION: "2020.3.48f1"
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       download:
+  #         - Bugsnag.unitypackage
+  #       upload:
+  #         - features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk
+  #         - features/scripts/buildEdmFixture.log
+  #         - features/scripts/edmImport.log
+  #         - features/scripts/enableEdm.log
+  #   commands:
+  #     - rake test:edm:build
+  #   retry:
+  #     automatic:
+  #       - exit_status: "*"
+  #         limit: 1
+
+  #
+  # Run Android tests
+  #
+  - label: ':bitbar: :android: Run Android e2e tests for Unity 2020'
     timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2022'
+    depends_on: 'build-android-fixture-2020'
     agents:
       queue: opensource
     env:
-      UNITY_VERSION: "2022.3.2f1"
+      UNITY_VERSION: "2020.3.48f1"
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2022.3.2f1.apk"
+          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
         upload:
           - "maze_output/**/*"
           - "maze_output/metrics.csv"
@@ -85,7 +108,7 @@ steps:
         command:
           - "features/csharp"
           - "features/android"
-          - "--app=features/fixtures/maze_runner/mazerunner_2022.3.2f1.apk"
+          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
           - "--farm=bb"
           - "--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
           - "--no-tunnel"
@@ -95,259 +118,117 @@ steps:
     concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
-  - label: ':ios: Generate Xcode project - Unity 2022'
+
+  # Run Android EDM tests
+
+  # - label: ':android: Run Android EDM e2e tests for Unity 2020'
+  #   timeout_in_minutes: 30
+  #   depends_on: 'build-edm-fixture-2020'
+  #   agents:
+  #     queue: opensource
+  #   env:
+  #     UNITY_VERSION: "2020.3.48f1"
+  #   plugins:
+  #     artifacts#v1.5.0:
+  #       download:
+  #         - "features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
+  #       upload:
+  #         - "maze_output/**/*"
+  #     docker-compose#v3.7.0:
+  #       pull: maze-runner
+  #       run: maze-runner
+  #       command:
+  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
+  #         - "--farm=bs"
+  #         - "--device=ANDROID_11_0"
+  #         - "features/edm"
+  #   concurrency: 5
+  #   concurrency_group: browserstack-app
+  #   concurrency_method: eager
+
+  #
+  # Build iOS test fixtures
+  #
+  - label: ':ios: Generate Xcode project - Unity 2020'
     timeout_in_minutes: 30
-    key: 'generate-fixture-project-2022'
+    key: 'generate-fixture-project-2020'
     depends_on: 'build-artifacts'
     env:
-      UNITY_VERSION: "2022.3.2f1"
+      UNITY_VERSION: "2020.3.48f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/unity.log
-          - project_2022.tgz
+          - project_2020.tgz
     commands:
       - rake test:ios:generate_xcode
-      - tar -zvcf project_2022.tgz features/fixtures/maze_runner/mazerunner_xcode
+      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
     retry:
       automatic:
         - exit_status: "*"
           limit: 1
 
-  - label: ':ios: Build iOS test fixture for Unity 2022'
+  - label: ':ios: Build iOS test fixture for Unity 2020'
     timeout_in_minutes: 30
-    key: 'build-ios-fixture-2022'
-    depends_on: 'generate-fixture-project-2022'
-    agents:
-      queue: macos-12-arm-unity
+    key: 'build-ios-fixture-2020'
+    depends_on: 'generate-fixture-project-2020'
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2022.3.2f1"
+      UNITY_VERSION: "2020.3.48f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
-          - project_2022.tgz
+          - project_2020.tgz
         upload:
-          - features/fixtures/maze_runner/mazerunner_2022.3.2f1.ipa
+          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa
           - features/fixtures/unity.log
     commands:
-      - tar -zxf project_2022.tgz features/fixtures/maze_runner
+      - tar -zxf project_2020.tgz features/fixtures/maze_runner
       - rake test:ios:build_xcode
     retry:
       automatic:
         - exit_status: "*"
           limit: 1
-#  # - label: Ensure notifier builds on Windows (for development)
-#  #   timeout_in_minutes: 30
-#  #   agents:
-#  #     queue: windows-unity-wsl
-#  #   env:
-#  #     UNITY_VERSION: "2018.4.36f1"
-#  #     WSLENV: UNITY_VERSION
-#  #   command:
-#  #     - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
-#  #   plugins:
-#  #     artifacts#v1.5.0:
-#  #       upload:
-#  #         - from: Bugsnag.unitypackage
-#  #           to: Bugsnag_WindowsBuilt.unitypackage
-#  #   retry:
-#  #     automatic:
-#  #       - exit_status: "*"
-#  #         limit: 1
-#
-#  # Build Android test fixtures
-#  - label: ':android: Build Android test fixture for Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'build-android-fixture-2020'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2020.3.48f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk
-#          - features/fixtures/build_android_apk.log
-#    commands:
-#      - rake test:android:build
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  # - label: ':android: Build Android EDM test fixture for Unity 2020'
-#  #   timeout_in_minutes: 30
-#  #   key: 'build-edm-fixture-2020'
-#  #   depends_on: 'build-artifacts'
-#  #   env:
-#  #     UNITY_VERSION: "2020.3.48f1"
-#  #   plugins:
-#  #     artifacts#v1.5.0:
-#  #       download:
-#  #         - Bugsnag.unitypackage
-#  #       upload:
-#  #         - features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk
-#  #         - features/scripts/buildEdmFixture.log
-#  #         - features/scripts/edmImport.log
-#  #         - features/scripts/enableEdm.log
-#  #   commands:
-#  #     - rake test:edm:build
-#  #   retry:
-#  #     automatic:
-#  #       - exit_status: "*"
-#  #         limit: 1
-#
-#  #
-#  # Run Android tests
-#  #
-#  - label: ':bitbar: :android: Run Android e2e tests for Unity 2020'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-android-fixture-2020'
-#    agents:
-#      queue: opensource
-#    env:
-#      UNITY_VERSION: "2020.3.48f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
-#        upload:
-#          - "maze_output/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner-bitbar
-#        run: maze-runner-bitbar
-#        service-ports: true
-#        command:
-#          - "features/csharp"
-#          - "features/android"
-#          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
-#          - "--farm=bb"
-#          - "--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    concurrency: 25
-#    concurrency_group: 'bitbar-app'
-#    concurrency_method: eager
-#
-#
-#  # Run Android EDM tests
-#
-#  # - label: ':android: Run Android EDM e2e tests for Unity 2020'
-#  #   timeout_in_minutes: 30
-#  #   depends_on: 'build-edm-fixture-2020'
-#  #   agents:
-#  #     queue: opensource
-#  #   env:
-#  #     UNITY_VERSION: "2020.3.48f1"
-#  #   plugins:
-#  #     artifacts#v1.5.0:
-#  #       download:
-#  #         - "features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
-#  #       upload:
-#  #         - "maze_output/**/*"
-#  #     docker-compose#v3.7.0:
-#  #       pull: maze-runner
-#  #       run: maze-runner
-#  #       command:
-#  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
-#  #         - "--farm=bs"
-#  #         - "--device=ANDROID_11_0"
-#  #         - "features/edm"
-#  #   concurrency: 5
-#  #   concurrency_group: browserstack-app
-#  #   concurrency_method: eager
-#
-#  #
-#  # Build iOS test fixtures
-#  #
-#  - label: ':ios: Generate Xcode project - Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'generate-fixture-project-2020'
-#    depends_on: 'build-artifacts'
-#    env:
-#      UNITY_VERSION: "2020.3.48f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#        upload:
-#          - features/fixtures/unity.log
-#          - project_2020.tgz
-#    commands:
-#      - rake test:ios:generate_xcode
-#      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  - label: ':ios: Build iOS test fixture for Unity 2020'
-#    timeout_in_minutes: 30
-#    key: 'build-ios-fixture-2020'
-#    depends_on: 'generate-fixture-project-2020'
-#    env:
-#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-#      UNITY_VERSION: "2020.3.48f1"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - Bugsnag.unitypackage
-#          - project_2020.tgz
-#        upload:
-#          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa
-#          - features/fixtures/unity.log
-#    commands:
-#      - tar -zxf project_2020.tgz features/fixtures/maze_runner
-#      - rake test:ios:build_xcode
-#    retry:
-#      automatic:
-#        - exit_status: "*"
-#          limit: 1
-#
-#  #
-#  # Run iOS tests
-#  #
-#  - label: ':bitbar: :ios: Run iOS e2e tests for Unity 2020'
-#    timeout_in_minutes: 60
-#    depends_on: 'build-ios-fixture-2020'
-#    agents:
-#      queue: opensource
-#    plugins:
-#      artifacts#v1.5.0:
-#        download:
-#          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
-#        upload:
-#          - "maze_output/**/*"
-#          - "maze_output/metrics.csv"
-#
-#      docker-compose#v4.7.0:
-#        pull: maze-runner-bitbar
-#        run: maze-runner-bitbar
-#        service-ports: true
-#        command:
-#          - "features/csharp"
-#          - "features/ios"
-#          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
-#          - "--farm=bb"
-#          - "--device=IOS_12|IOS_13|IOS_14|IOS_15"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    concurrency: 25
-#    concurrency_group: 'bitbar-app'
-#    concurrency_method: eager
-#
-#  #
-#  # Conditionally trigger full pipeline
-#  #
-#  - label: 'Conditionally trigger full set of tests'
-#    timeout_in_minutes: 30
-#    command: sh -c .buildkite/pipeline_trigger.sh
 
+  #
+  # Run iOS tests
+  #
+  - label: ':bitbar: :ios: Run iOS e2e tests for Unity 2020'
+    timeout_in_minutes: 60
+    depends_on: 'build-ios-fixture-2020'
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
+        upload:
+          - "maze_output/**/*"
+          - "maze_output/metrics.csv"
+
+      docker-compose#v4.7.0:
+        pull: maze-runner-bitbar
+        run: maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/csharp"
+          - "features/ios"
+          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
+          - "--farm=bb"
+          - "--device=IOS_12|IOS_13|IOS_14|IOS_15"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+
+  #
+  # Conditionally trigger full pipeline
+  #
+  - label: 'Conditionally trigger full set of tests'
+    timeout_in_minutes: 30
+    command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,214 +22,237 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  # - label: Ensure notifier builds on Windows (for development)
-  #   timeout_in_minutes: 30
-  #   agents:
-  #     queue: windows-unity-wsl
-  #   env:
-  #     UNITY_VERSION: "2018.4.36f1"
-  #     WSLENV: UNITY_VERSION
-  #   command:
-  #     - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       upload:
-  #         - from: Bugsnag.unitypackage
-  #           to: Bugsnag_WindowsBuilt.unitypackage
-  #   retry:
-  #     automatic:
-  #       - exit_status: "*"
-  #         limit: 1
-
-  # Build Android test fixtures
-  - label: ':android: Build Android test fixture for Unity 2020'
+  - label: Build Unity 2022 MacOS and WebGL test fixtures
     timeout_in_minutes: 30
-    key: 'build-android-fixture-2020'
+    key: 'cocoa-webgl-2022-fixtures'
     depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2020.3.48f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk
-          - features/fixtures/build_android_apk.log
-    commands:
-      - rake test:android:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  # - label: ':android: Build Android EDM test fixture for Unity 2020'
-  #   timeout_in_minutes: 30
-  #   key: 'build-edm-fixture-2020'
-  #   depends_on: 'build-artifacts'
-  #   env:
-  #     UNITY_VERSION: "2020.3.48f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - Bugsnag.unitypackage
-  #       upload:
-  #         - features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk
-  #         - features/scripts/buildEdmFixture.log
-  #         - features/scripts/edmImport.log
-  #         - features/scripts/enableEdm.log
-  #   commands:
-  #     - rake test:edm:build
-  #   retry:
-  #     automatic:
-  #       - exit_status: "*"
-  #         limit: 1
-
-  #
-  # Run Android tests
-  #
-  - label: ':bitbar: :android: Run Android e2e tests for Unity 2020'
-    timeout_in_minutes: 60
-    depends_on: 'build-android-fixture-2020'
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: "2020.3.48f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
-        upload:
-          - "maze_output/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner-bitbar
-        run: maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/android"
-          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
-          - "--farm=bb"
-          - "--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: 'bitbar-app'
-    concurrency_method: eager
-
-
-  # Run Android EDM tests
-
-  # - label: ':android: Run Android EDM e2e tests for Unity 2020'
-  #   timeout_in_minutes: 30
-  #   depends_on: 'build-edm-fixture-2020'
-  #   agents:
-  #     queue: opensource
-  #   env:
-  #     UNITY_VERSION: "2020.3.48f1"
-  #   plugins:
-  #     artifacts#v1.5.0:
-  #       download:
-  #         - "features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
-  #       upload:
-  #         - "maze_output/**/*"
-  #     docker-compose#v3.7.0:
-  #       pull: maze-runner
-  #       run: maze-runner
-  #       command:
-  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
-  #         - "--farm=bs"
-  #         - "--device=ANDROID_11_0"
-  #         - "features/edm"
-  #   concurrency: 5
-  #   concurrency_group: browserstack-app
-  #   concurrency_method: eager
-
-  #
-  # Build iOS test fixtures
-  #
-  - label: ':ios: Generate Xcode project - Unity 2020'
-    timeout_in_minutes: 30
-    key: 'generate-fixture-project-2020'
-    depends_on: 'build-artifacts'
-    env:
-      UNITY_VERSION: "2020.3.48f1"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/unity.log
-          - project_2020.tgz
-    commands:
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ':ios: Build iOS test fixture for Unity 2020'
-    timeout_in_minutes: 30
-    key: 'build-ios-fixture-2020'
-    depends_on: 'generate-fixture-project-2020'
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      UNITY_VERSION: "2020.3.48f1"
+      UNITY_VERSION: "2022.3.2f1"
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
-          - project_2020.tgz
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa
-          - features/fixtures/unity.log
     commands:
-      - tar -zxf project_2020.tgz features/fixtures/maze_runner
-      - rake test:ios:build_xcode
+      - scripts/ci-build-macos-packages.sh
+    artifact_paths:
+      - unity.log
+      - features/fixtures/maze_runner/build/MacOS-2022.3.2f1.zip
+      - features/fixtures/maze_runner/build/WebGL-2022.3.2f1.zip
     retry:
       automatic:
         - exit_status: "*"
           limit: 1
 
-  #
-  # Run iOS tests
-  #
-  - label: ':bitbar: :ios: Run iOS e2e tests for Unity 2020'
-    timeout_in_minutes: 60
-    depends_on: 'build-ios-fixture-2020'
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
-        upload:
-          - "maze_output/**/*"
-          - "maze_output/metrics.csv"
-
-      docker-compose#v4.7.0:
-        pull: maze-runner-bitbar
-        run: maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/ios"
-          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
-          - "--farm=bb"
-          - "--device=IOS_12|IOS_13|IOS_14|IOS_15"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: 'bitbar-app'
-    concurrency_method: eager
-
-  #
-  # Conditionally trigger full pipeline
-  #
-  - label: 'Conditionally trigger full set of tests'
-    timeout_in_minutes: 30
-    command: sh -c .buildkite/pipeline_trigger.sh
+#
+#  # - label: Ensure notifier builds on Windows (for development)
+#  #   timeout_in_minutes: 30
+#  #   agents:
+#  #     queue: windows-unity-wsl
+#  #   env:
+#  #     UNITY_VERSION: "2018.4.36f1"
+#  #     WSLENV: UNITY_VERSION
+#  #   command:
+#  #     - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
+#  #   plugins:
+#  #     artifacts#v1.5.0:
+#  #       upload:
+#  #         - from: Bugsnag.unitypackage
+#  #           to: Bugsnag_WindowsBuilt.unitypackage
+#  #   retry:
+#  #     automatic:
+#  #       - exit_status: "*"
+#  #         limit: 1
+#
+#  # Build Android test fixtures
+#  - label: ':android: Build Android test fixture for Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'build-android-fixture-2020'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2020.3.48f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk
+#          - features/fixtures/build_android_apk.log
+#    commands:
+#      - rake test:android:build
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  # - label: ':android: Build Android EDM test fixture for Unity 2020'
+#  #   timeout_in_minutes: 30
+#  #   key: 'build-edm-fixture-2020'
+#  #   depends_on: 'build-artifacts'
+#  #   env:
+#  #     UNITY_VERSION: "2020.3.48f1"
+#  #   plugins:
+#  #     artifacts#v1.5.0:
+#  #       download:
+#  #         - Bugsnag.unitypackage
+#  #       upload:
+#  #         - features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk
+#  #         - features/scripts/buildEdmFixture.log
+#  #         - features/scripts/edmImport.log
+#  #         - features/scripts/enableEdm.log
+#  #   commands:
+#  #     - rake test:edm:build
+#  #   retry:
+#  #     automatic:
+#  #       - exit_status: "*"
+#  #         limit: 1
+#
+#  #
+#  # Run Android tests
+#  #
+#  - label: ':bitbar: :android: Run Android e2e tests for Unity 2020'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-android-fixture-2020'
+#    agents:
+#      queue: opensource
+#    env:
+#      UNITY_VERSION: "2020.3.48f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
+#        upload:
+#          - "maze_output/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner-bitbar
+#        run: maze-runner-bitbar
+#        service-ports: true
+#        command:
+#          - "features/csharp"
+#          - "features/android"
+#          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
+#          - "--farm=bb"
+#          - "--device=ANDROID_9|ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    concurrency: 25
+#    concurrency_group: 'bitbar-app'
+#    concurrency_method: eager
+#
+#
+#  # Run Android EDM tests
+#
+#  # - label: ':android: Run Android EDM e2e tests for Unity 2020'
+#  #   timeout_in_minutes: 30
+#  #   depends_on: 'build-edm-fixture-2020'
+#  #   agents:
+#  #     queue: opensource
+#  #   env:
+#  #     UNITY_VERSION: "2020.3.48f1"
+#  #   plugins:
+#  #     artifacts#v1.5.0:
+#  #       download:
+#  #         - "features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
+#  #       upload:
+#  #         - "maze_output/**/*"
+#  #     docker-compose#v3.7.0:
+#  #       pull: maze-runner
+#  #       run: maze-runner
+#  #       command:
+#  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
+#  #         - "--farm=bs"
+#  #         - "--device=ANDROID_11_0"
+#  #         - "features/edm"
+#  #   concurrency: 5
+#  #   concurrency_group: browserstack-app
+#  #   concurrency_method: eager
+#
+#  #
+#  # Build iOS test fixtures
+#  #
+#  - label: ':ios: Generate Xcode project - Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'generate-fixture-project-2020'
+#    depends_on: 'build-artifacts'
+#    env:
+#      UNITY_VERSION: "2020.3.48f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#        upload:
+#          - features/fixtures/unity.log
+#          - project_2020.tgz
+#    commands:
+#      - rake test:ios:generate_xcode
+#      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  - label: ':ios: Build iOS test fixture for Unity 2020'
+#    timeout_in_minutes: 30
+#    key: 'build-ios-fixture-2020'
+#    depends_on: 'generate-fixture-project-2020'
+#    env:
+#      DEVELOPER_DIR: "/Applications/Xcode13.4.app"
+#      UNITY_VERSION: "2020.3.48f1"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - Bugsnag.unitypackage
+#          - project_2020.tgz
+#        upload:
+#          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa
+#          - features/fixtures/unity.log
+#    commands:
+#      - tar -zxf project_2020.tgz features/fixtures/maze_runner
+#      - rake test:ios:build_xcode
+#    retry:
+#      automatic:
+#        - exit_status: "*"
+#          limit: 1
+#
+#  #
+#  # Run iOS tests
+#  #
+#  - label: ':bitbar: :ios: Run iOS e2e tests for Unity 2020'
+#    timeout_in_minutes: 60
+#    depends_on: 'build-ios-fixture-2020'
+#    agents:
+#      queue: opensource
+#    plugins:
+#      artifacts#v1.5.0:
+#        download:
+#          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
+#        upload:
+#          - "maze_output/**/*"
+#          - "maze_output/metrics.csv"
+#
+#      docker-compose#v4.7.0:
+#        pull: maze-runner-bitbar
+#        run: maze-runner-bitbar
+#        service-ports: true
+#        command:
+#          - "features/csharp"
+#          - "features/ios"
+#          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
+#          - "--farm=bb"
+#          - "--device=IOS_12|IOS_13|IOS_14|IOS_15"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    concurrency: 25
+#    concurrency_group: 'bitbar-app'
+#    concurrency_method: eager
+#
+#  #
+#  # Conditionally trigger full pipeline
+#  #
+#  - label: 'Conditionally trigger full set of tests'
+#    timeout_in_minutes: 30
+#    command: sh -c .buildkite/pipeline_trigger.sh
 

--- a/features/fixtures/maze_runner/Assets/Editor/Builder.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/Builder.cs
@@ -42,6 +42,10 @@ public class Builder : MonoBehaviour {
         var opts = CommonOptions("mazerunner.apk");
         opts.target = BuildTarget.Android;
 
+#if UNITY_2022_1_OR_NEWER
+        PlayerSettings.insecureHttpOption = InsecureHttpOption.AlwaysAllowed;
+#endif
+
         var result = BuildPipeline.BuildPlayer(opts);
         Debug.Log("Result: " + result);
     }

--- a/features/fixtures/maze_runner/Assets/Editor/DisablingBitcodeiOS.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/DisablingBitcodeiOS.cs
@@ -1,12 +1,15 @@
+#if UNITY_IOS
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.iOS.Xcode;
 
 public class DisablingBitcodeiOS
 {
-#if UNITY_IOS
+
     [PostProcessBuild(1000)]
     public static void PostProcessBuildAttribute(BuildTarget target, string pathToBuildProject)
     {
@@ -32,5 +35,7 @@ public class DisablingBitcodeiOS
             File.WriteAllText(projectPath, projectInString);
         }
     }
-#endif
+
 }
+
+#endif

--- a/features/fixtures/maze_runner/Assets/Editor/DisablingBitcodeiOS.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/DisablingBitcodeiOS.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using UnityEditor;
+
+public class DisablingBitcodeiOS
+{
+#if UNITY_IOS
+    [PostProcessBuild(1000)]
+    public static void PostProcessBuildAttribute(BuildTarget target, string pathToBuildProject)
+    {
+        if (target == BuildTarget.iOS)
+        {
+            string projectPath = PBXProject.GetPBXProjectPath(pathToBuildProject);
+
+            PBXProject pbxProject = new PBXProject();
+            pbxProject.ReadFromFile(projectPath);
+#if UNITY_2019_3_OR_NEWER
+                var targetGuid = pbxProject.GetUnityMainTargetGuid();
+#else
+            var targetName = PBXProject.GetUnityTargetName();
+            var targetGuid = pbxProject.TargetGuidByName(targetName);
+#endif
+            pbxProject.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
+            pbxProject.WriteToFile(projectPath);
+
+            var projectInString = File.ReadAllText(projectPath);
+
+            projectInString = projectInString.Replace("ENABLE_BITCODE = YES;",
+                $"ENABLE_BITCODE = NO;");
+            File.WriteAllText(projectPath, projectInString);
+        }
+    }
+#endif
+}

--- a/features/fixtures/maze_runner/Assets/Editor/DisablingBitcodeiOS.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Editor/DisablingBitcodeiOS.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c2c2e2275f81452f85b06b3f114f684
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Plugins/Android/AndroidManifest.xml
+++ b/features/fixtures/maze_runner/Assets/Plugins/Android/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.bugsnag.mazerunner">
     <application android:usesCleartextTraffic="true" android:label="@string/app_name">
-        <activity android:name="com.unity3d.player.UnityPlayerActivity" android:label="@string/app_name">
+        <activity android:name="com.unity3d.player.UnityPlayerActivity" android:label="@string/app_name" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -67,14 +67,14 @@ When('I run the game in the {string} state') do |state|
   case platform
   when 'macos'
     # Call executable directly rather than use open, which flakes on CI
-    log = File.join(Dir.pwd, 'mazerunner.log')
-    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner"
+    log = File.join(Dir.pwd, "#{state}-mazerunner.log")
+    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args -logfile #{log} > /dev/null"
     Maze::Runner.run_command(command, blocking: false)
 
     execute_command('run_scenario', state)
 
   when 'windows'
-    win_log = File.join(Dir.pwd, 'mazerunner.log')
+    win_log = File.join(Dir.pwd, "#{state}-mazerunner.log")
     command = "#{Maze.config.app} --args -logfile #{win_log}"
     Maze::Runner.run_command(command, blocking: false)
 


### PR DESCRIPTION
## Goal

Add Unity 2022 to testing roster.

## Changeset

- Moved Xcode operations from 13 to 14
- Added Android, iOS, MacOS, WebGL and Windows unity 2022 steps
- Disabled bitcode in iOS builds
- Enabled http requests in later unity builds

## Testing

Covered by existing tests