### PR TITLE
Fix timing issues when Bugsnag started after the focus event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Update bugsnag-cocoa to [v6.29.0](https://github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.29.0) [#814](https://github.com/bugsnag/bugsnag-unity/pull/814)
 
+### Bug Fixes
+
+- Fix timing issues when Bugsnag is started after the focus event. [#821](https://github.com/bugsnag/bugsnag-unity/pull/821)
+
 ## 8.0.0 (2024-06-12)
 
 ### Enhancements

--- a/src/BugsnagUnity/Client.cs
+++ b/src/BugsnagUnity/Client.cs
@@ -203,6 +203,8 @@ namespace BugsnagUnity
         {
             _foregroundStopwatch = new Stopwatch();
             _backgroundStopwatch = new Stopwatch();
+            // Required in case the focus event is not recieved (if Bugsnag is started after it is sent)
+            _foregroundStopwatch.Start();
         }
 
         private void InitUserObject()

--- a/src/BugsnagUnity/Native/Fallback/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Fallback/NativeClient.cs
@@ -50,7 +50,7 @@ namespace BugsnagUnity
             }
             else
             {
-                isLaunching = app.DurationInForeground?.TotalMilliseconds < Configuration.LaunchDurationMillis;
+                isLaunching = app.Duration?.TotalMilliseconds < Configuration.LaunchDurationMillis;
             }
             app.IsLaunching = isLaunching;
         }

--- a/src/BugsnagUnity/Native/Windows/NativeClient.cs
+++ b/src/BugsnagUnity/Native/Windows/NativeClient.cs
@@ -44,7 +44,7 @@ namespace BugsnagUnity
             }
             else
             {
-                isLaunching = app.DurationInForeground?.TotalMilliseconds < Configuration.LaunchDurationMillis;
+                isLaunching = app.Duration?.TotalMilliseconds < Configuration.LaunchDurationMillis;
             }
             app.IsLaunching = isLaunching;
         }


### PR DESCRIPTION
## Goal

Fix issues where Bugsnag is started after the focus event is received (so the foreground timer was never started).

## Changeset

- Start the foreground stopwatch automatically on startup.
- Use the `Duration` rather than the `ForegroundDuration` to determine if the app has launched as it takes account of the time before Bugsnag was started.

Supersedes #821.