### PR TITLE
fix for legacy perf sdk versions

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagEditPerformanceAssemblyDeff.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagEditPerformanceAssemblyDeff.cs
@@ -1,0 +1,72 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+namespace BugsnagUnity.Editor
+{
+[InitializeOnLoad]
+public class BugsnagEditPerformanceAssemblyDeff
+{
+
+    // This script fixes and issue in versions 1.7.0 and bellow of the Bugsnag Performance package.
+    // The issue is that the BugsnagPerformance.asmdef file is not correctly configured to reference the BugsnagUnity package.
+    // And therefore cannot access the version of the BugsnagUnityWebRequest class packaged with the notifier.
+    // A fix for this issue was released in the 1.7.1 version of the Bugsnag Performance package. 
+    // So this fix is only to support using legacy versions of the perf sdk.
+
+    static BugsnagEditPerformanceAssemblyDeff()
+    {
+        FixBugsnagPerformanceAsmdef();
+    }
+    public static void FixBugsnagPerformanceAsmdef()
+    {
+        string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+        string packageCachePath = Path.Combine(projectRoot, "Library", "PackageCache");
+        if (!Directory.Exists(packageCachePath))
+        {
+            // Package cache directory doesn't exist, so we can't fix the asmdef
+            return;
+        }
+        string[] matchingDirs = Directory.GetDirectories(packageCachePath, "com.bugsnag.performance.unity*");
+        if (matchingDirs.Length == 0)
+        {
+            // No Bugsnag Performance package found
+            return;
+        }
+
+        string bugsnagPackageDir = matchingDirs[0];
+        string asmdefPath = Path.Combine(bugsnagPackageDir, "Runtime", "Scripts", "BugsnagPerformance.asmdef");
+        if (!File.Exists(asmdefPath))
+        {
+            return;
+        }
+        string originalJson = File.ReadAllText(asmdefPath).Trim();
+        string minimalJson = "{\n\t\"name\": \"BugsnagPerformance\"\n}";
+        string minimalJsonNoWhitespace = "{\"name\":\"BugsnagPerformance\"}";
+        bool isMinimal = originalJson == minimalJson || originalJson == minimalJsonNoWhitespace;
+        if (!isMinimal)
+        {
+            // The asmdef is already expanded, so we don't need to do anything
+            return;
+        }
+
+        string expandedJson = @"{
+    ""name"": ""BugsnagPerformance"",
+    ""rootNamespace"": """",
+    ""references"": [
+        ""BugsnagUnity""
+    ],
+    ""includePlatforms"": [],
+    ""excludePlatforms"": [],
+    ""allowUnsafeCode"": false,
+    ""overrideReferences"": false,
+    ""precompiledReferences"": [],
+    ""autoReferenced"": true,
+    ""defineConstraints"": [],
+    ""versionDefines"": [],
+    ""noEngineReferences"": false
+}";
+        File.WriteAllText(asmdefPath, expandedJson);
+        AssetDatabase.Refresh();
+    }
+}
+}

--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagEditPerformanceAssemblyDeff.cs.meta
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagEditPerformanceAssemblyDeff.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 626d8d7541b544aa1aefe6dc6eb22f99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Goal

This change fixes an issue when using the notifier with versions 1.7.0 and below of the Bugsnag Performance package.

The issue is that the BugsnagPerformance.asmdef file is not correctly configured to reference the new BugsnagUnity.asmdef and therefore cannot access the version of the BugsnagUnityWebRequest class packaged with the notifier.

A fix for this issue was released in the 1.7.1 version of the Bugsnag Performance package. 
So this fix is only to support using legacy versions of the perf sdk with the notifier.

## Changeset

- Added a script that searches the project local package cache for the perf sdk. if it finds it then it updates the BugsnagPerformance.asmdef file to reference the notifier assembly.

## Testing

Manually tested in Unity 2021 and 6000