### PR TITLE
Drop testing on Unity 2018 and 2019

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,6 +1,4 @@
 aliases:
-  - &2018 "2018.4.36f1"
-  - &2019 "2019.4.35f1"
   - &2020 "2020.3.48f1"
   - &2021 "2021.3.36f1"
   - &2022 "2022.3.22f1"
@@ -10,59 +8,11 @@ agents:
 
 steps:
   # Note:
-  #  The basic pipeline handles Unity 2020, but doesn't include the building of test fixtures for WebGL, macOS and
+  #  The basic pipeline handles Unity 2021, but doesn't include the building of test fixtures for WebGL, macOS and
   #  Windows.  They are included here instead.
 
   # Build MacOS and WebGL test fixtures
   #
-  - label: Build Unity 2018 MacOS and WebGL test fixtures
-    timeout_in_minutes: 30
-    key: "cocoa-webgl-2018-fixtures"
-    depends_on: "build-artifacts"
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
-      UNITY_VERSION: *2018
-      # Python2 needed for WebGL to build
-      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-    commands:
-      - scripts/ci-build-macos-packages.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: Build Unity 2019 MacOS and WebGL test fixtures
-    timeout_in_minutes: 30
-    key: "cocoa-webgl-2019-fixtures"
-    depends_on: "build-artifacts"
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
-      UNITY_VERSION: *2019
-      # Python2 needed for WebGL to build
-      EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-    commands:
-      - scripts/ci-build-macos-packages.sh
-    artifact_paths:
-      - unity.log
-      - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
-      - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
   - label: Build Unity 2020 MacOS and WebGL test fixtures
     timeout_in_minutes: 30
     key: "cocoa-webgl-2020-fixtures"
@@ -134,42 +84,6 @@ steps:
   #
   # Run macOS desktop tests
   #
-  - label: Run MacOS e2e tests for Unity 2018
-    timeout_in_minutes: 60
-    depends_on: "cocoa-webgl-2018-fixtures"
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      UNITY_VERSION: *2018
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/MacOS-2018.4.36f1.zip
-        upload:
-          - maze_output/**/*
-          - '*-mazerunner.log'
-          - maze_output/metrics.csv
-    commands:
-      - scripts/ci-run-macos-tests-csharp.sh
-
-  - label: Run MacOS e2e tests for Unity 2019
-    timeout_in_minutes: 60
-    depends_on: "cocoa-webgl-2019-fixtures"
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      UNITY_VERSION: *2019
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/MacOS-2019.4.35f1.zip
-        upload:
-          - maze_output/**/*
-          - '*-mazerunner.log'
-          - maze_output/metrics.csv
-    commands:
-      - scripts/ci-run-macos-tests-csharp.sh
-
   - label: Run MacOS e2e tests for Unity 2020
     timeout_in_minutes: 60
     depends_on: "cocoa-webgl-2020-fixtures"
@@ -228,42 +142,6 @@ steps:
   #
   # Note: These are run on Intel due to an issue with persistence with Firefox on ARM.
   #
-  - label: Run WebGL e2e tests for Unity 2018
-    timeout_in_minutes: 30
-    depends_on: "cocoa-webgl-2018-fixtures"
-    agents:
-      queue: opensource-mac-cocoa-11
-    env:
-      UNITY_VERSION: *2018
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/WebGL-2018.4.36f1.zip
-        upload:
-          - maze_output/**/*
-          - maze_output/metrics.csv
-    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-    commands:
-      - scripts/ci-run-webgl-tests.sh
-
-  - label: Run WebGL e2e tests for Unity 2019
-    timeout_in_minutes: 30
-    depends_on: "cocoa-webgl-2019-fixtures"
-    agents:
-      queue: opensource-mac-cocoa-11
-    env:
-      UNITY_VERSION: *2019
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/WebGL-2019.4.35f1.zip
-        upload:
-          - maze_output/**/*
-          - maze_output/metrics.csv
-    # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
-    commands:
-      - scripts/ci-run-webgl-tests.sh
-
   - label: Run WebGL e2e tests for Unity 2020
     timeout_in_minutes: 30
     depends_on: "cocoa-webgl-2020-fixtures"
@@ -317,60 +195,18 @@ steps:
   #
   # Build Android test fixtures
   #
-  - label: ":android: Build Android test fixture for Unity 2018"
+  - label: ":android: Build Android test fixture for Unity 2020"
     timeout_in_minutes: 30
