### PR TITLE
Rationalise BitBar CI concurrency group

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -443,7 +443,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   - label: ":bitbar: :android: Run Android e2e tests for Unity 2019"
@@ -474,7 +474,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   - label: ":bitbar: :android: Run Android e2e tests for Unity 2021"
@@ -505,7 +505,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   - label: ":bitbar: :android: Run Android e2e tests for Unity 2022"
@@ -536,7 +536,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   # - label: ':android: Run Android EDM e2e tests for Unity 2021'
@@ -782,7 +782,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2019"
@@ -811,7 +811,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2021"
@@ -840,7 +840,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2022"
@@ -869,7 +869,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   #

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -129,7 +129,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   # Run Android EDM tests
@@ -236,7 +236,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: "bitbar-app"
+    concurrency_group: "bitbar"
     concurrency_method: eager
 
   #


### PR DESCRIPTION
## Goal

NOTE: Please let me merge this PR myself, it needs to be merged as the same time as several others to avoid unnecessary failures on CI.

Rationalise the Buildkite concurrency group used to control access to BitBar across all of our repos.

## Design

We were using separate groups fro web and device usage, when in fact they are counted towards the same usage limit.  All groups are now being renamed to simply 'bitbar' with a limit of 25.

The main mistake that I could make here is missing an instance of the old groups (`bitbar-app` and `bitbar-web`, so I am using the global find and replace function of my IDE.

## Changeset

Buildkite concurrency group changes only.

## Testing

Verified by peer review.  
