### PR TITLE
[PLAT-12879] Add support for getting and searching the currently loaded images

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -289,7 +289,7 @@ namespace :plugin do
       build_type = "Release" # "Debug" or "Release"
       FileUtils.mkdir_p cocoa_build_dir
       FileUtils.cp_r "bugsnag-cocoa/Bugsnag", cocoa_build_dir
-      bugsnag_unity_file = File.realpath("BugsnagUnity.m", "src")
+      bugsnag_unity_file = File.realpath("BugsnagUnity.mm", "src")
       public_headers = Dir.entries(File.join(cocoa_build_dir, "Bugsnag", "include", "Bugsnag"))
 
       Dir.chdir cocoa_build_dir do

--- a/src/BugsnagUnity/Native/Cocoa/NativeImage.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeImage.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections;
+using System.Runtime.InteropServices;
+
+namespace BugsnagUnity
+{
+    /// <summary>
+    /// Wraps a NativeLoadedImage to provide automatic and lazy marshaling from the native side.
+    /// </summary>
+    /// <remarks>
+    /// We generally don't need the name and UUID except in specific cases, so we unmarshal
+    /// them lazily.
+    /// </remarks>
+    class LoadedImage
+    {
+        public UInt64 LoadAddress
+        {
+            get => Image.LoadAddress;
+        }
+        public UInt64 Size
+        {
+            get => Image.Size;
+        }
+        public string FileName
+        {
+            get
+            {
+                if (CachedFileName == null)
+                {
+                    CachedFileName = Marshal.PtrToStringAnsi(Image.FileName);
+                }
+                return CachedFileName;
+            }
+        }
+        public string Uuid
+        {
+            get
+            {
+                if (CachedUuid == null)
+                {
+                    var uuid = new byte[16];
+                    Marshal.Copy(Image.UuidBytes, uuid, 0, 16);
+                    CachedUuid = new Guid(uuid).ToString();
+                }
+                return CachedUuid;
+            }
+        }
+
+        public LoadedImage(NativeLoadedImage image)
+        {
+            Image = image;
+        }
+
+        private NativeLoadedImage Image;
+        private string CachedFileName;
+        private string CachedUuid;
+    }
+
+    class LoadedImages
+    {
+        /// <summary>
+        /// Refresh the list of loaded images to match what the native side currently says.
+        /// </summary>
+        /// <remarks>
+        /// Note: You MUST call this at least once before using an instance of this class!
+        /// </remarks>
+        public void Refresh()
+        {
+            // Ask for the current count * 2 in case new images get added between calls
+            var nativeImages = new NativeLoadedImage[NativeCode.bugsnag_getLoadedImageCount() * 2];
+            var count = NativeCode.bugsnag_getLoadedImages(nativeImages, (UInt64)nativeImages.LongLength);
+            var images = new LoadedImage[count];
+            for (UInt64 i = 0; i < count; i++)
+            {
+                images[i] = new LoadedImage(nativeImages[i]);
+            }
+            Images = images;
+        }
+
+        /// <summary>
+        /// Find the native loaded image that corresponds to a native instruction address
+        /// supplied by il2cpp_native_stack_trace().
+        /// </summary>
+        /// <param name="address">The address to find the corresponding image of</param>
+        /// <returns>The corresponding image, or null</returns>
+        public LoadedImage FindImageAtAddress(UInt64 address)
+        {
+            int idx = Array.BinarySearch(Images, address, new AddressToImageComparator());
+            if (idx < 0)
+            {
+                return null;
+            }
+            return Images[idx];
+        }
+
+        /// <summary>
+        /// The currently loaded images, as of the last call to Refresh().
+        /// </summary>
+        public LoadedImage[] Images;
+
+        private class AddressToImageComparator : IComparer
+        {
+            int IComparer.Compare(Object x, Object y)
+            {
+                LoadedImage image = (LoadedImage)x;
+                UInt64 address = (UInt64)y;
+                if (address < image.LoadAddress)
+                {
+                    return 1;
+                }
+                if (address > image.LoadAddress + image.Size)
+                {
+                    return -1;
+                }
+                return 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
As part of the il2cpp support, we need to be able to search through the loaded binary images to find a match for instruction addresses that we collect via `il2cpp_native_stack_trace()`.

This PR adds a new class `LoadedImages` that allows you to sync on-demand with what the dynamic loader has loaded using `Refresh()`, and to search for images using `FindImageAtAddress()`.

Xcode's formatter also had a go at one of the objective-c files, so it's a bit noisy.
