### PR TITLE
PLAT-12012 fix for incorrect ios device metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fixed issue where iOS C# events reported the incorrect value for device.osName. [#791](https://github.com/bugsnag/bugsnag-unity/pull/791)
+
 ## 7.7.3 (2024-04-11)
 
 ### Bug Fixes

--- a/features/csharp/csharp_metadata.feature
+++ b/features/csharp/csharp_metadata.feature
@@ -41,3 +41,12 @@ Feature: Metadata
     And the event "metaData.stringArray.testKey.1" equals "2"
     And the event "metaData.dictionary.foo" equals "bar"
     And the event "metaData.number.testKey" equals 123
+
+  @ios_only
+  Scenario: iOS metadata
+    When I run the game in the "NotifySmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+    And the event "device.osName" equals "iOS"

--- a/features/csharp/csharp_metadata.feature
+++ b/features/csharp/csharp_metadata.feature
@@ -42,11 +42,21 @@ Feature: Metadata
     And the event "metaData.dictionary.foo" equals "bar"
     And the event "metaData.number.testKey" equals 123
 
+  # these platform specific tests are smoke tests, if os name is wrong then it's a sign that the native information has not been properly retrieved from the native layer and the unity placeholder data is being used
   @ios_only
-  Scenario: iOS metadata
+  Scenario: iOS specific metadata
     When I run the game in the "NotifySmokeTest" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
     And expected device metadata is included in the event
     And expected app metadata is included in the event
     And the event "device.osName" equals "iOS"
+    
+  @android_only
+  Scenario: Android specific metadata
+    When I run the game in the "NotifySmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+    And the event "device.osName" equals "android"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -57,6 +57,10 @@ Before('@skip_android') do |_scenario|
   skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == 'android'
 end
 
+Before('@android_only') do |_scenario|
+  skip_this_scenario('Skipping scenario') unless Maze::Helper.get_current_platform == 'android'
+end
+
 
 BeforeAll do
   $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -28,6 +28,10 @@ Before('@macos_only') do |_scenario|
 end
 
 
+Before('@ios_only') do |_scenario|
+  skip_this_scenario('Skipping scenario') unless Maze::Helper.get_current_platform == 'ios'
+end
+
 Before('@cocoa_only') do |_scenario|
   skip_this_scenario('Skipping scenario') unless Maze.config.os == 'macos' || Maze::Helper.get_current_platform == 'ios'
 end

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -732,13 +732,26 @@ void bugsnag_retrieveBreadcrumbs(const void *managedBreadcrumbs, void (*breadcru
 
 char * bugsnag_retrieveAppData() {
     BugsnagAppWithState *app = [Bugsnag.client generateAppWithState:BSGGetSystemInfo()];
-     NSDictionary *appDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-        app.bundleVersion, @"bundleVersion",
-        app.id, @"id",
-        app.isLaunching ? @"true" : @"false", @"isLaunching",
-        app.type, @"type",
-        app.version, @"version",
-        nil];
+    if (app == nil) {
+        return NULL;
+    }
+
+    NSDictionary *appDictionary = [NSMutableDictionary dictionary];
+
+    if (app.bundleVersion != nil) {
+        [appDictionary setObject:app.bundleVersion forKey:@"bundleVersion"];
+    }
+    if (app.id != nil) {
+        [appDictionary setObject:app.id forKey:@"id"];
+    }
+    [appDictionary setObject:(app.isLaunching ? @"true" : @"false") forKey:@"isLaunching"];
+    if (app.type != nil) {
+        [appDictionary setObject:app.type forKey:@"type"];
+    }
+    if (app.version != nil) {
+        [appDictionary setObject:app.version forKey:@"version"];
+    }
+
     return getJson(appDictionary);
 }
 

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -755,7 +755,6 @@ void bugsnag_retrieveLastRunInfo(const void *lastRuninfo, void (*callback)(const
 char * bugsnag_retrieveDeviceData(const void *deviceData, void (*callback)(const void *instance, const char *key, const char *value)) {
     BugsnagDeviceWithState *device = [Bugsnag.client generateDeviceWithState:BSGGetSystemInfo()];
     NSDictionary *deviceDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-        device.freeDisk, @"freeDisk",
         device.freeMemory, @"freeMemory",
         device.id, @"id",
         device.jailbroken ? @"true" : @"false", @"jailbroken",

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -736,7 +736,7 @@ char * bugsnag_retrieveAppData() {
         return NULL;
     }
 
-    NSDictionary *appDictionary = [NSMutableDictionary dictionary];
+    NSMutableDictionary *appDictionary = [NSMutableDictionary dictionary];
 
     if (app.bundleVersion != nil) {
         [appDictionary setObject:app.bundleVersion forKey:@"bundleVersion"];

--- a/src/BugsnagUnity.m
+++ b/src/BugsnagUnity.m
@@ -754,20 +754,27 @@ void bugsnag_retrieveLastRunInfo(const void *lastRuninfo, void (*callback)(const
 
 char * bugsnag_retrieveDeviceData(const void *deviceData, void (*callback)(const void *instance, const char *key, const char *value)) {
     BugsnagDeviceWithState *device = [Bugsnag.client generateDeviceWithState:BSGGetSystemInfo()];
-    NSDictionary *deviceDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
-        device.freeMemory, @"freeMemory",
-        device.id, @"id",
-        device.jailbroken ? @"true" : @"false", @"jailbroken",
-        device.locale, @"locale",
-        device.manufacturer, @"manufacturer",
-        device.model, @"model",
-        device.modelNumber, @"modelNumber",
-        device.runtimeVersions[@"osBuild"], @"osBuild",
-        device.osName, @"osName",
-        device.osVersion,@ "osVersion",
-        nil];
+    NSMutableDictionary *deviceDictionary = [[NSMutableDictionary alloc] init];
+
+    if (device.freeDisk != nil) [deviceDictionary setObject:device.freeDisk forKey:@"freeDisk"];
+    if (device.freeMemory != nil) [deviceDictionary setObject:device.freeMemory forKey:@"freeMemory"];
+    if (device.id != nil) [deviceDictionary setObject:device.id forKey:@"id"];
+    if (device.jailbroken) {
+        [deviceDictionary setObject:@"true" forKey:@"jailbroken"];
+    } else {
+        [deviceDictionary setObject:@"false" forKey:@"jailbroken"];
+    }
+    if (device.locale != nil) [deviceDictionary setObject:device.locale forKey:@"locale"];
+    if (device.manufacturer != nil) [deviceDictionary setObject:device.manufacturer forKey:@"manufacturer"];
+    if (device.model != nil) [deviceDictionary setObject:device.model forKey:@"model"];
+    if (device.modelNumber != nil) [deviceDictionary setObject:device.modelNumber forKey:@"modelNumber"];
+    if (device.runtimeVersions[@"osBuild"] != nil) [deviceDictionary setObject:device.runtimeVersions[@"osBuild"] forKey:@"osBuild"];
+    if (device.osName != nil) [deviceDictionary setObject:device.osName forKey:@"osName"];
+    if (device.osVersion != nil) [deviceDictionary setObject:device.osVersion forKey:@"osVersion"];
+
     return getJson(deviceDictionary);
 }
+
 
 void bugsnag_populateUser(struct bugsnag_user *user) {
   user->user_id = BSGGetDefaultDeviceId().UTF8String;


### PR DESCRIPTION
## Goal

The changes made in the native cocoa notifier broke the method that collects native device metadata.

## Testing

Added smoke tests for android and iOS that will let us know in future if the native connection is broken.