### PR TITLE
Buildkite pipeline tidy-up

### DIFF
--- a/.buildkite/block.yml
+++ b/.buildkite/block.yml
@@ -3,6 +3,9 @@ steps:
     key: 'trigger-full-build'
 
   - label: 'Upload the full test pipeline'
+    agents:
+      queue: macos
+    timeout_in_minutes: 2
     depends_on: 'trigger-full-build'
     command: >
       buildkite-agent pipeline upload .buildkite/pipeline.full.yml

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,19 +1,23 @@
 agents:
-  queue: opensource
+  queue: macos
 
 steps:
-  - name: 'Append Unity 2020 Pipeline'
+  - label: 'Append Unity 2020 Pipeline'
+    timeout_in_minutes: 2
     commands:
         - buildkite-agent pipeline upload .buildkite/unity.2020.yml
 
-  - name: 'Append Full Unity 2021 Pipeline'
+  - label: 'Append Full Unity 2021 Pipeline'
+    timeout_in_minutes: 2
     commands:
         - buildkite-agent pipeline upload .buildkite/unity.2021.full.yml
 
-  - name: 'Append Unity 2022 Pipeline'
+  - label: 'Append Unity 2022 Pipeline'
+    timeout_in_minutes: 2
     commands:
         - buildkite-agent pipeline upload .buildkite/unity.2022.yml
 
-  - name: 'Append Unity 6000 Pipeline'
+  - label: 'Append Unity 6000 Pipeline'
+    timeout_in_minutes: 2
     commands:
         - buildkite-agent pipeline upload .buildkite/unity.6000.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,25 +1,24 @@
 aliases:
   - &2021 "2021.3.36f1"
 
+agents:
+  queue: macos-14
+
 steps:
-  - group: ":hammer: Build Unity packages"
-    steps:
-      - label: Build released notifier artifact
-        key: "build_unitypackage"
-        timeout_in_minutes: 30
-        agents:
-          queue: macos-14
-        env:
-          UNITY_VERSION: *2021
-        commands:
-          - bundle install
-          - bundle exec rake plugin:export
-        artifact_paths:
-          - Bugsnag.unitypackage
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 1
+  - label: Build released notifier artifact
+    key: "build_unitypackage"
+    timeout_in_minutes: 30
+    env:
+      UNITY_VERSION: *2021
+    commands:
+      - bundle install
+      - bundle exec rake plugin:export
+    artifact_paths:
+      - Bugsnag.unitypackage
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
   - label: 'Run size impact reporting'
     depends_on: build_unitypackage
@@ -33,8 +32,11 @@ steps:
     commands:
       features/scripts/do_size_test.sh
 
-  - name: 'Append Unity 2021 Pipeline'
+  - label: 'Append Unity 2021 Pipeline'
     depends_on: build_unitypackage
+    agents:
+      queue: macos
+    timeout_in_minutes: 2
     commands:
         - buildkite-agent pipeline upload .buildkite/unity.2021.yml
 
@@ -43,5 +45,7 @@ steps:
   #
   - label: "Conditionally trigger full set of tests"
     depends_on: build_unitypackage
-    timeout_in_minutes: 30
+    agents:
+      queue: macos
+    timeout_in_minutes: 2
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -31,7 +31,7 @@ steps:
       # Build iOS test fixtures
       #
       - label: ":ios: Generate Xcode project - Unity 2020"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: "generate-fixture-project-2020"
         env:
           UNITY_VERSION: *2020

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -8,7 +8,7 @@ steps:
   - group: ":hammer: Build Unity 2020 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 2020"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: "build-android-fixture-2020"
         env:
           UNITY_VERSION: *2020
@@ -52,7 +52,7 @@ steps:
               limit: 1
 
       - label: ":ios: Build iOS test fixture for Unity 2020"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "build-ios-fixture-2020"
         depends_on: "generate-fixture-project-2020"
         env:
@@ -76,7 +76,7 @@ steps:
               limit: 1
 
       - label: Build Unity 2020 MacOS test fixture
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "macos-2020-fixture"
         env:
           UNITY_VERSION: *2020
@@ -98,7 +98,7 @@ steps:
               limit: 1
 
       - label: Build Unity 2020 WebGL test fixture
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: "webgl-2020-fixture"
         env:
           UNITY_VERSION: *2020

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -8,7 +8,7 @@ steps:
   - group: ":hammer: Build Unity 2021 full test fixtures"
     steps:
       - label: ":android: Build Android DEV test fixture for Unity 2021"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: "build-android-dev-fixture-2021"
         env:
           UNITY_VERSION: *2021
@@ -28,7 +28,7 @@ steps:
               limit: 1
 
       - label: ":ios: Generate Xcode DEV project - Unity 2021"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "generate-dev-fixture-project-2021"
         env:
           UNITY_VERSION: *2021
@@ -49,7 +49,7 @@ steps:
               limit: 1
 
       - label: ":ios: Build DEV iOS test fixture for Unity 2021"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "build-ios-dev-fixture-2021"
         depends_on: "generate-dev-fixture-project-2021"
         env:
@@ -73,7 +73,7 @@ steps:
               limit: 1
       
       - label: Build Unity 2021 MacOS test fixture
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "macos-2021-fixture"
         env:
           UNITY_VERSION: *2021
@@ -113,7 +113,7 @@ steps:
               limit: 1
 
       - label: Build Unity 2021 WebGL test fixture
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: "webgl-2021-fixture"
         env:
           UNITY_VERSION: *2021
@@ -133,7 +133,7 @@ steps:
               limit: 1
 
       - label: Build Unity 2021 DEV WebGL test fixture
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: "webgl-2021-dev-fixture"
         env:
           UNITY_VERSION: *2021
@@ -269,7 +269,7 @@ steps:
         concurrency_method: eager
 
       - label: Run MacOS e2e tests for Unity 2021
-        timeout_in_minutes: 60
+        timeout_in_minutes: 30
         depends_on: 'macos-2021-fixture'
         agents:
           queue: macos-14
@@ -311,7 +311,7 @@ steps:
           - scripts/ci-run-macos-tests.sh dev
 
       - label: Run WebGL e2e tests for Unity 2021
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         depends_on: 'webgl-2021-fixture'
         env:
           UNITY_VERSION: *2021
@@ -330,7 +330,7 @@ steps:
           - scripts/ci-run-webgl-tests.sh release
 
       - label: Run WebGL e2e DEV tests for Unity 2021
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         depends_on: 'webgl-2021-dev-fixture'
         env:
           UNITY_VERSION: *2021

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -272,7 +272,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: 'macos-2021-fixture'
         agents:
-          queue: macos-12-arm-unity
+          queue: macos-14
         env:
           UNITY_VERSION: *2021
         plugins:
@@ -293,7 +293,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: 'macos-2021-dev-fixture'
         agents:
-          queue: macos-12-arm-unity
+          queue: macos-14
         env:
           UNITY_VERSION: *2021
         plugins:

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -8,7 +8,7 @@ steps:
   - group: ":hammer: Build Unity 2021 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 2021"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: "build-android-fixture-2021"
         env:
           UNITY_VERSION: *2021
@@ -31,7 +31,7 @@ steps:
       # Build iOS test fixtures
       #
       - label: ":ios: Generate Xcode project - Unity 2021"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: "generate-fixture-project-2021"
         env:
           UNITY_VERSION: *2021
@@ -52,7 +52,7 @@ steps:
               limit: 1
 
       - label: ":ios: Build iOS test fixture for Unity 2021"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "build-ios-fixture-2021"
         depends_on: "generate-fixture-project-2021"
         env:

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -28,7 +28,7 @@ steps:
               limit: 1
 
       - label: ":ios: Generate Xcode project - Unity 2022"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "generate-fixture-project-2022"
         env:
           UNITY_VERSION: *2022
@@ -49,7 +49,7 @@ steps:
               limit: 1
 
       - label: ":ios: Build iOS test fixture for Unity 2022"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "build-ios-fixture-2022"
         depends_on: "generate-fixture-project-2022"
         env:
@@ -73,7 +73,7 @@ steps:
               limit: 1
 
       - label: Build Unity 2022 MacOS fixture
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "macos-2022-fixture"
         env:
           UNITY_VERSION: *2022
@@ -93,7 +93,7 @@ steps:
               limit: 1
 
       - label: Build Unity 2022 WebGL test fixture
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "webgl-2022-fixture"
         env:
           UNITY_VERSION: *2022

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -8,7 +8,7 @@ steps:
   - group: ":hammer: Build Unity 6000 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 6000"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 20
         key: "build-android-fixture-6000"
         env:
           UNITY_VERSION: *6000
@@ -28,7 +28,7 @@ steps:
               limit: 1
 
       - label: ":ios: Generate Xcode project - Unity 6000"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "generate-fixture-project-6000"
         env:
           UNITY_VERSION: *6000
@@ -49,7 +49,7 @@ steps:
               limit: 1
 
       - label: ":ios: Build iOS test fixture for Unity 6000"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "build-ios-fixture-6000"
         depends_on: "generate-fixture-project-6000"
         env:
@@ -73,7 +73,7 @@ steps:
               limit: 1
 
       - label: Build Unity 6000 MacOS test fixture
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "macos-6000-fixture"
         env:
           UNITY_VERSION: *6000
@@ -93,7 +93,7 @@ steps:
               limit: 1
 
       - label: Build Unity 6000 WebGL test fixture
-        timeout_in_minutes: 30
+        timeout_in_minutes: 10
         key: "webgl-6000-fixture"
         env:
           UNITY_VERSION: *6000

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -211,7 +211,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: 'macos-6000-fixture'
         agents:
-          queue: macos-12-arm
+          queue: macos-14
         env:
           UNITY_VERSION: *6000
         plugins:


### PR DESCRIPTION
## Goal

General tidy-up of the Buildkite pipeline to:
- Ensure all steps have an adequate but not excessive timeout
- Agent queues are explicitly stated in each file (even if a default is used)
- Generic `macos` queue is used instead of specific macOS versions where possible

## Testing

Covered by a full CI run.