-    key: "build-android-fixture-2018"
+    key: "build-android-fixture-2020"
     depends_on: "build-artifacts"
     env:
-      UNITY_VERSION: *2018
+      UNITY_VERSION: *2020
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
-          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk
-          - features/fixtures/build_android_apk.log
-    commands:
-      - bundle install
-      - rake test:android:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ":android: Build Android test fixture for Unity 2019"
-    timeout_in_minutes: 30
-    key: "build-android-fixture-2019"
-    depends_on: "build-artifacts"
-    env:
-      UNITY_VERSION: *2019
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk
-          - features/fixtures/build_android_apk.log
-    commands:
-      - bundle install
-      - rake test:android:build
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ":android: Build Android test fixture for Unity 2021"
-    timeout_in_minutes: 30
-    key: "build-android-fixture-2021"
-    depends_on: "build-artifacts"
-    env:
-      UNITY_VERSION: *2021
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2021.3.36f1.apk
+          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk
           - features/fixtures/build_android_apk.log
     commands:
       - bundle install
@@ -401,18 +237,18 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  # - label: ':android: Build Android EDM test fixture for Unity 2021'
+  # - label: ':android: Build Android EDM test fixture for Unity 2020'
   #   timeout_in_minutes: 30
-  #   key: 'build-edm-fixture-2021'
+  #   key: 'build-edm-fixture-2020'
   #   depends_on: 'build-artifacts'
   #   env:
-  #     UNITY_VERSION: *2021
+  #     UNITY_VERSION: *2020
   #   plugins:
   #     artifacts#v1.5.0:
   #       download:
   #         - Bugsnag.unitypackage
   #       upload:
-  #         - features/fixtures/EDM_Fixture/edm_2021.3.36f1.apk
+  #         - features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk
   #         - features/scripts/buildEdmFixture.log
   #         - features/scripts/edmImport.log
   #         - features/scripts/enableEdm.log
@@ -426,17 +262,17 @@ steps:
   #
   # Run Android tests
   #
-  - label: ":bitbar: :android: Run Android e2e tests for Unity 2018"
+  - label: ":bitbar: :android: Run Android e2e tests for Unity 2020"
     timeout_in_minutes: 60
-    depends_on: "build-android-fixture-2018"
+    depends_on: "build-android-fixture-2020"
     agents:
       queue: opensource
     env:
-      UNITY_VERSION: *2018
+      UNITY_VERSION: *2020
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
+          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
         upload:
           - "maze_output/**/*"
           - "maze_output/metrics.csv"
@@ -447,71 +283,7 @@ steps:
         command:
           - "features/csharp"
           - "features/android"
-          - "--app=features/fixtures/maze_runner/mazerunner_2018.4.36f1.apk"
-          - "--farm=bb"
-          - "--appium-version=1.22"
-          - "--device=ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: "bitbar"
-    concurrency_method: eager
-
-  - label: ":bitbar: :android: Run Android e2e tests for Unity 2019"
-    timeout_in_minutes: 60
-    depends_on: "build-android-fixture-2019"
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: *2019
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
-        upload:
-          - "maze_output/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner-bitbar
-        run: maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/android"
-          - "--app=features/fixtures/maze_runner/mazerunner_2019.4.35f1.apk"
-          - "--farm=bb"
-          - "--appium-version=1.22"
-          - "--device=ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: "bitbar"
-    concurrency_method: eager
-
-  - label: ":bitbar: :android: Run Android e2e tests for Unity 2021"
-    timeout_in_minutes: 60
-    depends_on: "build-android-fixture-2021"
-    agents:
-      queue: opensource
-    env:
-      UNITY_VERSION: *2021
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2021.3.36f1.apk"
-        upload:
-          - "maze_output/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner-bitbar
-        run: maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/android"
-          - "--app=features/fixtures/maze_runner/mazerunner_2021.3.36f1.apk"
+          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
           - "--farm=bb"
           - "--appium-version=1.22"
           - "--device=ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
@@ -554,9 +326,9 @@ steps:
     concurrency_group: "bitbar"
     concurrency_method: eager
 
-  # - label: ':android: Run Android EDM e2e tests for Unity 2021'
+  # - label: ':android: Run Android EDM e2e tests for Unity 2020'
   #   timeout_in_minutes: 60
