### PR TITLE
Bump the NDK version in bugsnag-android-unity to match android

### DIFF
--- a/bugsnag-android-unity/build.gradle
+++ b/bugsnag-android-unity/build.gradle
@@ -28,7 +28,7 @@ android {
                 abiFilters "arm64-v8a", "armeabi-v7a", "x86", "x86_64"
             }
         }
-        ndkVersion = "16.1.4479499"
+        ndkVersion = "21.4.7075529"
     }
 
     externalNativeBuild {

--- a/features/fixtures/maze_runner/nativeplugin/android/build.gradle
+++ b/features/fixtures/maze_runner/nativeplugin/android/build.gradle
@@ -21,7 +21,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 30
-        ndkVersion = "16.1.4479499"
+        ndkVersion = "21.4.7075529"
     }
     externalNativeBuild.cmake.path "CMakeLists.txt"
 }


### PR DESCRIPTION
## Goal

I could not get the plugin to build due to this old ndk version. The bumped version is the one used in the android plugin so it will not break anything.

## Changeset

- Bump the ndk version in bugsnag-android-unity.