### PR TITLE
[PLAT-13460] Bump Unity Versions on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 aliases:
-  - &2021 "2021.3.36f1"
+  - &2021 "2021.3.45f1"
 
 agents:
   queue: macos-14

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -1,5 +1,5 @@
 aliases:
-  - &2021 "2021.3.36f1"
+  - &2021 "2021.3.45f1"
 
 agents:
   queue: macos-14

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -1,5 +1,5 @@
 aliases:
-  - &2021 "2021.3.36f1"
+  - &2021 "2021.3.45f1"
 
 agents:
   queue: macos-14

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -1,5 +1,5 @@
 aliases:
-  - &2022 "2022.3.22f1"
+  - &2022 "2022.3.57f1"
 
 agents:
   queue: macos-14

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -1,5 +1,5 @@
 aliases:
-  - &6000 "6000.0.25f1"
+  - &6000 "6000.0.36f1"
 
 agents:
   queue: macos-14


### PR DESCRIPTION
## Goal

Bump the version of Unity that we use on CI

Unity 2021 updated to 2021.3.45f1
Unity 2022 updated to 2022.3.57f1
Unity 6 updated to 6000.0.36f1

## Testing

Covered by CI