### PR TITLE
allow for the notifier to be started on RuntimeInitializeLoadType.SubsystemRegistration

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/BugsnagAutoInit.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/BugsnagAutoInit.cs
@@ -4,7 +4,7 @@ namespace BugsnagUnity
 
     public class BugsnagAutoInit
     {
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void OnBeforeSceneLoadRuntimeMethod()
         {
             var settings = Resources.Load<BugsnagSettingsObject>("Bugsnag/BugsnagSettingsObject");

--- a/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
@@ -116,7 +116,6 @@ namespace BugsnagUnity
 
         public Client(INativeClient nativeClient)
         {
-            InitMainthreadDispatcher();
             NativeClient = nativeClient;
             _errorBuilder = new ErrorBuilder(nativeClient);
             CacheManager = new CacheManager(Configuration);
@@ -142,11 +141,6 @@ namespace BugsnagUnity
             ListenForSceneLoad();
             SetupNetworkListeners();
             InitLogHandlers();
-        }
-
-        private void InitMainthreadDispatcher()
-        {
-            MainThreadDispatchBehaviour.Instance();
         }
 
         private bool IsUnity2019OrHigher()
@@ -384,8 +378,7 @@ namespace BugsnagUnity
             {
                 try
                 {
-                    var asyncHandler = MainThreadDispatchBehaviour.Instance();
-                    asyncHandler.Enqueue(() => { NotifyOnMainThread(exceptions, handledState, callback,logType, correlation); });
+                    MainThreadDispatchBehaviour.Enqueue(() => { NotifyOnMainThread(exceptions, handledState, callback,logType, correlation); });
                 }
                 catch
                 {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Delivery.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Delivery.cs
@@ -91,7 +91,7 @@ namespace BugsnagUnity
             }
             try
             {
-                MainThreadDispatchBehaviour.Instance().Enqueue(PushToServer(payload));
+                MainThreadDispatchBehaviour.Enqueue(PushToServer(payload));
             }
             catch
             {
@@ -508,7 +508,7 @@ namespace BugsnagUnity
             try
             {
                 _finishedCacheDeliveries.Clear();
-                MainThreadDispatchBehaviour.Instance().Enqueue(DeliverCachedPayloads());
+                MainThreadDispatchBehaviour.Enqueue(DeliverCachedPayloads());
             }
             catch
             {

--- a/Bugsnag/Assets/Bugsnag/Runtime/MainThreadDispatchBehaviour.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/MainThreadDispatchBehaviour.cs
@@ -29,7 +29,7 @@ namespace BugsnagUnity
 
         private static readonly Queue<Action> _executionQueue = new Queue<Action>();
 
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void InitializeLoop()
         {
             var playerLoop = PlayerLoop.GetCurrentPlayerLoop();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+- Allow the notifier to be started much earlier in the Unity lifecycle. [#862](https://github.com/bugsnag/bugsnag-unity/pull/862)
+
 ## 8.3.0 (2024-12-02)
 
 ### Enhancements


### PR DESCRIPTION
DO NOT MERGE UNTIL AFTER WINTER CODE FREEZE

## Goal

Previously it was not safe to start the notifier earlier than `RuntimeInitializeLoadType.BeforeSceneLoad` because we relied on a gameobject to make sure certain actions happened on the main thread. 

Creating a gameobject before the BeforeSceneLoad event can lead to unexpected behavior such as null reference exceptions because the object is destroyed unexpectedly or not created at all.

With this change it is safe to start at the earliest possible point in the unity lifecycle, SubsystemRegistration.

C# sessions and events will still not be delivered until the same point as before but events occurring before `BeforeSceneLoad` will be queued and the native notifiers will be started much earlier.

## Changeset

Changed main thread dispatcher to allow for queuing work without creating a gameobject until later in the unity lifecycle.

## Testing

Covered by existing e2e tests