-  #   depends_on: 'build-edm-fixture-2021'
+  #   depends_on: 'build-edm-fixture-2020'
   #   agents:
   #     queue: opensource
   #   env:
@@ -564,14 +336,14 @@ steps:
   #   plugins:
   #     artifacts#v1.5.0:
   #       download:
-  #         - "features/fixtures/EDM_Fixture/edm_2021.3.36f1.apk"
+  #         - "features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
   #       upload:
   #         - "maze_output/**/*"
   #     docker-compose#v3.7.0:
   #       pull: maze-runner
   #       run: maze-runner
   #       command:
-  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.36f1.apk"
+  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
   #         - "--farm=bs"
   #         - "--device=ANDROID_11_0"
   #         - "features/edm"
@@ -582,139 +354,44 @@ steps:
   #
   # Build iOS test fixtures
   #
-  - label: ":ios: Generate Xcode project - Unity 2018"
+  - label: ":ios: Generate Xcode project - Unity 2020"
     timeout_in_minutes: 30
-    key: "generate-fixture-project-2018"
+    key: "generate-fixture-project-2020"
     depends_on: "build-artifacts"
     env:
-      UNITY_VERSION: *2018
+      UNITY_VERSION: *2020
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/unity.log
-          - project_2018.tgz
+          - project_2020.tgz
     commands:
       - bundle install
       - rake test:ios:generate_xcode
-      - tar -zvcf project_2018.tgz  features/fixtures/maze_runner/mazerunner_xcode
+      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
     retry:
       automatic:
         - exit_status: "*"
           limit: 1
 
-  - label: ":ios: Build iOS test fixture for Unity 2018"
+  - label: ":ios: Build iOS test fixture for Unity 2020"
     timeout_in_minutes: 30
-    key: "build-ios-fixture-2018"
-    depends_on: "generate-fixture-project-2018"
+    key: "build-ios-fixture-2020"
+    depends_on: "generate-fixture-project-2020"
     agents:
       queue: macos-12-arm-unity
     env:
       DEVELOPER_DIR: "/Applications/Xcode14.0.app"
-      UNITY_VERSION: *2018
+      UNITY_VERSION: *2020
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
-          - project_2018.tgz
+          - project_2020.tgz
         upload:
-          - features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa
-          - features/fixtures/unity.log
-    commands:
-      - bundle install
-      - tar -zxf project_2018.tgz features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ":ios: Generate Xcode project - Unity 2019"
-    timeout_in_minutes: 30
-    key: "generate-fixture-project-2019"
-    depends_on: "build-artifacts"
-    env:
-      UNITY_VERSION: *2019
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/unity.log
-          - project_2019.tgz
-    commands:
-      - bundle install
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2019.tgz features/fixtures/maze_runner/mazerunner_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ":ios: Build iOS test fixture for Unity 2019"
-    timeout_in_minutes: 30
-    key: "build-ios-fixture-2019"
-    depends_on: "generate-fixture-project-2019"
-    agents:
-      queue: macos-14
-    env:
-      UNITY_VERSION: *2019
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-          - project_2019.tgz
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa
-          - features/fixtures/unity.log
-    commands:
-      - bundle install
-      - tar -zxf project_2019.tgz features/fixtures/maze_runner
-      - rake test:ios:build_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ":ios: Generate Xcode project - Unity 2021"
-    timeout_in_minutes: 30
-    key: "generate-fixture-project-2021"
-    depends_on: "build-artifacts"
-    env:
-      UNITY_VERSION: *2021
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - features/fixtures/unity.log
-          - project_2021.tgz
-    commands:
-      - bundle install
-      - rake test:ios:generate_xcode
-      - tar -zvcf project_2021.tgz features/fixtures/maze_runner/mazerunner_xcode
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: ":ios: Build iOS test fixture for Unity 2021"
-    timeout_in_minutes: 30
-    key: "build-ios-fixture-2021"
-    depends_on: "generate-fixture-project-2021"
-    agents:
-      queue: macos-12-arm-unity
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
-      UNITY_VERSION: *2021
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-          - project_2021.tgz
-        upload:
-          - features/fixtures/maze_runner/mazerunner_2021.3.36f1.ipa
+          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa
           - features/fixtures/unity.log
     commands:
       - bundle install
@@ -776,17 +453,15 @@ steps:
   #
   # Run iOS tests
   #
-  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2018"
+  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2020"
     timeout_in_minutes: 60
