### PR TITLE
PLAT-10762 fix android breadcrumb memory leak

### DIFF
--- a/src/BugsnagUnity/Native/Android/NativePayloadClassWrapper.cs
+++ b/src/BugsnagUnity/Native/Android/NativePayloadClassWrapper.cs
@@ -237,18 +237,18 @@ namespace BugsnagUnity
 
         public void SetNativeDictionary(string key,IDictionary<string, object> dict)
         {
-            using (var map = NativeInterface.DictionaryToJavaMap(dict))
-            {
-                NativePointer.Call(key,map);
-            }
+            var disposeableContainer = new DisposableContainer();
+            var map = NativeInterface.DictionaryToJavaMap(dict, ref disposeableContainer);
+            NativePointer.Call(key,map);
+            disposeableContainer.Dispose();
         }
 
         public void SetNativeMetadataSection(string key, string section, IDictionary<string, object> dict)
         {
-            using (var map = NativeInterface.DictionaryToJavaMap(dict))
-            {
-                NativePointer.Call(key, section, map);
-            }
+            var disposableContainer = new DisposableContainer();
+            var map = NativeInterface.DictionaryToJavaMap(dict, ref disposableContainer);
+            NativePointer.Call(key, section, map);
+            disposableContainer.Dispose();
         }
 
         public DateTimeOffset? GetNativeDateTime(string key)


### PR DESCRIPTION
## Goal

Some AndroidJavaObject instances were not properly Disposed when passing breadcrumbs through to the native android layer.

## Changeset

- Added a disposable container class that tracks all created objects and disposes of them after use.

## Testing

Created an example app that, when using the latest release, always crashed within 2 seconds of launching due to the leak.
Then rebuilt the app with a new build containing the fix and left it running with a profiler attached for 30 mins. It did not crash and memory usage remaind constant.