### PR TITLE
enable minification support

### DIFF
--- a/bugsnag-android-unity/build.gradle
+++ b/bugsnag-android-unity/build.gradle
@@ -29,6 +29,7 @@ android {
             }
         }
         ndkVersion = "21.4.7075529"
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     externalNativeBuild {

--- a/bugsnag-android-unity/proguard-rules.pro
+++ b/bugsnag-android-unity/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.bugsnag.android.** {*;}

--- a/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
+++ b/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
@@ -269,6 +269,9 @@ PlayerSettings:
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
   resolutionDialogBanner: {fileID: 0}
+  AndroidMinifyWithR8: 1
+  AndroidMinifyRelease: 1
+  AndroidMinifyDebug: 1
   m_BuildTargetIcons: []
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: Android


### PR DESCRIPTION
## Goal

When minification is enabled some classes from the native android sdk are stripped because calls from the unity C# to the native android SDK are not detected by the minifier and so it doesnt think they are used.

To fix this a pro guard file containing `-keep class com.bugsnag.android.** {*;}` has been added to the bugsnag android unity module.

## Testing

Minification has been enabled in the android e2e fixture so that we detect if anything is stripped.