### PR TITLE
suppress null return warning for session.GetUser

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
@@ -29,7 +29,10 @@ namespace BugsnagUnity.Payload
 
         internal User? User { get; set; }
 
+// Disabled warning as this is expected behaviour
+#pragma warning disable CS8603 // Possible null reference return.
         public IUser GetUser() => User;
+#pragma warning restore CS8603 // Possible null reference return.
 
         public void SetUser(string id, string email, string name)
         {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
@@ -29,10 +29,7 @@ namespace BugsnagUnity.Payload
 
         internal User? User { get; set; }
 
-// Disabled warning as this is expected behaviour
-#pragma warning disable CS8603 // Possible null reference return.
-        public IUser GetUser() => User;
-#pragma warning restore CS8603 // Possible null reference return.
+        public IUser? GetUser() => User;
 
         public void SetUser(string id, string email, string name)
         {


### PR DESCRIPTION
## Goal

Now that we ship source there is a compiler warning for session.GetUser because the method signature does not have an explicit nullable return type. This PR changes the method signature without it being a change in API behavior.

session.User and event.User should not be nullable and this will be addressed in the next major release because even though fixing it is unlikely to cause any users issues, it is technically a breaking change to the API.