### PR TITLE
PLAT-12206 treat discardClasses and redactedKeys as Regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added the `Bugsnag-Integrity` header to outgoing Bugsnag requests. [#797](https://github.com/bugsnag/bugsnag-unity/pull/797)
 
-- Changed proccessing of `Configuration.DiscardClasses` and `Configuration.RedactedKeys`. They remain sting collections in the config object, but are now converted to Regex objects when in use. [#807](https://github.com/bugsnag/bugsnag-unity/pull/807)
+- Changed processing of `Configuration.DiscardClasses` and `Configuration.RedactedKeys`. They remain sting collections in the config object, but are now converted to Regex objects when in use. [#807](https://github.com/bugsnag/bugsnag-unity/pull/807)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Added the `Bugsnag-Integrity` header to outgoing Bugsnag requests. [#797](https://github.com/bugsnag/bugsnag-unity/pull/797)
 
+- Changed proccessing of `Configuration.DiscardClasses` and `Configuration.RedactedKeys`. They remain sting collections in the config object, but are now converted to Regex objects when in use. [#807](https://github.com/bugsnag/bugsnag-unity/pull/807)
+
 ### Bug Fixes
 
 - Added a null check to the Bugsnag client to prevent crashes when accessing the client before it has been initialised [#788](https://github.com/bugsnag/bugsnag-unity/pull/788)

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DiscardErrorClass.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DiscardErrorClass.cs
@@ -1,11 +1,13 @@
-﻿using BugsnagUnity;
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using BugsnagUnity;
 
 public class DiscardErrorClass : Scenario
 {
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.DiscardClasses = new string[] { "IndexOutOfRangeException" };
+        Configuration.DiscardClasses = new List<Regex> { new Regex("IndexOutOfRangeException") };
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/RedactedKeys.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/RedactedKeys.cs
@@ -1,9 +1,12 @@
-﻿public class RedactedKeys : Scenario
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+public class RedactedKeys : Scenario
 {
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.RedactedKeys = new string[] { "testKey" };
+        Configuration.RedactedKeys = new List<Regex> { new Regex("testKey") };
         Configuration.AddMetadata("testSection","testKey","testValue");
     }
 

--- a/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
+++ b/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
@@ -34,7 +34,7 @@ namespace BugsnagUnity
         public bool PersistUser = true;
         public string SessionEndpoint = "https://sessions.bugsnag.com";
         public ThreadSendPolicy SendThreads = ThreadSendPolicy.UnhandledOnly;
-        public string[] RedactedKeys = new string[] { "password" };
+        public string[] RedactedKeys = new string[] { ".*password.*" };
         public string ReleaseStage;
         public bool ReportExceptionLogsAsHandled = true;
         public bool SendLaunchCrashesSynchronously = true;
@@ -79,7 +79,16 @@ namespace BugsnagUnity
 
             config.BreadcrumbLogLevel = GetLogTypeFromLogLevel( BreadcrumbLogLevel );
             config.Context = Context;
-            config.DiscardClasses = DiscardClasses;
+            foreach(string discardedClass in DiscardClasses){
+                try
+                {
+                    config.DiscardClasses.Add(new System.Text.RegularExpressions.Regex(discardedClass));
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Regex error adding discard class: " + e.Message);
+                }
+            }
             if (EnabledReleaseStages != null && EnabledReleaseStages.Length > 0)
             {
                 config.EnabledReleaseStages = EnabledReleaseStages;
@@ -98,7 +107,17 @@ namespace BugsnagUnity
             {
                 config.Endpoints = new EndpointConfiguration(NotifyEndpoint, SessionEndpoint);
             }
-            config.RedactedKeys = RedactedKeys;
+            foreach(string key in RedactedKeys)
+            {
+                try
+                {
+                    config.RedactedKeys.Add(new System.Text.RegularExpressions.Regex(key));
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Regex error adding redacted key: " + e.Message);
+                }
+            }
             if (string.IsNullOrEmpty(ReleaseStage))
             {
                 config.ReleaseStage = Debug.isDebugBuild ? "development" : "production";

--- a/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
+++ b/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
@@ -84,9 +84,9 @@ namespace BugsnagUnity
                 {
                     config.DiscardClasses.Add(new System.Text.RegularExpressions.Regex(discardedClass));
                 }
-                catch (Exception e)
+                catch (ArgumentException e)
                 {
-                    Debug.LogError("Regex error adding discard class: " + e.Message);
+                    Debug.LogError("Invalid Regex pattern for discard class: " + e.Message);
                 }
             }
             if (EnabledReleaseStages != null && EnabledReleaseStages.Length > 0)
@@ -113,9 +113,9 @@ namespace BugsnagUnity
                 {
                     config.RedactedKeys.Add(new System.Text.RegularExpressions.Regex(key));
                 }
-                catch (Exception e)
+                catch (ArgumentException e)
                 {
-                    Debug.LogError("Regex error adding redacted key: " + e.Message);
+                    Debug.LogError("Invalid Regex pattern for redacted key: " + e.Message);
                 }
             }
             if (string.IsNullOrEmpty(ReleaseStage))

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -63,7 +63,7 @@ namespace BugsnagUnity
             {
                 return false;
             }
-            if (_redactedKeysRegex == null)
+            if (_redactedKeysRegex == null || _redactedKeysRegex.Count != RedactedKeys.Length)
             {
                 _redactedKeysRegex = new List<Regex>();
                 foreach (var redactedKey in RedactedKeys)
@@ -74,6 +74,34 @@ namespace BugsnagUnity
             foreach (var regex in _redactedKeysRegex)
             {
                 if (regex.IsMatch(key))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public string[] DiscardClasses;
+
+        private List<Regex> _discardClassesRegex;
+
+        internal bool ErrorClassIsDiscarded(string className)
+        {
+            if (DiscardClasses == null || DiscardClasses.Length == 0)
+            {
+                return false;
+            }
+            if (_discardClassesRegex == null || _discardClassesRegex.Count != DiscardClasses.Length)
+            {
+                _discardClassesRegex = new List<Regex>();
+                foreach (var discardClass in DiscardClasses)
+                {
+                    _discardClassesRegex.Add(new Regex(discardClass));
+                }
+            }
+            foreach (var regex in _discardClassesRegex)
+            {
+                if (regex.IsMatch(className))
                 {
                     return true;
                 }
@@ -204,36 +232,6 @@ namespace BugsnagUnity
         public int MaxPersistedSessions = 128;
 
         public int MaxStringValueLength = 10000;
-        public string[] DiscardClasses;
-
-        private List<Regex> _discardClassesRegex;
-
-        internal bool ErrorClassIsDiscarded(string className)
-        {
-            if(DiscardClasses == null || DiscardClasses.Length == 0)
-            {
-                return false;
-            }
-            if(_discardClassesRegex == null)
-            {
-                _discardClassesRegex = new List<Regex>();
-                if(DiscardClasses != null)
-                {
-                    foreach (var discardClass in DiscardClasses)
-                    {
-                        _discardClassesRegex.Add(new Regex(discardClass));
-                    }
-                }               
-            }
-            foreach (var regex in _discardClassesRegex)
-            {
-                if (regex.IsMatch(className))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
 
         private bool IsRunningInEditor()
         {

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -55,23 +55,15 @@ namespace BugsnagUnity
 
         internal OrderedDictionary FeatureFlags = new OrderedDictionary();
 
-        private List<Regex> _redactedKeysRegex;
-        public string[] RedactedKeys = new string[] { "password" };
+
+        public List<Regex> RedactedKeys = new List<Regex>{new Regex(".*password.*",RegexOptions.IgnoreCase)};
         public bool KeyIsRedacted(string key)
         {
-            if (RedactedKeys == null || RedactedKeys.Length == 0)
+            if (RedactedKeys == null || RedactedKeys.Count == 0)
             {
                 return false;
             }
-            if (_redactedKeysRegex == null || _redactedKeysRegex.Count != RedactedKeys.Length)
-            {
-                _redactedKeysRegex = new List<Regex>();
-                foreach (var redactedKey in RedactedKeys)
-                {
-                    _redactedKeysRegex.Add(new Regex(redactedKey));
-                }
-            }
-            foreach (var regex in _redactedKeysRegex)
+            foreach (var regex in RedactedKeys)
             {
                 if (regex.IsMatch(key))
                 {
@@ -81,25 +73,15 @@ namespace BugsnagUnity
             return false;
         }
 
-        public string[] DiscardClasses;
-
-        private List<Regex> _discardClassesRegex;
+        public List<Regex> DiscardClasses = new List<Regex>();
 
         internal bool ErrorClassIsDiscarded(string className)
         {
-            if (DiscardClasses == null || DiscardClasses.Length == 0)
+            if (DiscardClasses == null || DiscardClasses.Count == 0)
             {
                 return false;
             }
-            if (_discardClassesRegex == null || _discardClassesRegex.Count != DiscardClasses.Length)
-            {
-                _discardClassesRegex = new List<Regex>();
-                foreach (var discardClass in DiscardClasses)
-                {
-                    _discardClassesRegex.Add(new Regex(discardClass));
-                }
-            }
-            foreach (var regex in _discardClassesRegex)
+            foreach (var regex in DiscardClasses)
             {
                 if (regex.IsMatch(className))
                 {

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -59,7 +59,7 @@ namespace BugsnagUnity
         public List<Regex> RedactedKeys = new List<Regex>{new Regex(".*password.*",RegexOptions.IgnoreCase)};
         public bool KeyIsRedacted(string key)
         {
-            if (RedactedKeys == null || RedactedKeys.Count == 0)
+            if (RedactedKeys == null)
             {
                 return false;
             }
@@ -77,7 +77,7 @@ namespace BugsnagUnity
 
         internal bool ErrorClassIsDiscarded(string className)
         {
-            if (DiscardClasses == null || DiscardClasses.Count == 0)
+            if (DiscardClasses == null)
             {
                 return false;
             }

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -454,9 +454,14 @@ namespace BugsnagUnity
             }
 
             // set DiscardedClasses
-            if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
+            if (config.DiscardClasses != null && config.DiscardClasses.Count > 0)
             {
-                obj.Call("setDiscardClasses", GetAndroidRegexPatternSetFromArray(config.DiscardClasses));
+                var patternsAsStrings = new string[config.DiscardClasses.Count];
+                foreach (var pattern in config.DiscardClasses)
+                {
+                    patternsAsStrings[config.DiscardClasses.IndexOf(pattern)] = pattern.ToString();
+                }
+                obj.Call("setDiscardClasses", GetAndroidRegexPatternSetFromArray(patternsAsStrings));
             }
 
             // set ProjectPackages
@@ -466,9 +471,14 @@ namespace BugsnagUnity
             }
 
             // set redacted keys
-            if (config.RedactedKeys != null && config.RedactedKeys.Length > 0)
+            if (config.RedactedKeys != null && config.RedactedKeys.Count > 0)
             {
-                obj.Call("setRedactedKeys", GetAndroidRegexPatternSetFromArray(config.RedactedKeys));
+                var patternsAsStrings = new string[config.RedactedKeys.Count];
+                foreach (var key in config.RedactedKeys)
+                {
+                    patternsAsStrings[config.RedactedKeys.IndexOf(key)] = key.ToString();
+                }
+                obj.Call("setRedactedKeys", GetAndroidRegexPatternSetFromArray(patternsAsStrings));
             }
 
             // add unity event callback

--- a/src/BugsnagUnity/Native/Android/NativeInterface.cs
+++ b/src/BugsnagUnity/Native/Android/NativeInterface.cs
@@ -461,6 +461,7 @@ namespace BugsnagUnity
                 {
                     patternsAsStrings[config.DiscardClasses.IndexOf(pattern)] = pattern.ToString();
                 }
+                
                 obj.Call("setDiscardClasses", GetAndroidRegexPatternSetFromArray(patternsAsStrings));
             }
 
@@ -525,8 +526,15 @@ namespace BugsnagUnity
 
             foreach (var item in array)
             {
-                AndroidJavaObject pattern = patternClass.CallStatic<AndroidJavaObject>("compile", item);
-                set.Call<bool>("add", pattern);
+                try
+                {
+                    AndroidJavaObject pattern = patternClass.CallStatic<AndroidJavaObject>("compile", item);
+                    set.Call<bool>("add", pattern);
+                }
+                catch (AndroidJavaException e)
+                {
+                    Debug.LogWarning("Failed to compile regex pattern: " + item + " " + e.Message);
+                }
             }
 
             return set;

--- a/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeClient.cs
@@ -73,13 +73,23 @@ namespace BugsnagUnity
                 var user = config.GetUser();
                 NativeCode.bugsnag_setUserInConfig(obj, user.Id, user.Email, user.Name);
             }
-            if (config.DiscardClasses != null && config.DiscardClasses.Length > 0)
+            if (config.DiscardClasses != null && config.DiscardClasses.Count > 0)
             {
-                NativeCode.bugsnag_setDiscardClasses(obj, config.DiscardClasses, config.DiscardClasses.Length);
+                var patternsAsStrings = new string[config.DiscardClasses.Count];
+                foreach (var key in config.DiscardClasses)
+                {
+                    patternsAsStrings[config.DiscardClasses.IndexOf(key)] = key.ToString();
+                }
+                NativeCode.bugsnag_setDiscardClasses(obj, patternsAsStrings, patternsAsStrings.Length);
             }
-            if (config.RedactedKeys != null && config.RedactedKeys.Length > 0)
+            if (config.RedactedKeys != null && config.RedactedKeys.Count > 0)
             {
-                NativeCode.bugsnag_setRedactedKeys(obj, config.RedactedKeys, config.RedactedKeys.Length);
+                var patternsAsStrings = new string[config.RedactedKeys.Count];
+                foreach (var key in config.RedactedKeys)
+                {
+                    patternsAsStrings[config.RedactedKeys.IndexOf(key)] = key.ToString();
+                }
+                NativeCode.bugsnag_setRedactedKeys(obj, patternsAsStrings, patternsAsStrings.Length);
             }
 
             SetEnabledTelemetryTypes(obj,config);

--- a/tests/BugsnagUnity.Tests/ConfigurationTests.cs
+++ b/tests/BugsnagUnity.Tests/ConfigurationTests.cs
@@ -82,5 +82,58 @@ namespace BugsnagUnity.Payload.Tests
 
             Assert.IsFalse(config.Endpoints.IsValid);
         }
+
+        [Test]
+        public void RedactedKeysTest()
+        {
+            var config = new Configuration("foo");
+            
+            // // Default redacted keys
+            Assert.IsTrue(config.KeyIsRedacted("password"));
+            Assert.IsFalse(config.KeyIsRedacted("username"));
+
+            var config2 = new Configuration("foo");
+
+            // Custom redacted keys
+            config2.RedactedKeys = new string[] { "secret", "token" };
+            Assert.IsTrue(config2.KeyIsRedacted("secret"));
+            Assert.IsTrue(config2.KeyIsRedacted("token"));
+            Assert.IsFalse(config2.KeyIsRedacted("password"));
+
+            var config3 = new Configuration("foo");
+
+            // Regex pattern keys
+            config3.RedactedKeys = new string[] { ".*_key$", "^token_.*" };
+            Assert.IsTrue(config3.KeyIsRedacted("api_key"));
+            Assert.IsTrue(config3.KeyIsRedacted("token_value"));
+            Assert.IsFalse(config3.KeyIsRedacted("password"));
+        }
+
+        [Test]
+        public void DiscardedClassesTest()
+        {
+            var config = new Configuration("foo");
+
+            // No discard classes by default
+            Assert.IsFalse(config.ErrorClassIsDiscarded("System.Exception"));
+
+
+            var config2 = new Configuration("foo");
+
+            // Adding discard classes
+            config2.DiscardClasses = new string[] { "System.Exception", "System.NullReferenceException" };
+            Assert.IsTrue(config2.ErrorClassIsDiscarded("System.Exception"));
+            Assert.IsTrue(config2.ErrorClassIsDiscarded("System.NullReferenceException"));
+            Assert.IsFalse(config2.ErrorClassIsDiscarded("System.ArgumentException"));
+
+            var config3 = new Configuration("foo");
+
+            // // Regex pattern discard classes
+            config3.DiscardClasses = new string[] { "^System\\..*Exception$", ".*ReferenceException" };
+            Assert.IsTrue(config3.ErrorClassIsDiscarded("System.Exception"));
+            Assert.IsTrue(config3.ErrorClassIsDiscarded("System.NullReferenceException"));
+            Assert.IsTrue(config3.ErrorClassIsDiscarded("CustomReferenceException"));
+            Assert.IsFalse(config3.ErrorClassIsDiscarded("ArgumentError"));
+        }
     }
 }

--- a/tests/BugsnagUnity.Tests/ConfigurationTests.cs
+++ b/tests/BugsnagUnity.Tests/ConfigurationTests.cs
@@ -90,7 +90,7 @@ namespace BugsnagUnity.Payload.Tests
             var config = new Configuration("foo");
 
             // Default redacted keys
-            Assert.IsTrue(config.KeyIsRedacted("password"));
+            Assert.IsTrue(config.KeyIsRedacted("user-password"));
             Assert.IsFalse(config.KeyIsRedacted("username"));
 
             var config2 = new Configuration("foo");
@@ -101,15 +101,7 @@ namespace BugsnagUnity.Payload.Tests
             Assert.IsTrue(config2.KeyIsRedacted("secret"));
             Assert.IsTrue(config2.KeyIsRedacted("token"));
             Assert.IsTrue(config2.KeyIsRedacted("password"));
-
-            var config3 = new Configuration("foo");
-
-            // Regex pattern keys
-            config3.RedactedKeys.Add(new Regex(".*api_key.*", RegexOptions.IgnoreCase));
-            config3.RedactedKeys.Add(new Regex(".*token_value.*", RegexOptions.IgnoreCase));
-            Assert.IsTrue(config3.KeyIsRedacted("api_key"));
-            Assert.IsTrue(config3.KeyIsRedacted("token_value"));
-            Assert.IsTrue(config3.KeyIsRedacted("password"));
+            Assert.IsFalse(config2.KeyIsRedacted("app_id"));
         }
 
         [Test]
@@ -128,16 +120,6 @@ namespace BugsnagUnity.Payload.Tests
             Assert.IsTrue(config2.ErrorClassIsDiscarded("System.Exception"));
             Assert.IsTrue(config2.ErrorClassIsDiscarded("System.NullReferenceException"));
             Assert.IsFalse(config2.ErrorClassIsDiscarded("System.ArgumentException"));
-
-            var config3 = new Configuration("foo");
-
-            // Regex pattern discard classes
-            config3.DiscardClasses.Add(new Regex("^System\\..*Exception$", RegexOptions.IgnoreCase));
-            config3.DiscardClasses.Add(new Regex(".*ReferenceException", RegexOptions.IgnoreCase));
-            Assert.IsTrue(config3.ErrorClassIsDiscarded("System.Exception"));
-            Assert.IsTrue(config3.ErrorClassIsDiscarded("System.NullReferenceException"));
-            Assert.IsTrue(config3.ErrorClassIsDiscarded("CustomReferenceException"));
-            Assert.IsFalse(config3.ErrorClassIsDiscarded("ArgumentError"));
         }
     }
 }


### PR DESCRIPTION
## Goal

Change discardClasses and redactedKeys to regex collections.

Keep the fields in the Bugsnag settings window as string collections so that unity and display them, but convert them to Regex when building the config object.

## Testing

Added Unit Tests and covered by existing E2E tests