### PR TITLE
fix for incorrect session handled/unhandled event counts

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
@@ -465,7 +465,7 @@ namespace BugsnagUnity
                 {
                     try
                     {
-                        if (!onErrorCallback.Invoke(@event))
+                        if (!RunEventCallback(onErrorCallback, @event))
                         {
                             return;
                         }
@@ -481,7 +481,7 @@ namespace BugsnagUnity
             {
                 if (callback != null)
                 {
-                    if (!callback.Invoke(@event))
+                    if (!RunEventCallback(callback, @event))
                     {
                         return;
                     }
@@ -505,6 +505,24 @@ namespace BugsnagUnity
                     }
                     SessionTracking.AddException(report);
                 }
+            }
+        }
+
+        private bool RunEventCallback(Func<IEvent,bool> callback, IEvent @event)
+        {
+            try
+            {
+                var initialUnhandledState = @event.Unhandled;
+                var callbackResult = callback.Invoke(@event);
+                if (initialUnhandledState != @event.Unhandled)
+                {
+                    ((Payload.Event)@event).UnhandledOverridden();
+                }
+                return callbackResult;
+            }
+            catch
+            {
+                return true;
             }
         }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Delivery.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Delivery.cs
@@ -73,7 +73,7 @@ namespace BugsnagUnity
                         {
                             try
                             {
-                                if (!onSendErrorCallback.Invoke(report.Event))
+                                if (!RunEventCallback(onSendErrorCallback, report.Event))
                                 {
                                     return;
                                 }
@@ -96,6 +96,24 @@ namespace BugsnagUnity
             catch
             {
                 // not avaliable in unit tests
+            }
+        }
+
+         private bool RunEventCallback(Func<IEvent,bool> callback, IEvent @event)
+        {
+            try
+            {
+                var initialUnhandledState = @event.Unhandled;
+                var callbackResult = callback.Invoke(@event);
+                if (initialUnhandledState != @event.Unhandled)
+                {
+                    ((Payload.Event)@event).UnhandledOverridden();
+                }
+                return callbackResult;
+            }
+            catch
+            {
+                return true;
             }
         }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Event.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Event.cs
@@ -38,7 +38,14 @@ namespace BugsnagUnity.Payload
             Breadcrumbs = new ReadOnlyCollection<IBreadcrumb>(breadcrumbsList);
             if (session != null)
             {
-                session.Events.UpdateEventCount(handledState.Handled, true);
+                if(handledState.Handled)
+                {
+                    session.Events.UpdateHandledCount(true);
+                }
+                else
+                {
+                    session.Events.UpdateUnhandledCount(true);
+                }
                 Session = session;
             }
             _featureFlags = featureFlags;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Event.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Event.cs
@@ -36,7 +36,7 @@ namespace BugsnagUnity.Payload
                 breadcrumbsList.Add(crumb);
             }
             Breadcrumbs = new ReadOnlyCollection<IBreadcrumb>(breadcrumbsList);
-
+            _originalUnhandledState = !handledState.Handled;
             if (session != null)
             {
                 if (handledState.Handled)
@@ -53,7 +53,7 @@ namespace BugsnagUnity.Payload
         }
 
         internal Event(Dictionary<string, object> serialisedPayload)
