### PR TITLE
Display BugsnagUnity version in the configuration panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## TBD
 
+### Enhancements
+
+- Added the BugsnagUnity version to the configuration window. [#819](https://github.com/bugsnag/bugsnag-unity/pull/819)
+
 ### Dependencies
 
 - Update bugsnag-cocoa to [v6.29.0](https://github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.29.0) [#814](https://github.com/bugsnag/bugsnag-unity/pull/814)

--- a/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
+++ b/src/Assets/Bugsnag/Editor/BugsnagEditor.cs
@@ -78,6 +78,9 @@ namespace BugsnagUnity.Editor
             var settings = GetSettingsObject();
             var so = new SerializedObject(settings);
 
+            var assemblyName = BugsnagUnity.Configuration.GetAssemblyName();
+            var version = assemblyName.Version;
+            EditorGUILayout.LabelField($"{assemblyName.Name} version {version.Major}.{version.Minor}.{version.Build}");
 
             _showBasicConfig = EditorGUILayout.Foldout(_showBasicConfig, "Basic Configuration", true);
             if (_showBasicConfig)

--- a/src/BugsnagUnity/Configuration.cs
+++ b/src/BugsnagUnity/Configuration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -360,6 +361,10 @@ namespace BugsnagUnity
         public void ClearFeatureFlags()
         {
             FeatureFlags.Clear();
+        }
+
+        public static AssemblyName GetAssemblyName() {
+            return typeof(Configuration).Assembly.GetName(); 
         }
     }
 


### PR DESCRIPTION
## Goal

Show the BugsnagUnity version.

## Changeset

- New function in the configuration to access the AssemblyName.
- Add the version and name information to the configuration window.


Supersedes #819.