### PR TITLE
PLAT-11641 handle json serialisation errors and remove payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD ()
+
+### Enhancements
+
+- Improved handling of serialisation errors when flushing the event cache [#773](https://github.com/bugsnag/bugsnag-unity/pull/773)
+
 ## 7.7.1 (2024-01-25)
 
 ### Bug Fixes

--- a/features/csharp/csharp_persistence.feature
+++ b/features/csharp/csharp_persistence.feature
@@ -103,3 +103,15 @@ Feature: Unity Persistence
     And the exception "message" equals "PersistDeviceId"
     And the error payload field "events.0.device.id" equals the stored value "device_id"
 
+  Scenario: Handle Corrupt Json
+    And I run the game in the "CorruptedCacheFile" state
+    And I wait for requests to persist
+    And I close the Unity app
+    And On Mobile I relaunch the app
+    And I run the game in the "NotifyWithStrings" state
+    And I wait for requests to persist
+    And I wait to receive 1 errors
+    And the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "NotifyWithStrings"
+
+

--- a/features/csharp/csharp_persistence.feature
+++ b/features/csharp/csharp_persistence.feature
@@ -108,10 +108,10 @@ Feature: Unity Persistence
     And I wait for requests to persist
     And I close the Unity app
     And On Mobile I relaunch the app
-    And I run the game in the "NotifyWithStrings" state
+    And I run the game in the "PersistEventReport" state
     And I wait for requests to persist
     And I wait to receive 1 errors
     And the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "NotifyWithStrings"
+    And the exception "message" equals "Error 2"
 
 

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.3731192, g: 0.38073966, b: 0.35872677, a: 1}
+  m_IndirectSpecularColor: {r: 0.3731316, g: 0.38074902, b: 0.3587254, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1537,6 +1537,7 @@ GameObject:
   - component: {fileID: 1523264808}
   - component: {fileID: 1523264809}
   - component: {fileID: 1523264810}
+  - component: {fileID: 1523264811}
   m_Layer: 0
   m_Name: Persistence
   m_TagString: Untagged
@@ -1673,6 +1674,21 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f0bba5b8a0a434b1a8385e1f33a02a80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2 () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &1523264811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523264801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 395039af028ee4010baf61afa7f7e066, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/CorruptedCacheFile.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/CorruptedCacheFile.cs
@@ -5,6 +5,16 @@ using UnityEngine;
 
 public class CorruptedCacheFile : Scenario
 {
+
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        if (Application.platform == RuntimePlatform.IPhonePlayer)
+        {
+            Configuration.EnabledErrorTypes.OOMs = false;
+        }
+    }
+
     public override void Run()
     {
         var dirPath = Application.persistentDataPath + "/Bugsnag/Events";

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/CorruptedCacheFile.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/CorruptedCacheFile.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class CorruptedCacheFile : Scenario
+{
+    public override void Run()
+    {
+        var dirPath = Application.persistentDataPath + "/Bugsnag/Events";
+        if (!Directory.Exists(dirPath))
+        {
+            Directory.CreateDirectory(dirPath);
+        }
+        File.WriteAllText(dirPath + "/f04274f7-6f7d-448e-b62e-486cc019a708.event", "NOT JSON");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/CorruptedCacheFile.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/CorruptedCacheFile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 395039af028ee4010baf61afa7f7e066
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -524,7 +524,7 @@ namespace BugsnagUnity
 
                     try
                     {
-                        // if something goes wrong at this stage then we silently discard the file as it's most likley an io error at some point
+                        // if something goes wrong at this stage then we silently discard the file as it's most likely that the file wasn't fully serialised to disk
                         payloadDictionary = ((JsonObject)SimpleJson.DeserializeObject(payloadJson)).GetDictionary();
                     }
                     catch (Exception e)

--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -544,29 +544,33 @@ namespace BugsnagUnity
                     // if something goes wrong at this stage then we discard the file and report the error as it might be a bug in the sdk
                     if (isSession)
                     {
+                        SessionReport sessionReport = null;
                         try
                         {
-                            var sessionReport = new SessionReport(_configuration, payloadDictionary);
-                            Deliver(sessionReport);
+                            sessionReport = new SessionReport(_configuration, payloadDictionary);
                         }
                         catch
                         {
+                            // this will be internally reported in a future update
                             _cacheManager.RemoveCachedSession(id);
                             continue;
                         }
+                        Deliver(sessionReport);
                     }
                     else
                     {
+                        Report report = null;
                         try
                         {
-                            var report = new Report(_configuration, payloadDictionary);
-                            Deliver(report);
+                            report = new Report(_configuration, payloadDictionary);
                         }
                         catch
                         {
+                            // this will be internally reported in a future update
                             _cacheManager.RemoveCachedEvent(id);
                             continue;
                         }
+                        Deliver(report);
                     }
                     
                     yield return new WaitUntil(() => CachedPayloadProcessed(id));

--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -528,7 +528,11 @@ namespace BugsnagUnity
                     }
                     catch (Exception e)
                     {
-                        Debug.LogException(new Exception("Bugsnag Error. Deserialising a cached payload for delivery failed: " + e.Message + " Cached json: " + payloadJson));
+                        Bugsnag.Notify(new Exception("Bugsnag Error. Deserialising a cached payload for delivery failed"),(@event)=>{
+                            @event.AddMetadata("Bugsnag","failedJson",payloadJson);
+                            return true;
+                        });
+                        _cacheManager.RemoveCachedEvent(id);
                         continue;
                     }
 

--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -540,8 +540,6 @@ namespace BugsnagUnity
                         continue;
                     }
 
-
-                    // if something goes wrong at this stage then we discard the file and report the error as it might be a bug in the sdk
                     if (isSession)
                     {
                         SessionReport sessionReport = null;

--- a/src/BugsnagUnity/Delivery.cs
+++ b/src/BugsnagUnity/Delivery.cs
@@ -527,9 +527,16 @@ namespace BugsnagUnity
                         // if something goes wrong at this stage then we silently discard the file as it's most likely that the file wasn't fully serialised to disk
                         payloadDictionary = ((JsonObject)SimpleJson.DeserializeObject(payloadJson)).GetDictionary();
                     }
-                    catch (Exception e)
+                    catch
                     {
-                        _cacheManager.RemoveCachedEvent(id);
+                        if (isSession)
+                        {
+                            _cacheManager.RemoveCachedSession(id);
+                        }
+                        else
+                        {
+                            _cacheManager.RemoveCachedEvent(id);
+                        }
                         continue;
                     }
 
@@ -542,14 +549,8 @@ namespace BugsnagUnity
                             var sessionReport = new SessionReport(_configuration, payloadDictionary);
                             Deliver(sessionReport);
                         }
-                        catch (Exception e)
+                        catch
                         {
-                            Bugsnag.Notify(e,(@event)=>
-                            {
-                                @event.Context = "BugSnag Session Cache Error";
-                                @event.AddMetadata("BugsnagSessionData",payloadDictionary);
-                                return true;
-                            });
                             _cacheManager.RemoveCachedSession(id);
                             continue;
                         }
@@ -561,14 +562,8 @@ namespace BugsnagUnity
                             var report = new Report(_configuration, payloadDictionary);
                             Deliver(report);
                         }