-    depends_on: "build-ios-fixture-2018"
+    depends_on: "build-ios-fixture-2020"
     agents:
       queue: opensource
-    env:
-      UNITY_VERSION: *2018
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
+          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
         upload:
           - "maze_output/**/*"
           - "maze_output/metrics.csv"
@@ -797,67 +472,7 @@ steps:
         command:
           - "features/csharp"
           - "features/ios"
-          - "--app=features/fixtures/maze_runner/mazerunner_2018.4.36f1.ipa"
-          - "--farm=bb"
-          - "--appium-version=1.22"
-          - "--device=IOS_13|IOS_14|IOS_15"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: "bitbar"
-    concurrency_method: eager
-
-  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2019"
-    timeout_in_minutes: 60
-    depends_on: "build-ios-fixture-2019"
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
-        upload:
-          - "maze_output/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner-bitbar
-        run: maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/ios"
-          - "--app=features/fixtures/maze_runner/mazerunner_2019.4.35f1.ipa"
-          - "--farm=bb"
-          - "--appium-version=1.22"
-          - "--device=IOS_13|IOS_14|IOS_15"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    concurrency: 25
-    concurrency_group: "bitbar"
-    concurrency_method: eager
-
-  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2021"
-    timeout_in_minutes: 60
-    depends_on: "build-ios-fixture-2021"
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - "features/fixtures/maze_runner/mazerunner_2021.3.36f1.ipa"
-        upload:
-          - "maze_output/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner-bitbar
-        run: maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/csharp"
-          - "features/ios"
-          - "--app=features/fixtures/maze_runner/mazerunner_2021.3.36f1.ipa"
+          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.28f1.ipa"
           - "--farm=bb"
           - "--appium-version=1.22"
           - "--device=IOS_13|IOS_14|IOS_15"
@@ -901,50 +516,6 @@ steps:
   #
   # Build Windows test fixtures
   #
-  - label: Build Unity 2018 Windows test fixture
-    timeout_in_minutes: 30
-    key: "windows-2018-fixture"
-    depends_on: "build-artifacts"
-    agents:
-      queue: windows-unity-wsl
-    env:
-      UNITY_VERSION: *2018
-    command:
-      - scripts/ci-build-windows-fixture-wsl.sh
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - unity.log
-          - features/fixtures/maze_runner/build/Windows-2018.4.36f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
-  - label: Build Unity 2019 Windows test fixture
-    timeout_in_minutes: 30
-    key: "windows-2019-fixture"
-    depends_on: "build-artifacts"
-    agents:
-      queue: windows-unity-wsl
-    env:
-      UNITY_VERSION: *2019
-    command:
-      - scripts/ci-build-windows-fixture-wsl.sh
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - Bugsnag.unitypackage
-        upload:
-          - unity.log
-          - features/fixtures/maze_runner/build/Windows-2019.4.35f1.zip
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 1
-
   - label: Build Unity 2020 Windows test fixture
     timeout_in_minutes: 30
     key: "windows-2020-fixture"
@@ -1014,40 +585,6 @@ steps:
   #
   # Run Windows e2e tests
   #
-  - label: Run Windows e2e tests for Unity 2018
-    timeout_in_minutes: 30
-    depends_on: "windows-2018-fixture"
-    agents:
-      queue: windows-general-wsl
-    env:
-      UNITY_VERSION: *2018
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/Windows-2018.4.36f1.zip
-        upload:
-          - maze_output/**/*
-          - maze_output/metrics.csv
-    commands:
-      - scripts/ci-run-windows-tests-wsl.sh
-
-  - label: Run Windows e2e tests for Unity 2019
-    timeout_in_minutes: 30
-    depends_on: "windows-2019-fixture"
-    agents:
-      queue: windows-general-wsl
-    env:
-      UNITY_VERSION: *2019
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - features/fixtures/maze_runner/build/Windows-2019.4.35f1.zip
-        upload:
-          - maze_output/**/*
-          - maze_output/metrics.csv
-    commands:
-      - scripts/ci-run-windows-tests-wsl.sh
-
   - label: Run Windows e2e tests for Unity 2020
     timeout_in_minutes: 30
     depends_on: "windows-2020-fixture"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -4,7 +4,7 @@ aliases:
   - &2022 "2022.3.22f1"
 
 agents:
-  queue: macos-12-arm-unity
+  queue: macos-14
 
 steps:
   # Note:
