### PR TITLE
Use the dynamic linker's data directly and copy it C# side immediately

### DIFF
--- a/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
+++ b/src/BugsnagUnity/Native/Cocoa/NativeCode.cs
@@ -49,12 +49,24 @@ namespace BugsnagUnity
         /// <param name="capacity">The number of entries in images.</param>
         /// <returns>The number of entries that were filled.</returns>
         /// <remarks>
+        /// You MUST call bugsnag_unlockLoadedImages() after you are done with the NativeLoadedImage structs.
+        ///
         /// Note: Array types MUST be declared as [In, Out] or else you'll get all sorts of weird issues,
         /// like arrays being truncated to zero length, or a single entry being duplicated across the
         /// entire array. The compiler won't complain, either.
         /// </remarks>
         [DllImport(Import)]
         internal static extern UInt64 bugsnag_getLoadedImages([In, Out] NativeLoadedImage[] images, UInt64 capacity);
+
+        /// <summary>
+        /// Unlock the mutex protecting the loaded images list.
+        /// </summary>
+        /// <remarks>
+        /// This MUST be called after collecting the data from tha NativeLoadedImage structs returned by
+        /// bugsnag_getLoadedImages().
+        /// </remarks>
+        [DllImport(Import)]
+        internal static extern void bugsnag_unlockLoadedImages();
 
         [DllImport(Import)]
         internal static extern void bugsnag_startBugsnagWithConfiguration(IntPtr configuration, string notifierVersion);


### PR DESCRIPTION
## Goal

The previous native image monitor had a bug in that it was copying the dynamic linker's pointers directly rather than allocating a copy of the data it pointed to. It would then crash when trying to free those pointers if the dynamic loader ever removed an image.

But even without the bug, there would have been a concurrency hole if an image gets deallocated before we lazily fetch the data from the C# side of things.

## Design

The implementation now just treats the C++ side's `NativeLoadedImage` as a glorified struct, and memcpys the data across to C# land. C# then marshals all of the pointed-to data immediately. This 2-step process is protected by the existing mutex for concurrency protection.

A nice effect of this approach is that we don't have to manage memory at all on the C++ side.

## Testing

Tested manually in a macos app and an ios app.
