### PR TITLE
Release 8.3.0 UAT fixes

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagAddScriptingSymbol.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagAddScriptingSymbol.cs
@@ -3,47 +3,42 @@ using UnityEditor;
 using UnityEditor.Build;
 #endif
 using UnityEngine;
-[InitializeOnLoad]
-public class BugsnagAddScriptingSymbol : MonoBehaviour
+namespace BugsnagUnity.Editor
 {
-    private const string DEFINE_SYMBOL = "BUGSNAG_UNITY_WEB_REQUEST";
-
-    private static BuildTargetGroup[] _supportedPlatforms = { BuildTargetGroup.Android, BuildTargetGroup.Standalone, BuildTargetGroup.iOS, BuildTargetGroup.WebGL };
-
-    static BugsnagAddScriptingSymbol()
+    [InitializeOnLoad]
+    public class BugsnagAddScriptingSymbol : MonoBehaviour
     {
-        foreach (var target in _supportedPlatforms)
-        {
-            try
-            {
-                SetScriptingSymbol(target);
-            }
-            catch
-            {
-                // Some users might not have a platform installed, in that case ignore the error
-            }
-        }
-    }
+        private const string DEFINE_SYMBOL = "BUGSNAG_UNITY_WEB_REQUEST";
 
-    static void SetScriptingSymbol(BuildTargetGroup buildTargetGroup)
-    {
-        #if UNITY_6000_0_OR_NEWER
-            var existingSymbols = PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
-        #else
-            var existingSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
-        #endif
-        if (string.IsNullOrEmpty(existingSymbols))
+        private static BuildTargetGroup[] _supportedPlatforms = { BuildTargetGroup.Android, BuildTargetGroup.Standalone, BuildTargetGroup.iOS, BuildTargetGroup.WebGL };
+
+        static BugsnagAddScriptingSymbol()
         {
-            existingSymbols = DEFINE_SYMBOL;
+            foreach (var target in _supportedPlatforms)
+            {
+                try
+                {
+                    SetScriptingSymbol(target);
+                }
+                catch
+                {
+                    // Some users might not have a platform installed, in that case ignore the error
+                }
+            }
         }
-        else if (!existingSymbols.Contains(DEFINE_SYMBOL))
+
+        static void SetScriptingSymbol(BuildTargetGroup buildTargetGroup)
         {
-            existingSymbols += ";" + DEFINE_SYMBOL;
+            var existingSymbols = BugsnagPlayerSettingsCompat.GetScriptingDefineSymbols(buildTargetGroup);
+            if (string.IsNullOrEmpty(existingSymbols))
+            {
+                existingSymbols = DEFINE_SYMBOL;
+            }
+            else if (!existingSymbols.Contains(DEFINE_SYMBOL))
+            {
+                existingSymbols += ";" + DEFINE_SYMBOL;
+            }
+            BugsnagPlayerSettingsCompat.SetScriptingDefineSymbols(buildTargetGroup, existingSymbols);
         }
-        #if UNITY_6000_0_OR_NEWER
-            PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), existingSymbols);
-        #else
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, existingSymbols);
-        #endif
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagAddScriptingSymbol.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagAddScriptingSymbol.cs
@@ -1,7 +1,4 @@
 using UnityEditor;
-#if UNITY_6000_0_OR_NEWER
-using UnityEditor.Build;
-#endif
 using UnityEngine;
 namespace BugsnagUnity.Editor
 {

--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagAddScriptingSymbol.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagAddScriptingSymbol.cs
@@ -1,4 +1,7 @@
 using UnityEditor;
+#if UNITY_6000_0_OR_NEWER
+using UnityEditor.Build;
+#endif
 using UnityEngine;
 [InitializeOnLoad]
 public class BugsnagAddScriptingSymbol : MonoBehaviour
@@ -24,7 +27,11 @@ public class BugsnagAddScriptingSymbol : MonoBehaviour
 
     static void SetScriptingSymbol(BuildTargetGroup buildTargetGroup)
     {
-        var existingSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
+        #if UNITY_6000_0_OR_NEWER
+            var existingSymbols = PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+        #else
+            var existingSymbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
+        #endif
         if (string.IsNullOrEmpty(existingSymbols))
         {
             existingSymbols = DEFINE_SYMBOL;
@@ -33,6 +40,10 @@ public class BugsnagAddScriptingSymbol : MonoBehaviour
         {
             existingSymbols += ";" + DEFINE_SYMBOL;
         }
-        PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, existingSymbols);
+        #if UNITY_6000_0_OR_NEWER
+            PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), existingSymbols);
+        #else
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, existingSymbols);
+        #endif
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs
@@ -1,0 +1,37 @@
+using UnityEditor;
+
+namespace BugsnagUnity.Editor
+{
+    internal static class BugsnagPlayerSettingsCompat
+    {
+        // Get Scripting Backend
+        public static ScriptingImplementation GetScriptingBackend(BuildTargetGroup buildTargetGroup)
+        {
+#if UNITY_6000_0_OR_NEWER
+        return PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+#else
+            return PlayerSettings.GetScriptingBackend(buildTargetGroup);
+#endif
+        }
+
+        // Get Scripting Define Symbols
+        public static string GetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup)
+        {
+#if UNITY_6000_0_OR_NEWER
+        return PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+#else
+            return PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
+#endif
+        }
+
+        // Set Scripting Define Symbols
+        public static void SetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup, string defineSymbols)
+        {
+#if UNITY_6000_0_OR_NEWER
+        PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), defineSymbols);
+#else
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defineSymbols);
+#endif
+        }
+    }
+}