-        {        
+        {
             ApiKey = serialisedPayload["apiKey"].ToString();
 
             var eventObject = (Dictionary<string, object>)serialisedPayload["event"];
@@ -66,7 +66,7 @@ namespace BugsnagUnity.Payload
             {
                 Add("unhandled", false);
             }
-            
+
             if (eventObject["severity"] != null)
             {
                 Add("severity", eventObject["severity"]);
@@ -162,6 +162,8 @@ namespace BugsnagUnity.Payload
             _androidProjectPackages = packages;
         }
 
+        private bool _originalUnhandledState;
+
         private OrderedDictionary _featureFlags;
 
         HandledState _handledState;
@@ -172,13 +174,13 @@ namespace BugsnagUnity.Payload
 
         private Metadata _metadata { get; }
 
-        public void AddMetadata(string section, string key, object value) => _metadata.AddMetadata(section,key,value);
+        public void AddMetadata(string section, string key, object value) => _metadata.AddMetadata(section, key, value);
 
         public void AddMetadata(string section, IDictionary<string, object> metadata) => _metadata.AddMetadata(section, metadata);
 
         public IDictionary<string, object> GetMetadata(string section) => _metadata.GetMetadata(section);
 
-        public object GetMetadata(string section, string key) => _metadata.GetMetadata(section,key);
+        public object GetMetadata(string section, string key) => _metadata.GetMetadata(section, key);
 
         public void ClearMetadata(string section) => _metadata.ClearMetadata(section);
 
@@ -198,30 +200,37 @@ namespace BugsnagUnity.Payload
 
         internal LogType? LogType { get; }
 
-        public bool Unhandled {     
-        get {
-            var currentValue = Get("unhandled"); 
-            if (currentValue == null) 
-            {
-                return false;
-            }
-            return (bool)currentValue;
-        } 
-        set => Add("unhandled",value); 
-        }
-
-        internal bool IsHandled
+        public bool Unhandled
         {
             get
             {
-                if (Get("unhandled") is bool unhandled)
+                var currentValue = Get("unhandled");
+                if (currentValue == null)
                 {
-                    return !unhandled;
+                    return false;
                 }
-
-                return false;
+                return (bool)currentValue;
+            }
+            set
+            {
+                if(value != _originalUnhandledState && Session != null)
+                {
+                    if (value)
+                    {
+                        Session.Events.IncrementUnhandledCount();
+                        Session.Events.DecrementHandledCount();
+                    }
+                    else
+                    {
+                        Session.Events.IncrementHandledCount();
+                        Session.Events.DecrementUnhandledCount();
+                    }
+                }
+                Add("unhandled", value);
             }
         }
+
+
 
         public string Context { get; set; }
 
@@ -238,7 +247,7 @@ namespace BugsnagUnity.Payload
         public List<IError> Errors { get; }
 
         public string GroupingHash { get; set; }
-        
+
         public Severity Severity
         {
             set => HandledState = HandledState.ForCallbackSpecifiedSeverity(value, _handledState);
@@ -253,7 +262,7 @@ namespace BugsnagUnity.Payload
 
         public void SetUser(string id, string email, string name)
         {
-            _user = new User(id, email, name );
+            _user = new User(id, email, name);
         }
 
         internal bool IsAndroidJavaError()
@@ -317,7 +326,7 @@ namespace BugsnagUnity.Payload
             Add("groupingHash", GroupingHash);
             Add("payloadVersion", PayloadVersion);
             Add("exceptions", _errors);
-            if(Correlation != null)
+            if (Correlation != null)
             {
                 Add("correlation", Correlation.Payload);
             }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/HandledState.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/HandledState.cs
@@ -9,6 +9,12 @@ namespace BugsnagUnity.Payload
     /// </summary>
     class HandledState : Dictionary<string, object>
     {
+
+        public void UnhandledOverridden()
+        {
+            var severityReason = this["severityReason"] as SeverityReason;
+            severityReason["unhandledOverridden"] = true;
+        }
         /// <summary>
         /// Creates a HandledState object for an error report payload where the exception was not handled by the application
         /// and caught by a global error handler.
@@ -145,6 +151,7 @@ namespace BugsnagUnity.Payload
             {
                 this.AddToPayload("type", type);
                 this.AddToPayload("attributes", attributes);
+                this.AddToPayload("unhandledOverridden",false);
             }
         }
     }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Report.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Report.cs
@@ -64,7 +64,7 @@ namespace BugsnagUnity.Payload
 
         internal Session Session => Event.Session;
 
-        internal bool IsHandled => Event.IsHandled;
+        internal bool IsHandled => !Event.Unhandled;
 
         internal string Context => Event.Context;
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
@@ -116,11 +116,27 @@ namespace BugsnagUnity.Payload
             }
         }
 
+        internal void DecrementHandledCount()
+        {
+            lock (_handledLock)
+            {
+                this["handled"]--;
+            }
+        }
+
         internal void IncrementUnhandledCount()
         {
             lock (_unhandledLock)
             {
                 this["unhandled"]++;
+            }
+        }
+
+        internal void DecrementUnhandledCount()
+        {
+            lock (_unhandledLock)
+            {
+                this["unhandled"]--;
             }
         }
     }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
@@ -74,7 +74,14 @@ namespace BugsnagUnity.Payload
 
         internal void AddException(Report report)
         {
-            Events.UpdateEventCount(report.IsHandled, true);
+            if(report.IsHandled)
+            {
+                Events.UpdateHandledCount(true);
+            }
+            else
+            {
+                Events.UpdateUnhandledCount(true);
+            }
         }
 
         internal Session Copy()