-                        catch (Exception e)
+                        catch
                         {
-                            Bugsnag.Notify(e,(@event)=>
-                            {
-                                @event.Context = "BugSnag Event Cache Error";
-                                @event.AddMetadata("BugsnagEventData",payloadDictionary);
-                                return true;
-                            });
                             _cacheManager.RemoveCachedEvent(id);
                             continue;
                         }

--- a/src/BugsnagUnity/Native/Fallback/CacheManager.cs
+++ b/src/BugsnagUnity/Native/Fallback/CacheManager.cs
@@ -188,9 +188,13 @@ namespace BugsnagUnity
 
         private void WriteFile(string path, string data)
         {
+            // not using File.WriteAllText to avoid under the hood buffering. We want the file to be written immediately to avoid truncation in case of a crash
             try
             {
-                File.WriteAllText(path, data);
+                var file = File.Create(path);
+                file.Write(System.Text.Encoding.UTF8.GetBytes(data), 0, data.Length);
+                file.Flush();
+                file.Close();
             }catch { }
         }
 


### PR DESCRIPTION
## Goal

### Error handling
Sometimes, while flushing the session and event cache, a serialisation error can occur.

This PR improves the handling of those errors. The new setup is as follows:

- if an error occurs while trying to serialise the json into a dictionary then we silently remove the offending file, as it is most likely caused by an unpreventable IO error.
- if an error occurs while trying to create an event or session from the dictionary then we remove the file and notify the dashboard with the dictionary attached as metadata so that we can try and solve the issue.

ignore errors and delete the payload when turning json string into dictionary
report errors and delete the payload when trying to create an event or session from the dictionary

### File writing

It could be possible the the method File.writeAllText is buffered under the hood. So we are now using a file stream to write data and using the method FileStream.Flush to force it to write all at once.


## Testing

Covered by existing tests