--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs
@@ -1,5 +1,7 @@
 using UnityEditor;
-
+#if UNITY_6000_0_OR_NEWER
+using UnityEditor.Build;
+#endif
 namespace BugsnagUnity.Editor
 {
     internal static class BugsnagPlayerSettingsCompat

--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs.meta
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7bbe25803445b4eb1803630ed345f4ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Bugsnag/Assets/Bugsnag/Editor/BuildPreprocessor.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BuildPreprocessor.cs
@@ -9,21 +9,26 @@ public class BuildPreprocessor : IPreprocessBuildWithReport
 
     public void OnPreprocessBuild(BuildReport report)
     {
-        // This will be enabled once IL2CPP source mapping is supported
-        // if (PlayerSettings.GetScriptingBackend(report.summary.platformGroup) != ScriptingImplementation.IL2CPP)
-        // {
-        //     return;
-        // }
-
-        // // Causes il2cpp to generate my-build-dir/Classes/Native/Symbols/LineNumberMappings.json
-        // // Note: It used to be stored in the project root dir as:
-        // //   my-build-dir_BackUpThisFolder_ButDontShipItWithYourGame/il2cppOutput/Symbols/LineNumberMappings.json
-        // const string emitIl2cppSourceMapping = "--emit-source-mapping";
-
-        // var args = PlayerSettings.GetAdditionalIl2CppArgs();
-        // if (!args.Contains(emitIl2cppSourceMapping))
-        // {
-        //     PlayerSettings.SetAdditionalIl2CppArgs(args + emitIl2cppSourceMapping);
-        // }
+        //This will be enabled once IL2CPP source mapping is supported
+        #if UNITY_6000_0_OR_NEWER
+        if (PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(report.summary.platformGroup)) != ScriptingImplementation.IL2CPP)
+        {
+            return;
+        }
+        #else
+        if (PlayerSettings.GetScriptingBackend(report.summary.platformGroup) != ScriptingImplementation.IL2CPP)
+        {
+            return;
+        }
+        #endif
+        // Causes il2cpp to generate my-build-dir/Classes/Native/Symbols/LineNumberMappings.json
+        // Note: It used to be stored in the project root dir as:
+        //   my-build-dir_BackUpThisFolder_ButDontShipItWithYourGame/il2cppOutput/Symbols/LineNumberMappings.json
+        const string emitIl2cppSourceMapping = "--emit-source-mapping";
+        var args = PlayerSettings.GetAdditionalIl2CppArgs();
+        if (!args.Contains(emitIl2cppSourceMapping))
+        {
+            PlayerSettings.SetAdditionalIl2CppArgs(args + emitIl2cppSourceMapping);
+        }
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Editor/BuildPreprocessor.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BuildPreprocessor.cs
@@ -2,33 +2,27 @@ using UnityEditor;
 using UnityEngine;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
-
-public class BuildPreprocessor : IPreprocessBuildWithReport
+namespace BugsnagUnity.Editor
 {
-    public int callbackOrder => 0;
-
-    public void OnPreprocessBuild(BuildReport report)
+    public class BuildPreprocessor : IPreprocessBuildWithReport
     {
-        //This will be enabled once IL2CPP source mapping is supported
-        #if UNITY_6000_0_OR_NEWER
-        if (PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(report.summary.platformGroup)) != ScriptingImplementation.IL2CPP)
+        public int callbackOrder => 0;
+
+        public void OnPreprocessBuild(BuildReport report)
         {
-            return;
-        }
-        #else
-        if (PlayerSettings.GetScriptingBackend(report.summary.platformGroup) != ScriptingImplementation.IL2CPP)
-        {
-            return;
-        }
-        #endif
-        // Causes il2cpp to generate my-build-dir/Classes/Native/Symbols/LineNumberMappings.json
-        // Note: It used to be stored in the project root dir as:
-        //   my-build-dir_BackUpThisFolder_ButDontShipItWithYourGame/il2cppOutput/Symbols/LineNumberMappings.json
-        const string emitIl2cppSourceMapping = "--emit-source-mapping";
-        var args = PlayerSettings.GetAdditionalIl2CppArgs();
-        if (!args.Contains(emitIl2cppSourceMapping))
-        {
-            PlayerSettings.SetAdditionalIl2CppArgs(args + emitIl2cppSourceMapping);
+            if (BugsnagPlayerSettingsCompat.GetScriptingBackend(report.summary.platformGroup) != ScriptingImplementation.IL2CPP)
+            {
+                return;
+            }
+            // Causes il2cpp to generate my-build-dir/Classes/Native/Symbols/LineNumberMappings.json
+            // Note: It used to be stored in the project root dir as:
+            //   my-build-dir_BackUpThisFolder_ButDontShipItWithYourGame/il2cppOutput/Symbols/LineNumberMappings.json
+            const string emitIl2cppSourceMapping = "--emit-source-mapping";
+            var args = PlayerSettings.GetAdditionalIl2CppArgs();
+            if (!args.Contains(emitIl2cppSourceMapping))
+            {
+                PlayerSettings.SetAdditionalIl2CppArgs(args + emitIl2cppSourceMapping);
+            }
         }
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Editor/BuildPreprocessor.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BuildPreprocessor.cs
@@ -9,20 +9,21 @@ public class BuildPreprocessor : IPreprocessBuildWithReport
 
     public void OnPreprocessBuild(BuildReport report)
     {
-        if (PlayerSettings.GetScriptingBackend(report.summary.platformGroup) != ScriptingImplementation.IL2CPP)
-        {
-            return;
-        }
+        // This will be enabled once IL2CPP source mapping is supported
+        // if (PlayerSettings.GetScriptingBackend(report.summary.platformGroup) != ScriptingImplementation.IL2CPP)
+        // {
+        //     return;
+        // }
 
-        // Causes il2cpp to generate my-build-dir/Classes/Native/Symbols/LineNumberMappings.json
-        // Note: It used to be stored in the project root dir as:
-        //   my-build-dir_BackUpThisFolder_ButDontShipItWithYourGame/il2cppOutput/Symbols/LineNumberMappings.json
-        const string emitIl2cppSourceMapping = "--emit-source-mapping";
+        // // Causes il2cpp to generate my-build-dir/Classes/Native/Symbols/LineNumberMappings.json
+        // // Note: It used to be stored in the project root dir as:
+        // //   my-build-dir_BackUpThisFolder_ButDontShipItWithYourGame/il2cppOutput/Symbols/LineNumberMappings.json
+        // const string emitIl2cppSourceMapping = "--emit-source-mapping";
 
-        var args = PlayerSettings.GetAdditionalIl2CppArgs();
-        if (!args.Contains(emitIl2cppSourceMapping))
-        {
-            PlayerSettings.SetAdditionalIl2CppArgs(args + emitIl2cppSourceMapping);
-        }
+        // var args = PlayerSettings.GetAdditionalIl2CppArgs();
+        // if (!args.Contains(emitIl2cppSourceMapping))
+        // {
+        //     PlayerSettings.SetAdditionalIl2CppArgs(args + emitIl2cppSourceMapping);
+        // }
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Reflection;
+[assembly: AssemblyVersion("8.3.0.0")]

--- a/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs.meta
+++ b/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2623cd03ba5e94654b458c985fdee049
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ bundle exec maze-runner features/handled_errors.feature
 
 2. Checkout the `next` branch.
 
-3. Set the new version in `CHANGELOG.md`
+3. Set the new version in `CHANGELOG.md` and `Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs`
 
 4. Make a pull request to merge the changes into `master`
 


### PR DESCRIPTION
## Changeset

- Add `AssemblyInfo.cs` file so that the version is available for the Editor window to display.
- Update `BugsnagAddScriptingSymbol.cs` and IL2CPP BuildPreprocessor to stop warnings in Unity v6.
