### PR TITLE
Hotfix release v7.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.7.6 (2024-05-17)
+
+- Fixed issue where meta files for the MacOS bundle were not generated. [#802](https://github.com/bugsnag/bugsnag-unity/pull/802)
+
+
 ## 7.7.5 (2024-05-02)
 
 ### Bug Fixes

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@ var target = Argument("target", "Default");
 var solution = File("./BugsnagUnity.sln");
 var configuration = Argument("configuration", "Release");
 var project = File("./src/BugsnagUnity/BugsnagUnity.csproj");
-var version = "7.7.5";
+var version = "7.7.6";
 
 Task("Restore-NuGet-Packages")
     .Does(() => NuGetRestore(solution));

--- a/upm-tools/build-upm-package.sh
+++ b/upm-tools/build-upm-package.sh
@@ -16,13 +16,22 @@ fi
 
 VERSION=$1
 
-if [ -z "$UNITY_VERSION" ]
+if [ -z "$UNITY_UPM_VERSION" ]
 then
-  echo "UNITY_VERSION must be set"
+  echo "UNITY_UPM_VERSION must be set"
   exit 1
 fi
 
-UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS"
+#There is a bug in some versions of unity 2020, 2021 and 2022 where macos bundles will not be imported as a single plugin file.
+#In which case all sub dirs and files must have .meta files to work with UPM.
+#Building the UPM package with unity 2019 ensures that the meta files are created 
+
+if [[ "$UNITY_UPM_VERSION" != *"2019"* ]]; then
+  echo "ERROR: UNITY_UPM_VERSION must be a version of Unity 2019. See script comments for details."
+  exit 1
+fi
+
+UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_UPM_VERSION/Unity.app/Contents/MacOS"
 
 
 


### PR DESCRIPTION
## 7.7.6 (2024-05-17)

- Fixed issue where meta files for the MacOS bundle were not generated. [#802](https://github.com/bugsnag/bugsnag-unity/pull/802)

