### PR TITLE
Plat 11883 update bugsnag editor edm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## TBD
 
-- Updated naming for BugsnagEditor EDM menu 
+- Updated naming for BugsnagEditor EDM menu [#780](https://github.com/bugsnag/bugsnag-unity/pull/780)
 
 ## 7.7.2 (2024-03-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBD
+
+- Updated naming for BugsnagEditor EDM menu 
+
 ## 7.7.2 (2024-03-01)
 
 ### Enhancements

--- a/src/Assets/Bugsnag/Editor/BugsnagEditor.EDM.cs
+++ b/src/Assets/Bugsnag/Editor/BugsnagEditor.EDM.cs
@@ -36,7 +36,7 @@ namespace BugsnagUnity.Editor
         [MenuItem(EDM_MENU_ITEM, true)]
         private static bool ToggleEDMValidate()
         {
-            Menu.SetChecked(EDM_MENU_ITEM, IsEDMEnabled());
+            UnityEditor.Menu.SetChecked(EDM_MENU_ITEM, IsEDMEnabled());
             return true;
         }
 


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
BugsnagEditor.EDM Menu is causing conflicts with separate libraries.

## Changeset
Changed in BugsnagEditor.EDM.cs

```Menu.SetChecked(EDM_MENU_ITEM, IsEDMEnabled());```

to 

```UnityEditor.Menu.SetChecked(EDM_MENU_ITEM, IsEDMEnabled());```


<!-- What changed? -->

## Testing

Ran locally