### PR TITLE
PLAT-12127 add traceid to events

### DIFF
--- a/src/BugsnagUnity/Payload/Correlation.cs
+++ b/src/BugsnagUnity/Payload/Correlation.cs
@@ -9,7 +9,7 @@ namespace BugsnagUnity.Payload
     {
        
         private const string TRACE_ID_KEY = "traceid";
-        private const string SPAN_ID_KEY = "string";
+        private const string SPAN_ID_KEY = "spanid";
 
         internal Correlation(string traceId, string spanId)
         {

--- a/src/BugsnagUnity/Payload/Correlation.cs
+++ b/src/BugsnagUnity/Payload/Correlation.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using UnityEngine.Events;
+#nullable enable
+
+namespace BugsnagUnity.Payload
+{
+    public class Correlation : PayloadContainer
+    {
+       
+        private const string TRACE_ID_KEY = "traceid";
+        private const string SPAN_ID_KEY = "string";
+
+        internal Correlation(string traceId, string spanId)
+        {
+            TraceId = traceId;
+            SpanId = spanId;  
+        }
+
+        public string TraceId
+        {
+            get {
+                var @object = Get(TRACE_ID_KEY);
+                if (@object == null)
+                {
+                    return string.Empty;
+                }
+                return (string)@object;
+            } 
+            set
+            {
+                Add(TRACE_ID_KEY, value);
+            }  
+        }
+
+        public string SpanId
+        {
+            get
+            {
+                var @object = Get(SPAN_ID_KEY);
+                if (@object == null)
+                {
+                    return string.Empty;
+                }
+                return (string)@object;
+            }
+            set
+            {
+                Add(SPAN_ID_KEY, value);
+            }
+        }
+    }
+}

--- a/src/BugsnagUnity/Payload/Event.cs
+++ b/src/BugsnagUnity/Payload/Event.cs
@@ -10,7 +10,7 @@ namespace BugsnagUnity.Payload
     public class Event : PayloadContainer, IEvent
     {
 
-        internal Event(string context, Metadata metadata, AppWithState app, DeviceWithState device, User user, Error[] errors, HandledState handledState, List<Breadcrumb> breadcrumbs, Session session, string apiKey, OrderedDictionary featureFlags, LogType? logType = null)
+        internal Event(string context, Metadata metadata, AppWithState app, DeviceWithState device, User user, Error[] errors, HandledState handledState, List<Breadcrumb> breadcrumbs, Session session, string apiKey, OrderedDictionary featureFlags, Correlation correlation, LogType? logType = null)
         {
             ApiKey = apiKey;
             OriginalSeverity = handledState;
@@ -23,6 +23,7 @@ namespace BugsnagUnity.Payload
             _user = user;
             _errors = errors.ToList();
             Errors = new List<IError>();
+            Correlation = correlation;
             foreach (var error in _errors)
             {
                 Errors.Add(error);
@@ -182,6 +183,8 @@ namespace BugsnagUnity.Payload
 
         public string ApiKey { get; set; }
 
+        public Correlation Correlation;
+
         private List<Breadcrumb> _breadcrumbs;
 
         public ReadOnlyCollection<IBreadcrumb> Breadcrumbs { get; }
@@ -299,6 +302,10 @@ namespace BugsnagUnity.Payload
             Add("groupingHash", GroupingHash);
             Add("payloadVersion", PayloadVersion);
             Add("exceptions", _errors);
+            if(Correlation != null)
+            {
+                Add("correlation", Correlation.Payload);
+            }
             if (_androidProjectPackages != null)
             {
                 Add("projectPackages", _androidProjectPackages);

--- a/src/BugsnagUnity/PerformanceHelper.cs
+++ b/src/BugsnagUnity/PerformanceHelper.cs
@@ -1,4 +1,4 @@
-#define PERFORMANCE_HELPER_LOG
+//#define PERFORMANCE_HELPER_LOG
 using System;
 using System.Linq;
 using System.Reflection;

--- a/src/BugsnagUnity/PerformanceHelper.cs
+++ b/src/BugsnagUnity/PerformanceHelper.cs
@@ -1,0 +1,107 @@
+#define PERFORMANCE_HELPER_LOG
+using System;
+using System.Linq;
+using System.Reflection;
+using BugsnagUnity.Payload;
+using UnityEngine;
+
+namespace BugsnagUnity
+{
+    internal class PerformanceHelper
+    {
+        const string BUGSNAG_PERFORMANCE_ASSEMBLY_NAME = "BugsnagUnityPerformance.BugsnagPerformance";
+        const string GET_PERFORMANCE_STATE_METHOD_NAME = "GetPerformanceState";
+
+        static MethodInfo _getPerformanceStateMethodInfo;
+        private static bool _isPerformanceLibraryAvailable = true;
+
+         [Serializable]
+        private class PerformanceState
+        {
+            public string currentContextSpanId;
+            public string currentContextTraceId;
+            public PerformanceState(string currentContextSpanId, string currentContextTraceId)
+            {
+                this.currentContextSpanId = currentContextSpanId;
+                this.currentContextTraceId = currentContextTraceId;
+            }
+        } 
+
+        internal static Correlation GetCurrentPerformanceSpanContext()
+        {
+            Log("Entering GetCurrentPerformanceSpanContext");
+
+            if (!_isPerformanceLibraryAvailable)
+            {
+                Log("Performance library is not available");
+                return null;
+            }
+
+            try
+            {
+                Log("Initializing GetCurrentContextInternalMethod if needed");
+                InitializeGetCurrentContextInternalMethodIfNeeded();
+
+                Log("Invoking _getCurrentContextInternalMethod");
+                string result = (string)_getPerformanceStateMethodInfo?.Invoke(null, null);
+
+                Log("Result from _getCurrentContextInternalMethod: " + result);
+
+                if (string.IsNullOrEmpty(result))
+                {
+                    Log("Result is null or empty");
+                    return null;
+                }
+
+                Log("Parsing result to CorrelationTransfer");
+                var performanceState = JsonUtility.FromJson<PerformanceState>(result);
+
+                if (performanceState == null)
+                {
+                    Log("Deserialization failed, CorrelationTransfer is null");
+                    return null;
+                }
+
+                Log("Performance library context: traceId=" + performanceState.currentContextTraceId + ", spanId=" + performanceState.currentContextSpanId);
+
+                var correlation = new Correlation(performanceState.currentContextTraceId, performanceState.currentContextSpanId);
+
+                Log("Performance library correlation: spanId=" + correlation.SpanId + ", traceId=" + correlation.TraceId);
+
+                Log("Exiting GetCurrentPerformanceSpanContext with correlation");
+                return correlation;
+            }
+            catch (Exception ex)
+            {
+                Log("Exception caught: " + ex.Message);
+                // Silently handle case where performance library is not available or out of date
+                Log("Performance library is not available or out of date");
+                _isPerformanceLibraryAvailable = false;
+
+                Log("Exiting GetCurrentPerformanceSpanContext with null due to exception");
+                return null;
+            }
+        }
+
+        private static void InitializeGetCurrentContextInternalMethodIfNeeded()
+        {
+            if (_getPerformanceStateMethodInfo != null) return;
+
+            var bugsnagPerformanceType = AppDomain.CurrentDomain.GetAssemblies()
+                .Select(assembly => assembly.GetType(BUGSNAG_PERFORMANCE_ASSEMBLY_NAME))
+                .FirstOrDefault(type => type != null);
+
+            _getPerformanceStateMethodInfo = bugsnagPerformanceType?.GetMethod(
+                GET_PERFORMANCE_STATE_METHOD_NAME, 
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+        }
+
+        private static void Log(string message)
+        {
+            #if PERFORMANCE_HELPER_LOG
+                UnityEngine.Debug.Log(message);
+            #endif
+        }
+    }
+}


### PR DESCRIPTION
## NOTE

This PR is part of work connected to the Unity Notifier, the sister PR can be found here: https://github.com/bugsnag/bugsnag-unity-performance/pull/112

Please do not review this PR without also reviewing the other

## Goal

When a C# layer error occurs, get the current span context from the Unity Performance SDK and include it in the event report.

## Changeset

Added PerformanceHelper class to get information from the Performance SDK if it is present.

## Testing

Manually tested
E2E Tests will be added in a later task