### PR TITLE
[PLAT-12880] Add il2cpp build preprocessor

### DIFF
--- a/src/Assets/Bugsnag/Editor/BuildPreprocessor.cs
+++ b/src/Assets/Bugsnag/Editor/BuildPreprocessor.cs
@@ -1,0 +1,28 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+
+public class BuildPreprocessor : IPreprocessBuildWithReport
+{
+    public int callbackOrder => 0;
+
+    public void OnPreprocessBuild(BuildReport report)
+    {
+        if (PlayerSettings.GetScriptingBackend(report.summary.platformGroup) != ScriptingImplementation.IL2CPP)
+        {
+            return;
+        }
+
+        // Causes il2cpp to generate my-build-dir/Classes/Native/Symbols/LineNumberMappings.json
+        // Note: It used to be stored in the project root dir as:
+        //   my-build-dir_BackUpThisFolder_ButDontShipItWithYourGame/il2cppOutput/Symbols/LineNumberMappings.json
+        const string emitIl2cppSourceMapping = "--emit-source-mapping";
+
+        var args = PlayerSettings.GetAdditionalIl2CppArgs();
+        if (!args.Contains(emitIl2cppSourceMapping))
+        {
+            PlayerSettings.SetAdditionalIl2CppArgs(args + emitIl2cppSourceMapping);
+        }
+    }
+}

--- a/src/Assets/Bugsnag/Editor/BuildPreprocessor.cs.meta
+++ b/src/Assets/Bugsnag/Editor/BuildPreprocessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa2475012ac674a7e9d2b68a06847aaf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add the `--emit-source-mapping` switch when calling il2cpp so that it emits `LineNumberMappings.json` for matching C# code to native stack frames.
