### PR TITLE
PLAT-9602 make unhandled non null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Changed `Configuration.DiscardClasses` and `Configuration.RedactedKeys` to Regex types. [#807](https://github.com/bugsnag/bugsnag-unity/pull/807)
 
-- `Event.Unhandled` is (accessed via OnError and OnSend callbacks) is now non null. [#813](https://github.com/bugsnag/bugsnag-unity/pull/813)
+- `Event.Unhandled` is (accessed via OnError and OnSend callbacks) is now non-nullable. [#813](https://github.com/bugsnag/bugsnag-unity/pull/813)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Changed `Configuration.DiscardClasses` and `Configuration.RedactedKeys` to Regex types. [#807](https://github.com/bugsnag/bugsnag-unity/pull/807)
 
+- `Event.Unhandled` is (accessed via OnError and OnSend callbacks) is now non null. [#813](https://github.com/bugsnag/bugsnag-unity/pull/813)
+
 ### Bug Fixes
 
 - Added a null check to the Bugsnag client to prevent crashes when accessing the client before it has been initialised [#788](https://github.com/bugsnag/bugsnag-unity/pull/788)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,8 @@ Upgrading
 
 If you are using the `DiscardClasses` and `RedactedKeys` sections of the Bugsnag Unity Configuration Window, you can enter Regex patterns as strings and they will be converted into Regex objects when the Bugsnag SDK is started.
 
+`Event.Unhandled` (accessed via OnError and OnSend callbacks) is now non null.
+
 ## 6.x to 7.x
 
 When building using Unity 2019+, the Bugsnag SDK now uses a new method to intercept uncaught C# exceptions. This allows us access to the original exception object, meaning more accurate exception data and full support for inner exceptions.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,7 +7,7 @@ Upgrading
 
 If you are using the `DiscardClasses` and `RedactedKeys` sections of the Bugsnag Unity Configuration Window, you can enter Regex patterns as strings and they will be converted into Regex objects when the Bugsnag SDK is started.
 
-`Event.Unhandled` (accessed via OnError and OnSend callbacks) is now non null.
+`Event.Unhandled` (accessed via OnError and OnSend callbacks) is now non-nullable.
 
 ## 6.x to 7.x
 

--- a/src/BugsnagUnity/Native/Android/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Android/NativeEvent.cs
@@ -28,7 +28,7 @@ namespace BugsnagUnity
 
         public List<IThread> Threads => GetThreads();
 
-        public bool? Unhandled { get => NativePointer.Call<bool>("isUnhandled"); set => NativePointer.Call("setUnhandled", (bool)value); }
+        public bool Unhandled { get => NativePointer.Call<bool>("isUnhandled"); set => NativePointer.Call("setUnhandled", (bool)value); }
 
         private Severity GetSeverity()
         {

--- a/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeEvent.cs
@@ -28,7 +28,13 @@ namespace BugsnagUnity
 
         public string GroupingHash { get => GetNativeString(GROUPING_HASH_KEY); set => SetNativeString(GROUPING_HASH_KEY, value); }
 
-        public bool? Unhandled { get => GetNativeBool(UNHANDLED_KEY); set => SetNativeBool(UNHANDLED_KEY, value); }
+        public bool Unhandled { 
+            get {
+                var nativeBool = GetNativeBool(UNHANDLED_KEY); 
+                return nativeBool.HasValue ? nativeBool.Value : false;
+            }
+            set => SetNativeBool(UNHANDLED_KEY, value); 
+        }
 
         private List<IBreadcrumb> _breadcrumbs = new List<IBreadcrumb>();
 

--- a/src/BugsnagUnity/Payload/Event.cs
+++ b/src/BugsnagUnity/Payload/Event.cs
@@ -61,6 +61,11 @@ namespace BugsnagUnity.Payload
             {
                 Add("unhandled", eventObject["unhandled"]);
             }
+            else
+            {
+                Add("unhandled", false);
+            }
+            
             if (eventObject["severity"] != null)
             {
                 Add("severity", eventObject["severity"]);
@@ -190,7 +195,17 @@ namespace BugsnagUnity.Payload
 
         internal LogType? LogType { get; }
 
-        public bool? Unhandled { get => (bool)Get("unhandled"); set => Add("unhandled",value); }
+        public bool Unhandled {     
+        get {
+            var currentValue = Get("unhandled"); 
+            if (currentValue == null) 
+            {
+                return false;
+            }
+            return (bool)currentValue;
+        } 
+        set => Add("unhandled",value); 
+        }
 
         internal bool IsHandled
         {

--- a/src/BugsnagUnity/Payload/IEvent.cs
+++ b/src/BugsnagUnity/Payload/IEvent.cs
@@ -27,6 +27,6 @@ namespace BugsnagUnity
 
         List<IThread> Threads { get; }
 
-        bool? Unhandled { get; set; }
+        bool Unhandled { get; set; }
     }
 }


### PR DESCRIPTION
## Goal

make Event.unhandled non null

unhandled should always be either true or false and should not be missing from any serialised payload.

## Testing

covered by existing E2E tests