### PR TITLE
Fix network breadcrumb test

### DIFF
--- a/features/csharp/csharp_breadcrumbs.feature
+++ b/features/csharp/csharp_breadcrumbs.feature
@@ -84,24 +84,24 @@ Feature: Csharp Breadcrumbs
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "NetworkBreadcrumbsSuccess"
     
+    And the event "breadcrumbs.0.name" equals "UnityWebRequest succeeded"
+    And the event "breadcrumbs.0.type" equals "request"
+    And the event "breadcrumbs.0.metaData.method" equals "GET" 
+    And the error payload field "events.0.breadcrumbs.0.metaData.url" matches the regex "^http:\/\/\S*:\d{4}(\/.*)?"
+    And the event "breadcrumbs.0.metaData.status" equals 200
+    And the event "breadcrumbs.0.metaData.urlParams.success" equals "true"
+    And the event "breadcrumbs.0.metaData.urlParams.redactthis" equals "[REDACTED]"
+    And the event "breadcrumbs.0.metaData.duration" is greater than 0
+    And the event "breadcrumbs.0.metaData.responseContentLength" is greater than 0
+
     And the event "breadcrumbs.1.name" equals "UnityWebRequest succeeded"
     And the event "breadcrumbs.1.type" equals "request"
-    And the event "breadcrumbs.1.metaData.method" equals "GET" 
+    And the event "breadcrumbs.1.metaData.method" equals "POST" 
     And the error payload field "events.0.breadcrumbs.1.metaData.url" matches the regex "^http:\/\/\S*:\d{4}(\/.*)?"
     And the event "breadcrumbs.1.metaData.status" equals 200
-    And the event "breadcrumbs.1.metaData.urlParams.success" equals "true"
-    And the event "breadcrumbs.1.metaData.urlParams.redactthis" equals "[REDACTED]"
     And the event "breadcrumbs.1.metaData.duration" is greater than 0
     And the event "breadcrumbs.1.metaData.responseContentLength" is greater than 0
-
-    And the event "breadcrumbs.2.name" equals "UnityWebRequest succeeded"
-    And the event "breadcrumbs.2.type" equals "request"
-    And the event "breadcrumbs.2.metaData.method" equals "POST" 
-    And the error payload field "events.0.breadcrumbs.2.metaData.url" matches the regex "^http:\/\/\S*:\d{4}(\/.*)?"
-    And the event "breadcrumbs.2.metaData.status" equals 200
-    And the event "breadcrumbs.2.metaData.duration" is greater than 0
-    And the event "breadcrumbs.2.metaData.responseContentLength" is greater than 0
-    And the event "breadcrumbs.2.metaData.requestContentLength" is greater than 0
+    And the event "breadcrumbs.1.metaData.requestContentLength" is greater than 0
 
 
  Scenario: Network breadcrumb fails

--- a/features/csharp/csharp_breadcrumbs.feature
+++ b/features/csharp/csharp_breadcrumbs.feature
@@ -113,7 +113,7 @@ Feature: Csharp Breadcrumbs
     And the event "breadcrumbs.1.type" equals "request"
     And the event "breadcrumbs.1.metaData.method" equals "GET" 
     And the error payload field "events.0.breadcrumbs.1.metaData.url" equals "https://localhost:994/?success=false"
-    And the event "breadcrumbs.1.metaData.status" equals 0
+    And the event "breadcrumbs.1.metaData.status" has failed
     And the event "breadcrumbs.1.metaData.urlParams.success" equals "false"
     And the event "breadcrumbs.1.metaData.duration" is greater than 0
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/NetworkBreadcrumbsSuccess.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/NetworkBreadcrumbsSuccess.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using BugsnagNetworking;
+using BugsnagUnity;
 using UnityEngine;
 
 public class NetworkBreadcrumbsSuccess : Scenario
@@ -11,6 +12,7 @@ public class NetworkBreadcrumbsSuccess : Scenario
     {
         base.PrepareConfig(apiKey, host);
         Configuration.RedactedKeys = new List<Regex> { new Regex("redactthis") };
+        Configuration.EnabledBreadcrumbTypes = new BugsnagUnity.Payload.BreadcrumbType[] { BugsnagUnity.Payload.BreadcrumbType.Request };
     }
     public override void Run()
     {

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -141,6 +141,17 @@ Then('the error is valid for the error reporting API sent by the Unity notifier'
   check_error_reporting_api notifier_name
 end
 
+Then('the event "breadcrumbs.1.metaData.status" has failed') do
+  status = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.breadcrumbs.1.metaData.status')
+  platform = Maze::Helper.get_current_platform
+  # 500 is returned due to browser CORs
+  if platform == 'browser'
+    Maze.check.equal(status, 500)
+  else
+    Maze.check.equal(status, 0)
+  end
+end
+
 Then('the stack frame methods should match:') do |expected_values|
   stacktrace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.exceptions.0.stacktrace')
   expected_frame_values = expected_values.raw

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -143,13 +143,8 @@ end
 
 Then('the event "breadcrumbs.1.metaData.status" has failed') do
   status = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.breadcrumbs.1.metaData.status')
-  platform = Maze::Helper.get_current_platform
-  # 500 is returned due to browser CORs
-  if platform == 'browser'
-    Maze.check.equal(status, 500)
-  else
-    Maze.check.equal(status, 0)
-  end
+  # 500 may be returned due to browser CORs
+  Maze.check.true(status == 0 || status == 500, "Expected an error status of 0 or 500 but got #{status}")
 end
 
 Then('the stack frame methods should match:') do |expected_values|


### PR DESCRIPTION
## Goal

On some platforms other breadcrumbs such as window focus caused the network breadcrumbs test to fail. This is resolved by ignoring breadcrumb types other than request in the test.