### PR TITLE
fix for flakes caused by accidental OOM errors reporting during iOS tests

### DIFF
--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -38,6 +38,10 @@ public class Scenario : MonoBehaviour
         Configuration.DotnetScriptingRuntime = FindDotnetScriptingRuntime();
         Configuration.DotnetApiCompatibility = FindDotnetApiCompatibility();
         Configuration.AutoTrackSessions = false;
+         if (Application.platform == RuntimePlatform.IPhonePlayer)
+        {
+            Configuration.EnabledErrorTypes.OOMs = false;
+        }
     }
 
     public void AddSwitchConfigValues(SwitchCacheType switchCacheType, int switchCacheIndex, string switchMountName)

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -38,7 +38,7 @@ public class Scenario : MonoBehaviour
         Configuration.DotnetScriptingRuntime = FindDotnetScriptingRuntime();
         Configuration.DotnetApiCompatibility = FindDotnetApiCompatibility();
         Configuration.AutoTrackSessions = false;
-         if (Application.platform == RuntimePlatform.IPhonePlayer)
+        if (Application.platform == RuntimePlatform.IPhonePlayer)
         {
             Configuration.EnabledErrorTypes.OOMs = false;
         }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/CorruptedCacheFile.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/CorruptedCacheFile.cs
@@ -9,10 +9,6 @@ public class CorruptedCacheFile : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        if (Application.platform == RuntimePlatform.IPhonePlayer)
-        {
-            Configuration.EnabledErrorTypes.OOMs = false;
-        }
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/MaxPersistEvents.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/MaxPersistEvents.cs
@@ -9,10 +9,6 @@ public class MaxPersistEvents : Scenario
     {
         base.PrepareConfig(apiKey, host);
         Configuration.MaxPersistedEvents = 3;
-        if (Application.platform == RuntimePlatform.IPhonePlayer)
-        {
-            Configuration.EnabledErrorTypes.OOMs = false;
-        }
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistDeviceId.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistDeviceId.cs
@@ -5,10 +5,6 @@ public class PersistDeviceId : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        if (Application.platform == RuntimePlatform.IPhonePlayer)
-        {
-            Configuration.EnabledErrorTypes.OOMs = false;
-        }
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEvent.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEvent.cs
@@ -6,10 +6,6 @@ public class PersistEvent : Scenario
     {
         base.PrepareConfig(apiKey, host);
         Configuration.Context = "Error 1";
-        if (Application.platform == RuntimePlatform.IPhonePlayer)
-        {
-            Configuration.EnabledErrorTypes.OOMs = false;
-        }
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReport.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReport.cs
@@ -6,10 +6,6 @@ public class PersistEventReport : Scenario
     {
         base.PrepareConfig(apiKey, host);
         Configuration.Context = "Error 2";
-        if (Application.platform == RuntimePlatform.IPhonePlayer)
-        {
-            Configuration.EnabledErrorTypes.OOMs = false;
-        }
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReportCallback.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReportCallback.cs
@@ -26,10 +26,6 @@ public class PersistEventReportCallback : Scenario
 
             return true;
         });
-        if (Application.platform == RuntimePlatform.IPhonePlayer)
-        {
-            Configuration.EnabledErrorTypes.OOMs = false;
-        }
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/ReportMaxPersistedEvents.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/ReportMaxPersistedEvents.cs
@@ -10,10 +10,6 @@ public class ReportMaxPersistedEvents : Scenario
     {
         _eventsCorrect = CheckForEvents();
         base.PrepareConfig(apiKey, host);
-        if (Application.platform == RuntimePlatform.IPhonePlayer)
-        {
-            Configuration.EnabledErrorTypes.OOMs = false;
-        }
     }
 
     private bool CheckForEvents()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosDisableCrashes.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosDisableCrashes.cs
@@ -8,7 +8,6 @@ public class IosDisableCrashes : Scenario
     {
         base.PrepareConfig(apiKey, host);
         Configuration.EnabledErrorTypes.Crashes = false;
-        Configuration.EnabledErrorTypes.OOMs = true;
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosDisableCrashes.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosDisableCrashes.cs
@@ -8,6 +8,7 @@ public class IosDisableCrashes : Scenario
     {
         base.PrepareConfig(apiKey, host);
         Configuration.EnabledErrorTypes.Crashes = false;
+        Configuration.EnabledErrorTypes.OOMs = true;
     }
 
     public override void Run()

--- a/features/ios/ios_native_errors.feature
+++ b/features/ios/ios_native_errors.feature
@@ -8,8 +8,7 @@ Feature: iOS Native Errors
     And I wait for 2 seconds
     And On Mobile I relaunch the app
     And I run the game in the "StartSDKDefault" state
-    And I wait to receive an error
-    And the exception "message" equals "The app was likely terminated by the operating system while in the foreground"
+    And I should receive no errors
 
   Scenario: Last Run Info
     When I run the game in the "IosNativeException" state


### PR DESCRIPTION
## Goal

Sometimes an OOM report is generated because of the way that appium closes the fixture leading to E2E flakes. 
This change disables OOM reporting by default but still alows for it to be enabled if a scenario requires it.

## Changeset

- added config code to disable all OOM reports in iOS builds
- removed scenario specific OOM config setup

## Testing

Covered by existing tests