### PR TITLE
Move WebGL tests from MacOS 11 boxes to MacOS 14

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -186,8 +186,6 @@ steps:
   - label: Run WebGL e2e tests for Unity 2020
     timeout_in_minutes: 30
     depends_on: "cocoa-webgl-2020-fixtures"
-    agents:
-      queue: opensource-mac-cocoa-11
     env:
       UNITY_VERSION: *2020
     plugins:
@@ -221,8 +219,6 @@ steps:
   - label: Run WebGL e2e tests for Unity 2022
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2022-fixtures'
-    agents:
-      queue: opensource-mac-cocoa-11
     env:
       UNITY_VERSION: *2022
     plugins:
@@ -238,8 +234,6 @@ steps:
   - label: Run WebGL e2e tests for Unity 2023
     timeout_in_minutes: 30
     depends_on: 'cocoa-webgl-2023-fixtures'
-    agents:
-      queue: opensource-mac-cocoa-11
     env:
       UNITY_VERSION: *2023
     plugins:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -111,6 +111,14 @@ Maze.hooks.before do
   end
 end
 
+Maze.hooks.before do |scenario|
+  # Detect if we're running the webgl tests
+  if Maze.config.farm.eql?('local')
+    # Allows each scenario to auto retry once due to instability in the local browser
+    scenario.tags << '@retry'
+  end
+end
+
 After do |scenario|
   next if scenario.status == :skipped
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -115,7 +115,7 @@ Maze.hooks.before do |scenario|
   # Detect if we're running the webgl tests
   if Maze.config.farm.eql?('local')
     # Allows each scenario to auto retry once due to instability in the local browser
-    scenario.tags << '@retry'
+    scenario.tags << Cucumber::Core::Test::Tag.new(nil, '@retry')
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -112,8 +112,10 @@ Maze.hooks.before do
 end
 
 Before do |scenario|
+  pp Maze.config.farm
   # Detect if we're running the webgl tests
   if Maze.config.farm.eql?('local')
+    pp "Adding retry tag"
     # Allows each scenario to auto retry once due to instability in the local browser
     scenario.tags << Cucumber::Core::Test::Tag.new(nil, '@retry')
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -111,7 +111,7 @@ Maze.hooks.before do
   end
 end
 
-Maze.hooks.before do |scenario|
+Before do |scenario|
   # Detect if we're running the webgl tests
   if Maze.config.farm.eql?('local')
     # Allows each scenario to auto retry once due to instability in the local browser

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -112,10 +112,8 @@ Maze.hooks.before do
 end
 
 Before do |scenario|
-  pp Maze.config.farm
   # Detect if we're running the webgl tests
-  if Maze.config.farm.eql?('local')
-    pp "Adding retry tag"
+  if Maze.config.farm.to_s.eql?('local')
     # Allows each scenario to auto retry once due to instability in the local browser
     scenario.tags << Cucumber::Core::Test::Tag.new(nil, '@retry')
   end


### PR DESCRIPTION
## Goal

These are among the last remaining tests running on our MacOS 11 boxes, allowing us to decommission them.

## Changes

The tests run on MacOS 14, although they are flakey and long-running enough that I've had to add some individual retries to the scenarios.  This isn't an issue with the library, rather the firefox selenium connection on the MacOS box.

## Testing

Full test runs have been run on this branch, showing these tests complete successfully.