### PR TITLE
Handle null status of client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### TBD
+
+- Added more null reference checking to the Bugsnag client to prevent crashes when accessing the client before it has been initialised [#788](https://github.com/bugsnag/bugsnag-unity/pull/788)
+
 ## 7.7.3 (2024-04-11)
 
 ### Bug Fixes

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -71,7 +71,7 @@ namespace BugsnagUnity
         /// the tracking of in foreground time for the application.
         /// </summary>
         /// <param name="inFocus"></param>
-        public static void SetApplicationState(bool inFocus) => Client.SetApplicationState(inFocus);
+        public static void SetApplicationState(bool inFocus) => Client?.SetApplicationState(inFocus);
 
         /// <summary>
         /// Bugsnag uses the concept of contexts to help display and group your errors.

--- a/src/BugsnagUnity/Bugsnag.cs
+++ b/src/BugsnagUnity/Bugsnag.cs
@@ -71,7 +71,13 @@ namespace BugsnagUnity
         /// the tracking of in foreground time for the application.
         /// </summary>
         /// <param name="inFocus"></param>
-        public static void SetApplicationState(bool inFocus) => Client?.SetApplicationState(inFocus);
+        public static void SetApplicationState(bool inFocus)
+        {
+            if(Client != null)
+            {
+                 Client.SetApplicationState(inFocus);
+            }
+        }
 
         /// <summary>
         /// Bugsnag uses the concept of contexts to help display and group your errors.


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
The client should not be null at this point.

## Design

<!-- Why was this approach used? -->
 I've added an elvis operator to set application state of the client if it isn't null. I think that this might work to some degree, but it doesn't really handle the race condition.
Might be better to add a less performative try/catch block instead. or check the client again to see whether it is null and return a log error.

## Changeset

<!-- What changed? -->
Added null checking operator. to SetApplicationState of client.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
Manually