### PR TITLE
Grab test app logs after each scenario

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ./maze_output:/app/maze_output
 
   maze-runner-bitbar:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:appium-pull-file-cli
     environment:
       <<: *common-environment
       BITBAR_USERNAME:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ./maze_output:/app/maze_output
 
   maze-runner-bitbar:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:appium-pull-file-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli
     environment:
       <<: *common-environment
       BITBAR_USERNAME:

--- a/features/fixtures/maze_runner/Assets/Scripts/Logger.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Logger.cs
@@ -15,7 +15,7 @@ public class Logger : MonoBehaviour
     public static void I(string msg)
     {
         Debug.Log(LOG_PREFIX + msg);
-        _currentLog = msg + "\n";
+        _currentLog += msg + "\n";
         WriteLogFile();
     }
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -119,6 +119,28 @@ After do |scenario|
   end
 end
 
+device_logs = []
+After do |scenario|
+  if Maze.driver && Maze.driver.is_a?(Maze::Driver::Appium)
+    log_file = Maze::Api::Appium::FileManager.new.read_app_file('mazerunner-unity.log')
+    device_logs << {
+      file: log_file,
+      scenario: scenario.name
+    }
+  end
+end
+
+AfterAll do
+  maze_output = File.join(Dir.pwd, 'maze_output')
+  device_logs_folder = File.join(maze_output, 'device_logs')
+  FileUtils.makedirs(device_logs_folder)
+  device_logs.each do |log|
+    File.open(File.join(device_logs_folder, "#{log[:scenario]}.log"), 'w') do |f|
+      f.write(log[:file])
+    end
+  end
+end
+
 AfterAll do
   case Maze::Helper.get_current_platform
   when 'macos'


### PR DESCRIPTION
## Goal

Adds functionality to pull custom app logs from the test application after each test run.  These will then be uploaded as part of the maze_output.zip artifact.