### PR TITLE
build and test upm package on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -62,8 +62,6 @@ steps:
     env:
       UNITY_VERSION: *2021
     key: "import-upm-2020"
-    env:
-      UNITY_VERSION: *2020
     plugins:
       artifacts#v1.9.0:
         download:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,21 @@ steps:
         - exit_status: "*"
           limit: 1
 
+  - label: "Test UPM Package Import"
+    depends_on: build_unitypackage
+    timeout_in_minutes: 10
+    env:
+      UNITY_VERSION: *2021
+    key: "import-upm-2020"
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - upm-package.zip
+        upload:
+          - upm-import.log
+    commands:
+          - "features/scripts/test_upm_package_import.sh"
+
   - label: 'Run size impact reporting'
     depends_on: build_unitypackage
     timeout_in_minutes: 30
@@ -52,21 +67,3 @@ steps:
       queue: macos
     timeout_in_minutes: 2
     command: sh -c .buildkite/pipeline_trigger.sh
-
-      #
-      # test UPM import
-      #
-  - label: "Test UPM Package Import"
-    depends_on: build_unitypackage
-    timeout_in_minutes: 10
-    env:
-      UNITY_VERSION: *2021
-    key: "import-upm-2020"
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - upm-package.zip
-        upload:
-          - upm-import.log
-    commands:
-          - "features/scripts/test_upm_package_import.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,8 +13,11 @@ steps:
     commands:
       - bundle install
       - bundle exec rake plugin:export
+      - zip -r upm-package.zip upm-package
     artifact_paths:
       - Bugsnag.unitypackage
+      - upm-package.zip
+
     retry:
       automatic:
         - exit_status: "*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,3 +52,23 @@ steps:
       queue: macos
     timeout_in_minutes: 2
     command: sh -c .buildkite/pipeline_trigger.sh
+
+      #
+      # test UPM import
+      #
+  - label: "Test UPM Package Import"
+    depends_on: build_unitypackage
+    timeout_in_minutes: 10
+    env:
+      UNITY_VERSION: *2021
+    key: "import-upm-2020"
+    env:
+      UNITY_VERSION: *2020
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - upm-package.zip
+        upload:
+          - upm-import.log
+    commands:
+          - "features/scripts/test_upm_package_import.sh"

--- a/Rakefile
+++ b/Rakefile
@@ -247,6 +247,23 @@ def update_package_git(package_dir)
   end
 end
 
+def build_upm_package
+  assembly_info_path = File.join("Bugsnag", "Assets", "Bugsnag", "Runtime", "AssemblyInfo.cs")
+  version_match = File.read(assembly_info_path).match(/AssemblyVersion\("(\d+\.\d+\.\d+)/)
+
+  unless version_match
+    raise "Could not extract version from #{assembly_info_path}"
+  end
+
+  version = version_match[1]
+  script = File.join("upm", "build-upm-package.sh")
+  command = "#{script} #{version}"
+
+  unless system command
+    raise 'build upm package failed'
+  end
+end
+
 namespace :plugin do
   namespace :build do
     cocoa_build_dir = "bugsnag-cocoa-build"
@@ -414,6 +431,7 @@ namespace :plugin do
     Rake::Task["plugin:build:native_plugins"].invoke unless is_windows?
     run_unit_tests
     export_package("Bugsnag.unitypackage")
+    build_upm_package
   end
 end
 

--- a/features/scripts/test_upm_package_import.sh
+++ b/features/scripts/test_upm_package_import.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+if [ -z "$UNITY_VERSION" ]; then
+  echo "UNITY_VERSION must be set"
+  exit 1
+fi
+
+UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS"
+
+
+FIXTURE_PATH="features/fixtures/maze_runner"
+DEFAULT_CLI_ARGS="-batchmode -nographics -quit"
+
+# Proceed with unzipping the main package
+root_path=$(pwd)
+destination="features/fixtures/maze_runner/Packages"
+package="$root_path/upm-package.zip"
+
+rm -rf "$destination/package"
+unzip -q "$package" -d "$destination"
+
+# Remove the __MACOSX directory if it exists
+if [ -d "$destination/__MACOSX" ]; then
+  rm -rf "$destination/__MACOSX"
+fi
+
+echo "Package unzipped successfully"
+
+$UNITY_PATH/Unity -batchmode -quit -projectPath $FIXTURE_PATH -logFile upm-import.log -executeMethod UnityEditor.Compilation.CompilationPipeline.RequestScriptCompilation


### PR DESCRIPTION
## Goal

Before this change the UPM packaged released was always generated and import tested locally. Now it's done in the same moment as the Unity Package meaning there should never be a chance for differences between the released artifacts.

## Changeset

- build the upm package in the same command as the Unity Package.
- Upload it in a zip
- Test importing it into the fixture, if anything is wrong then compilation errors should happen and the step will fail.

## Testing

Currently only testing with Unity 2021, I don't think it's necessary to test every unity version as UPM compatibility is very general across the versions we support.