### PR TITLE
tool to easily choose C# dev env 

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/Breadcrumbs.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/Breadcrumbs.cs
@@ -1,4 +1,4 @@
-﻿#if (UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_WEBGL) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV || BSG_WIN_DEV)
+﻿#if (UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_WEBGL || BSG_WIN_DEV) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV)
 using System.Collections.Generic;
 using System.Linq;
 using BugsnagUnity.Payload;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/MacOS/NativeCode.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/MacOS/NativeCode.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_STANDALONE_OSX && !UNITY_EDITOR
+﻿#if (UNITY_STANDALONE_OSX && !UNITY_EDITOR) || (UNITY_STANDALONE_OSX && BSG_COCOA_DEV)
 namespace BugsnagUnity
 {
     partial class NativeCode

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/iOS/NativeCode.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/iOS/NativeCode.cs
@@ -1,4 +1,4 @@
-﻿#if (UNITY_IOS && !UNITY_EDITOR) || BSG_COCOA_DEV
+﻿#if (UNITY_IOS && !UNITY_EDITOR) || (UNITY_IOS && BSG_COCOA_DEV)
 namespace BugsnagUnity
 {
     partial class NativeCode

--- a/Bugsnag/Assets/Editor/CompilerFlagsTool.cs
+++ b/Bugsnag/Assets/Editor/CompilerFlagsTool.cs
@@ -1,0 +1,44 @@
+using UnityEditor;
+
+public static class CompilerFlagsMenu
+{
+    private static readonly string[] flags = { "BSG_COCOA_DEV", "BSG_WIN_DEV", "BSG_ANDROID_DEV" };
+
+    [MenuItem("BugsnagDev/Select Env/COCOA")]
+    private static void SetCocoaFlag()
+    {
+        SetCompilerFlag("BSG_COCOA_DEV");
+    }
+
+    [MenuItem("BugsnagDev/Select Env/WINDOWS")]
+    private static void SetWinFlag()
+    {
+        SetCompilerFlag("BSG_WIN_DEV");
+    }
+
+    [MenuItem("BugsnagDev/Select Env/ANDROID")]
+    private static void SetAndroidFlag()
+    {
+        SetCompilerFlag("BSG_ANDROID_DEV");
+    }
+
+    [MenuItem("BugsnagDev/Select Env/FALLBACK")]
+    private static void SetNoFlag()
+    {
+        SetCompilerFlag(null);
+    }
+
+    private static void SetCompilerFlag(string selectedFlag)
+    {
+        try
+        {
+            string defines = selectedFlag ?? ""; // If selectedFlag is null, set defines to an empty string
+            foreach (BuildTargetGroup group in System.Enum.GetValues(typeof(BuildTargetGroup)))
+            {
+                if (group == BuildTargetGroup.Unknown) continue;
+                PlayerSettings.SetScriptingDefineSymbolsForGroup(group, defines);
+            }
+        }
+        catch { }
+    }
+}

--- a/Bugsnag/Assets/Editor/CompilerFlagsTool.cs.meta
+++ b/Bugsnag/Assets/Editor/CompilerFlagsTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 976c50e33517d4300a88b76c05db663f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Goal

This tool allows you to quickly switch between C# platform code compilation.

Also fixed macos test build issue

<img width="261" alt="image" src="https://github.com/user-attachments/assets/b737c223-27a5-4f23-b111-2b336a9564bd">