### PR TITLE
PLAT-11482 copy xprivacy file into plugin dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Copy the xprivacy api usage file from bugsnag-cocoa on build [#768](https://github.com/bugsnag/bugsnag-unity/pull/768)
+
 ## 7.7.0 (2024-01-04)
 
 ### Enhancements

--- a/Rakefile
+++ b/Rakefile
@@ -263,6 +263,9 @@ namespace :plugin do
 
       tvos_dir = File.join(assets_path, "tvOS")
 
+      #copy framework usage api file
+      cp_r File.join("bugsnag-cocoa", "Bugsnag", "resources", "PrivacyInfo.xcprivacy"), ios_dir
+
       cd cocoa_build_dir do
         cd "build" do
           def is_fat library_path


### PR DESCRIPTION
## Goal

The xprivacy file was not included in the built cocoa lib.

Following advice here: https://forum.unity.com/threads/apple-privacy-manifest-updates-for-unity-engine.1529026/

## Changeset

Copy the xprivacy file on build