### PR TITLE
updated generateAnonymousID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-#TBD 
-
-- Added GenerateAnonymousId to the BugsnagSettingsObject [#812](https://github.com/bugsnag/bugsnag-unity/pull/812)
-
 ## 8.0.0 (2024-06-10)
 
 ### Enhancements
@@ -17,6 +13,8 @@
 - Added a null check to the Bugsnag client to prevent crashes when accessing the client before it has been initialised [#788](https://github.com/bugsnag/bugsnag-unity/pull/788)
 
 - Made all callback collections within the Configuration class thread safe. [#810](https://github.com/bugsnag/bugsnag-unity/pull/810)
+
+- Added GenerateAnonymousId to the BugsnagSettingsObject. This fixes a null object reference error on GenerateAnonymousId when using both the performance SDK and Error monitoring SDK, where the error monitoring SDK shares the confirguration with the performance monitoring SDK. [#812](https://github.com/bugsnag/bugsnag-unity/pull/812)
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#TBD 
+
+- Added GenerateAnonymousId to the BugsnagSettingsObject [#812](https://github.com/bugsnag/bugsnag-unity/pull/812)
+
 ## 8.0.0 (2024-06-10)
 
 ### Enhancements

--- a/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
+++ b/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
@@ -164,6 +164,7 @@ namespace BugsnagUnity.Editor
             }
             EditorGUILayout.PropertyField(so.FindProperty("AutoDetectErrors"));
             EditorGUILayout.PropertyField(so.FindProperty("AutoTrackSessions"));
+            EditorGUILayout.PropertyField(so.FindProperty("GenerateAnonymousId"));
             EditorGUILayout.PropertyField(so.FindProperty("BreadcrumbLogLevel"));
             EditorGUILayout.PropertyField(so.FindProperty("Context"));
             EditorGUILayout.PropertyField(so.FindProperty("DiscardClasses"));

--- a/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
+++ b/src/Assets/Bugsnag/Scripts/BugsnagSettingsObject.cs
@@ -42,6 +42,7 @@ namespace BugsnagUnity
         public List<TelemetryType> Telemetry = new List<TelemetryType> { TelemetryType.InternalErrors, TelemetryType.Usage };
         public int VersionCode = -1;
 
+        public bool GenerateAnonymousId = true;
         public SwitchCacheType SwitchCacheType = SwitchCacheType.R;
         public string SwitchCacheMountName = "BugsnagCache";
         public int SwitchCacheIndex = 0;
@@ -132,7 +133,7 @@ namespace BugsnagUnity
             config.SecondsPerUniqueLog = TimeSpan.FromSeconds(SecondsPerUniqueLog);
             config.Telemetry = Telemetry;
             config.VersionCode = VersionCode;
-
+            config.GenerateAnonymousId = GenerateAnonymousId;
             config.SwitchCacheType = SwitchCacheType;
             config.SwitchCacheIndex = SwitchCacheIndex;
             config.SwitchCacheMaxSize = SwitchCacheMaxSize;


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
When using the performance library with `use bugsnag error monitoring sdk settings` enabled, it cannot find the `GenerateAnonymousId` value.

## Changeset

added generateanonymousid value to the bugsnag setting object

## Testing

Running automated tests on buildkite