### PR TITLE
PLAT-12022 missing cocoa callback values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fixed issue where changes to device.TotalMemory and device.ModelNumber in cocoa on send callbacks were not respected. [#793](https://github.com/bugsnag/bugsnag-unity/pull/793)
+
 ## 7.7.4 (2024-05-19)
 
 ### Bug Fixes

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosNativeOnSendCallback.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosNativeOnSendCallback.cs
@@ -40,7 +40,9 @@ public class IosNativeOnSendCallback : Scenario
                 device.Jailbroken = true;
                 device.Orientation = "Custom Orientation";
                 device.Time = new DateTimeOffset(1985, 08, 21, 01, 01, 01, TimeSpan.Zero);
-
+                device.TotalMemory = 999;
+                device.ModelNumber = "Custom ModelNumber";
+                
                 // breadcrumbs
                 foreach (var crumb in @event.Breadcrumbs)
                 {

--- a/features/ios/ios_callbacks.feature
+++ b/features/ios/ios_callbacks.feature
@@ -50,6 +50,10 @@ Feature: Callbacks
     And the event "device.osVersion" equals "Custom OsVersion"
     And the event "device.runtimeVersions.scoop" equals "dewoop"
     And the event "device.orientation" equals "Custom Orientation"
+    And the event "device.modelNumber" equals "Custom ModelNumber"
+    And the event "device.totalmemory" equals "999"
+
+
 
     # Breadcrumbs
     And the event "breadcrumbs.0.name" equals "Custom Message"

--- a/features/ios/ios_callbacks.feature
+++ b/features/ios/ios_callbacks.feature
@@ -51,7 +51,7 @@ Feature: Callbacks
     And the event "device.runtimeVersions.scoop" equals "dewoop"
     And the event "device.orientation" equals "Custom Orientation"
     And the event "device.modelNumber" equals "Custom ModelNumber"
-    And the event "device.totalMemory" equals "999"
+    And the event "device.totalMemory" equals 999
 
 
 

--- a/features/ios/ios_callbacks.feature
+++ b/features/ios/ios_callbacks.feature
@@ -51,7 +51,7 @@ Feature: Callbacks
     And the event "device.runtimeVersions.scoop" equals "dewoop"
     And the event "device.orientation" equals "Custom Orientation"
     And the event "device.modelNumber" equals "Custom ModelNumber"
-    And the event "device.totalmemory" equals "999"
+    And the event "device.totalMemory" equals "999"
 
 
 

--- a/src/BugsnagUnity/Native/Cocoa/NativeDevice.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeDevice.cs
@@ -14,6 +14,8 @@ namespace BugsnagUnity
         private const string MODEL_KEY = "model";
         private const string OS_NAME_KEY = "osName";
         private const string OS_VERSION_KEY = "osVersion";
+        private const string MODEL_NUMBER_KEY = "modelNumber";
+        private const string TOTAL_MEMORY_KEY = "totalMemory";
 
         internal NativePayloadClassWrapper NativeWrapper;
 
@@ -25,11 +27,9 @@ namespace BugsnagUnity
         public string BrowserName { get; set; }
         public string BrowserVersion { get; set; }
         public string[] CpuAbi { get; set; }
-        public long? TotalMemory { get; set; }
+        public long? TotalMemory {get => NativeWrapper.GetNativeLong(TOTAL_MEMORY_KEY); set => NativeWrapper.SetNativeLong(TOTAL_MEMORY_KEY, value); }
         public string UserAgent { get; set; }
-        public string ModelNumber { get; set; }
-
-
+        public string ModelNumber { get => NativeWrapper.GetNativeString(MODEL_NUMBER_KEY); set => NativeWrapper.SetNativeString(MODEL_NUMBER_KEY,value); }
         public string Id { get => NativeWrapper.GetNativeString(ID_KEY); set => NativeWrapper.SetNativeString(ID_KEY,value); }
 
         public bool? Jailbroken { get => NativeWrapper.GetNativeBool(JAIL_BROKEN_KEY); set => NativeWrapper.SetNativeBool(JAIL_BROKEN_KEY, value); }


### PR DESCRIPTION
## Goal

The callback parameters `TotalMemory` and `ModelNumber` were not properly implemented.

## Testing

Expanded existing e2e tests