### PR TITLE
Update BugsnagEditor.EDM.cs

### DIFF
--- a/src/Assets/Bugsnag/Editor/BugsnagEditor.EDM.cs
+++ b/src/Assets/Bugsnag/Editor/BugsnagEditor.EDM.cs
@@ -36,7 +36,7 @@ namespace BugsnagUnity.Editor
         [MenuItem(EDM_MENU_ITEM, true)]
         private static bool ToggleEDMValidate()
         {
-            Menu.SetChecked(EDM_MENU_ITEM, IsEDMEnabled());
+            UnityEditor.Menu.SetChecked(EDM_MENU_ITEM, IsEDMEnabled());
             return true;
         }
 


### PR DESCRIPTION
UnityEditor.Menu.SetChecked(EDM_MENU_ITEM, IsEDMEnabled());

instead of

Menu.SetChecked(EDM_MENU_ITEM, IsEDMEnabled());


removes problems with others libs

## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->