@@ -18,8 +18,8 @@ steps:
     key: "cocoa-webgl-2020-fixtures"
     depends_on: "build-artifacts"
     env:
-      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: *2020
+      XCODE_VERSION: "15.3.0"
       # Python2 needed for WebGL to build
       EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
     plugins:
@@ -42,8 +42,8 @@ steps:
     key: "cocoa-webgl-2021-fixtures"
     depends_on: "build-artifacts"
     env:
-      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: *2021
+      XCODE_VERSION: "15.3.0"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -64,8 +64,8 @@ steps:
     key: "cocoa-webgl-2022-fixtures"
     depends_on: "build-artifacts"
     env:
-      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: *2022
+      XCODE_VERSION: "15.3.0"
     plugins:
       artifacts#v1.5.0:
         download:
@@ -87,8 +87,6 @@ steps:
   - label: Run MacOS e2e tests for Unity 2020
     timeout_in_minutes: 60
     depends_on: "cocoa-webgl-2020-fixtures"
-    agents:
-      queue: macos-12-arm-unity
     env:
       UNITY_VERSION: *2020
     plugins:
@@ -123,8 +121,6 @@ steps:
   - label: Run MacOS e2e tests for Unity 2022
     timeout_in_minutes: 60
     depends_on: 'cocoa-webgl-2022-fixtures'
-    agents:
-      queue: macos-12-arm-unity
     env:
       UNITY_VERSION: *2022
     plugins:
@@ -380,10 +376,8 @@ steps:
     timeout_in_minutes: 30
     key: "build-ios-fixture-2020"
     depends_on: "generate-fixture-project-2020"
-    agents:
-      queue: macos-12-arm-unity
     env:
-      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
+      XCODE_VERSION: "15.3.0"
       UNITY_VERSION: *2020
     plugins:
       artifacts#v1.5.0:
@@ -395,7 +389,7 @@ steps:
           - features/fixtures/unity.log
     commands:
       - bundle install
-      - tar -zxf project_2021.tgz features/fixtures/maze_runner
+      - tar -zxf project_2020.tgz features/fixtures/maze_runner
       - rake test:ios:build_xcode
     retry:
       automatic:
@@ -428,11 +422,9 @@ steps:
     timeout_in_minutes: 30
     key: "build-ios-fixture-2022"
     depends_on: "generate-fixture-project-2022"
-    agents:
-      queue: macos-12-arm-unity
     env:
-      DEVELOPER_DIR: "/Applications/Xcode14.0.app"
       UNITY_VERSION: *2022
+      XCODE_VERSION: "15.3.0"
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -87,6 +87,8 @@ steps:
   - label: Run MacOS e2e tests for Unity 2020
     timeout_in_minutes: 60
     depends_on: "cocoa-webgl-2020-fixtures"
+    agents:
+      queue: macos-12-arm
     env:
       UNITY_VERSION: *2020
     plugins:
@@ -121,6 +123,8 @@ steps:
   - label: Run MacOS e2e tests for Unity 2022
     timeout_in_minutes: 60
     depends_on: 'cocoa-webgl-2022-fixtures'
+    agents:
+      queue: macos-12-arm
     env:
       UNITY_VERSION: *2022
     plugins:
@@ -176,6 +180,8 @@ steps:
   - label: Run WebGL e2e tests for Unity 2022
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2022-fixtures'
+    agents:
+      queue: opensource-mac-cocoa-11
     env:
       UNITY_VERSION: *2022
     plugins:
@@ -464,7 +470,7 @@ steps:
         command:
           - "features/csharp"
           - "features/ios"
-          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.28f1.ipa"
+          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
           - "--farm=bb"
           - "--appium-version=1.22"
           - "--device=IOS_13|IOS_14|IOS_15"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -192,6 +192,7 @@ steps:
     depends_on: "generate-fixture-project-2021"
     env:
       UNITY_VERSION: *2021
+      XCODE_VERSION: "15.3.0"
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
     timeout_in_minutes: 30
     key: "build-artifacts"
     env:
-      UNITY_VERSION: *2020
+      UNITY_VERSION: *2021
     commands:
       - bundle install
       - bundle exec rake plugin:export

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,19 +1,19 @@
 aliases:
-  - &2018 "2018.4.36f1"
   - &2020 "2020.3.48f1"
+  - &2021 "2021.3.36f1"
 
 agents:
   queue: macos-14
 
 steps:
   #