@@ -103,7 +110,7 @@ namespace BugsnagUnity.Payload
         internal int Handled => this[HANDLED_KEY];
         internal int Unhandled => this[UNHANDLED_KEY];
 
-        internal void UpdateEventCount(bool handled, bool increment)
+        private void UpdateEventCount(bool handled, bool increment)
         {
             lock (_lock)
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fixed an issue where session handled/unhandled event counts were not updated if the handled status of the event was changed in a callback. [#865](https://github.com/bugsnag/bugsnag-unity/pull/865)
+
 ## 8.3.1 (2024-12-09)
 
 ### Bug Fixes

--- a/features/csharp/csharp_callbacks.feature
+++ b/features/csharp/csharp_callbacks.feature
@@ -5,17 +5,26 @@ Feature: Callbacks
 
   Scenario: OnError callbacks in config
     When I run the game in the "OnErrorInConfig" state
+    And I wait to receive a session
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
 
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "Error 1"
     And all possible parameters have been edited in a callback
+    And the event "session.events.unhandled" equals 1
+    And the event "session.events.handled" equals 0
+
+
     And I discard the oldest error
 
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "Error 2"
     And all possible parameters have been edited in a callback
+    And the event "session.events.unhandled" equals 2
+    And the event "session.events.handled" equals 0
+
+
 
   Scenario: OnError callbacks added after Start
     When I run the game in the "OnErrorAfterStart" state

--- a/features/csharp/csharp_callbacks.feature
+++ b/features/csharp/csharp_callbacks.feature
@@ -5,7 +5,6 @@ Feature: Callbacks
 
   Scenario: OnError callbacks in config
     When I run the game in the "OnErrorInConfig" state
-    And I wait to receive a session
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
 
@@ -21,10 +20,6 @@ Feature: Callbacks
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "Error 2"
     And all possible parameters have been edited in a callback
-    And the event "session.events.unhandled" equals 2
-    And the event "session.events.handled" equals 0
-
-
 
   Scenario: OnError callbacks added after Start
     When I run the game in the "OnErrorAfterStart" state
@@ -71,3 +66,34 @@ Feature: Callbacks
     And I wait to receive 1 session
     And all possible parameters have been edited in a session callback
 
+  Scenario: Edit handled state in callbacks
+    When I run the game in the "EditUnhandled" state
+    And I wait to receive 4 errors
+
+    # Error 1
+    And the exception "message" equals "Control"
+    And the event "unhandled" is false
+    And the event "severityReason.unhandledOverridden" is false
+    And the event "session.events.unhandled" equals 0
+    And the event "session.events.handled" equals 1
+    And I discard the oldest error
+
+    And the exception "message" equals "HandledInNotifyCallback"
+    And the event "unhandled" is true
+    And the event "severityReason.unhandledOverridden" is true
+    And the event "session.events.unhandled" equals 1
+    And the event "session.events.handled" equals 1
+    And I discard the oldest error
+
+    And the exception "message" equals "HandledInOnSendCallback"
+    And the event "unhandled" is true
+    And the event "severityReason.unhandledOverridden" is true
+    And the event "session.events.unhandled" equals 2
+    And the event "session.events.handled" equals 1
+    And I discard the oldest error
+
+    And the exception "message" equals "UnhandledInOnErrorCallback"
+    And the event "unhandled" is false
+    And the event "severityReason.unhandledOverridden" is true
+    And the event "session.events.unhandled" equals 2
+    And the event "session.events.handled" equals 2

--- a/features/csharp/csharp_callbacks.feature
+++ b/features/csharp/csharp_callbacks.feature
@@ -7,13 +7,9 @@ Feature: Callbacks
     When I run the game in the "OnErrorInConfig" state
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
-
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "Error 1"
     And all possible parameters have been edited in a callback
-    And the event "session.events.unhandled" equals 1
-    And the event "session.events.handled" equals 0
-
 
     And I discard the oldest error
 

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -15,6 +15,8 @@ Feature: csharp events
       | NotifySmokeTest.Run()                                                       | Main+<RunNextMazeCommand>d__8.MoveNext() |
     And expected device metadata is included in the event
     And expected app metadata is included in the event
+    And the error payload field "events.0.severityReason.unhandledOverridden" is false
+
 
   Scenario: Uncaught Exception smoke test
     When I run the game in the "UncaughtExceptionSmokeTest" state

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -38,7 +38,6 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311932, g: 0.38073996, b: 0.3587271, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1146,6 +1145,7 @@ GameObject:
   - component: {fileID: 1160627406}
   - component: {fileID: 1160627409}
   - component: {fileID: 1160627407}
+  - component: {fileID: 1160627410}
   m_Layer: 0
   m_Name: Callbacks
   m_TagString: Untagged
@@ -1264,6 +1264,18 @@ MonoBehaviour:
 
     Main.CUSTOM2
     () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &1160627410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1160627402}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df293b62197504f21a7d582167548183, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1338701864
 GameObject:
   m_ObjectHideFlags: 0
@@ -1394,6 +1406,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3cbe76e3ceae047ee85769786e2840dd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2
+    () (at Assets/Scripts/Main.cs:123)'
 --- !u!114 &1338701872
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1406,6 +1422,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36160400d18884e48983505794649646, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2
+    () (at Assets/Scripts/Main.cs:123)'
 --- !u!1 &1388241496
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -157,7 +157,6 @@ public class Scenario : MonoBehaviour
         @event.AddMetadata("test1", new Dictionary<string, object> { { "test", "test" } });
         @event.AddMetadata("test2", new Dictionary<string, object> { { "test", "test" } });
         @event.ClearMetadata("test2");
-        @event.Unhandled = true;
         @event.AddFeatureFlag("fromCallback", "a");
 
         return true;

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -157,7 +157,7 @@ public class Scenario : MonoBehaviour
         @event.AddMetadata("test1", new Dictionary<string, object> { { "test", "test" } });
         @event.AddMetadata("test2", new Dictionary<string, object> { { "test", "test" } });
         @event.ClearMetadata("test2");
-
+        @event.Unhandled = true;
         @event.AddFeatureFlag("fromCallback", "a");
 
         return true;

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/EditUnhandled.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/EditUnhandled.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections;
+using BugsnagUnity;
+using UnityEngine;
+
+public class EditUnhandled : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.AddOnError(SimpleEventCallback);
+        Configuration.ReportExceptionLogsAsHandled = false;
+        Configuration.AddOnError(OnErrorCallback);
+        Configuration.AddOnSendError(OnSendCallback);
+    }
+
+    public override void Run()
+    {
+        Bugsnag.StartSession();
+        StartCoroutine(DoTest());
+    }
+
+    private IEnumerator DoTest()
+    {
+        Bugsnag.Notify(new Exception("Control"));
+        yield return new WaitForSeconds(1);
+        Bugsnag.Notify(new Exception("HandledInNotifyCallback"), (report) =>
+        {
+            report.Unhandled = true;
+            return true;
+        });
+        yield return new WaitForSeconds(1);
+        Bugsnag.Notify(new Exception("HandledInOnSendCallback"));
+        yield return new WaitForSeconds(1);
+        throw new Exception("UnhandledInOnErrorCallback");
+    }
+
+    private bool OnErrorCallback(IEvent @event)
+    {
+        if (@event.Errors[0].ErrorMessage == "UnhandledInOnErrorCallback")
+        {
+            @event.Unhandled = false;
+            return true;
+        }
+        return true;
+    }
+    private bool OnSendCallback(IEvent @event)
+    {
+        if (@event.Errors[0].ErrorMessage == "HandledInOnSendCallback")
+        {
+            @event.Unhandled = true;
+            return true;
+        }
+        return true;
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/EditUnhandled.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/EditUnhandled.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df293b62197504f21a7d582167548183
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnErrorInConfig.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnErrorInConfig.cs
@@ -11,6 +11,7 @@ public class OnErrorInConfig : Scenario
 
     public override void Run()
     {
+        Bugsnag.StartSession();
         Bugsnag.Notify(new Exception("Error 1"));
         throw new Exception("Error 2");
     }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnErrorInConfig.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnErrorInConfig.cs
@@ -11,7 +11,6 @@ public class OnErrorInConfig : Scenario
 
     public override void Run()
     {
-        Bugsnag.StartSession();
         Bugsnag.Notify(new Exception("Error 1"));
         throw new Exception("Error 2");
     }


### PR DESCRIPTION
## Goal

The session handled/unhandled event counts were not updated if the handled status of the event was changed in a callback.

Additionally, events are supposed to have a `unhandledOverridden` property within the severity reason object, this was added.

## Changeset

- Updated `Event.cs` to track changes in the handled state and update session event counts as needed.
- Removed unnecessary property `Event.IsHandled`.
- Added `unhandledOverridden` to severity reason.


## Testing

Added a new E2E callback test