-  # Build notifier.  We run tests for all Unity versions with the 2018 artifacts, as that is what we ship.
+  # Build notifier.  We run tests for all Unity versions with the 2020 artifacts, as that is what we ship.
   #
   - label: Build released notifier artifact
     timeout_in_minutes: 30
     key: "build-artifacts"
     env:
-      UNITY_VERSION: *2018
+      UNITY_VERSION: *2020
     commands:
       - bundle install
       - bundle exec rake plugin:export
@@ -29,7 +29,7 @@ steps:
   #   agents:
   #     queue: windows-unity-wsl
   #   env:
-  #     UNITY_VERSION: "2018.4.36f1"
+  #     UNITY_VERSION: *2020
   #     WSLENV: UNITY_VERSION
   #   command:
   #     - /mnt/c/Windows/System32/cmd.exe /c  .\\scripts\\ci-build-windows-plugin.bat
@@ -47,7 +47,7 @@ steps:
     timeout_in_minutes: 10
     depends_on: build-artifacts
     env:
-      UNITY_VERSION: *2020
+      UNITY_VERSION: *2021
     plugins:
       'artifacts#v1.9.0':
         download:
@@ -56,18 +56,18 @@ steps:
       features/scripts/do_size_test.sh
 
   # Build Android test fixtures
-  - label: ":android: Build Android test fixture for Unity 2020"
+  - label: ":android: Build Android test fixture for Unity 2021"
     timeout_in_minutes: 30
-    key: "build-android-fixture-2020"
+    key: "build-android-fixture-2021"
     depends_on: "build-artifacts"
     env:
-      UNITY_VERSION: *2020
+      UNITY_VERSION: *2021
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk
+          - features/fixtures/maze_runner/mazerunner_2021.3.36f1.apk
           - features/fixtures/build_android_apk.log
     commands:
       - bundle install
@@ -77,18 +77,18 @@ steps:
         - exit_status: "*"
           limit: 1
 
-  # - label: ':android: Build Android EDM test fixture for Unity 2020'
+  # - label: ':android: Build Android EDM test fixture for Unity 2021'
   #   timeout_in_minutes: 30
-  #   key: 'build-edm-fixture-2020'
+  #   key: 'build-edm-fixture-2021'
   #   depends_on: 'build-artifacts'
   #   env:
-  #     UNITY_VERSION: "2020.3.48f1"
+  #     UNITY_VERSION: *2021
   #   plugins:
   #     artifacts#v1.5.0:
   #       download:
   #         - Bugsnag.unitypackage
   #       upload:
-  #         - features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk
+  #         - features/fixtures/EDM_Fixture/edm_2021.3.36f1.apk
   #         - features/scripts/buildEdmFixture.log
   #         - features/scripts/edmImport.log
   #         - features/scripts/enableEdm.log
@@ -102,17 +102,17 @@ steps:
   #
   # Run Android tests
   #
-  - label: ":bitbar: :android: Run Android e2e tests for Unity 2020"
+  - label: ":bitbar: :android: Run Android e2e tests for Unity 2021"
     timeout_in_minutes: 60
-    depends_on: "build-android-fixture-2020"
+    depends_on: "build-android-fixture-2021"
     agents:
       queue: opensource
     env:
-      UNITY_VERSION: *2020
+      UNITY_VERSION: *2021
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
+          - "features/fixtures/maze_runner/mazerunner_2021.3.36f1.apk"
         upload:
           - "maze_output/**/*"
           - "maze_output/metrics.csv"
@@ -123,7 +123,7 @@ steps:
         command:
           - "features/csharp"
           - "features/android"
-          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.apk"
+          - "--app=features/fixtures/maze_runner/mazerunner_2021.3.36f1.apk"
           - "--farm=bb"
           - "--appium-version=1.22"
           - "--device=ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
@@ -136,24 +136,24 @@ steps:
 
   # Run Android EDM tests
 
-  # - label: ':android: Run Android EDM e2e tests for Unity 2020'
+  # - label: ':android: Run Android EDM e2e tests for Unity 2021'
   #   timeout_in_minutes: 30
-  #   depends_on: 'build-edm-fixture-2020'
+  #   depends_on: 'build-edm-fixture-2021'
   #   agents:
   #     queue: opensource
   #   env:
-  #     UNITY_VERSION: "2020.3.48f1"
+  #     UNITY_VERSION: "2021.3.36f1"
   #   plugins:
   #     artifacts#v1.5.0:
   #       download:
-  #         - "features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
+  #         - "features/fixtures/EDM_Fixture/edm_2021.3.36f1.apk"
   #       upload:
   #         - "maze_output/**/*"
   #     docker-compose#v3.7.0:
   #       pull: maze-runner
   #       run: maze-runner
   #       command:
-  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2020.3.48f1.apk"
+  #         - "--app=/app/features/fixtures/EDM_Fixture/edm_2021.3.36f1.apk"
   #         - "--farm=bs"
   #         - "--device=ANDROID_11_0"
   #         - "features/edm"
@@ -164,45 +164,45 @@ steps:
   #
   # Build iOS test fixtures
   #
-  - label: ":ios: Generate Xcode project - Unity 2020"
+  - label: ":ios: Generate Xcode project - Unity 2021"
     timeout_in_minutes: 30
-    key: "generate-fixture-project-2020"
+    key: "generate-fixture-project-2021"
     depends_on: "build-artifacts"
     env:
-      UNITY_VERSION: *2020
+      UNITY_VERSION: *2021
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
         upload:
           - features/fixtures/unity.log
-          - project_2020.tgz
+          - project_2021.tgz
     commands:
       - bundle install
       - rake test:ios:generate_xcode
-      - tar -zvcf project_2020.tgz features/fixtures/maze_runner/mazerunner_xcode
+      - tar -zvcf project_2021.tgz features/fixtures/maze_runner/mazerunner_xcode
     retry:
       automatic:
         - exit_status: "*"
           limit: 1
 
-  - label: ":ios: Build iOS test fixture for Unity 2020"
+  - label: ":ios: Build iOS test fixture for Unity 2021"
     timeout_in_minutes: 30
-    key: "build-ios-fixture-2020"
-    depends_on: "generate-fixture-project-2020"
+    key: "build-ios-fixture-2021"
+    depends_on: "generate-fixture-project-2021"
     env:
-      UNITY_VERSION: *2020
+      UNITY_VERSION: *2021
     plugins:
       artifacts#v1.5.0:
         download:
           - Bugsnag.unitypackage
-          - project_2020.tgz
+          - project_2021.tgz
         upload:
-          - features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa
+          - features/fixtures/maze_runner/mazerunner_2021.3.36f1.ipa
           - features/fixtures/unity.log
     commands:
       - bundle install
-      - tar -zxf project_2020.tgz features/fixtures/maze_runner
+      - tar -zxf project_2021.tgz features/fixtures/maze_runner
       - rake test:ios:build_xcode
     retry:
       automatic:
@@ -212,15 +212,15 @@ steps:
   #
   # Run iOS tests
   #
-  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2020"
+  - label: ":bitbar: :ios: Run iOS e2e tests for Unity 2021"
     timeout_in_minutes: 60
-    depends_on: "build-ios-fixture-2020"
+    depends_on: "build-ios-fixture-2021"
     agents:
       queue: opensource
     plugins:
       artifacts#v1.5.0:
         download:
-          - "features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
+          - "features/fixtures/maze_runner/mazerunner_2021.3.36f1.ipa"
         upload:
           - "maze_output/**/*"
           - "maze_output/metrics.csv"
@@ -232,7 +232,7 @@ steps:
         command:
           - "features/csharp"
           - "features/ios"
-          - "--app=features/fixtures/maze_runner/mazerunner_2020.3.48f1.ipa"
+          - "--app=features/fixtures/maze_runner/mazerunner_2021.3.36f1.ipa"
           - "--farm=bb"
           - "--appium-version=1.22"
           - "--device=IOS_13|IOS_14|IOS_15"

--- a/example/ProjectSettings/ProjectVersion.txt
+++ b/example/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,2 @@
-m_EditorVersion: 2018.4.34f1
+m_EditorVersion: 2020.3.48f1
+m_EditorVersionWithRevision: 2020.3.48f1 (b805b124c6b7)


### PR DESCRIPTION
## Goal

- Drops testing on Unity 2018 and 2019.
- Updates example app version.
## Design

Testing on iOS/Android for Unity 2021 is moved to the basic pipeline, everything else goes to the full pipeline.

The artifact is now built under Unity 2021.  Initially I tried using 2020, but there seems to be an obscure bug where the export would hang randomly and for no obvious reason.

## Testing

Covered by a full CI run.