### PR TITLE
Android il2cpp stackframes

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeClient.cs
@@ -186,7 +186,7 @@ namespace BugsnagUnity
             {
                 StackTraceLine Frame = new StackTraceLine();
 
-                Frame.File = mainImageFileName;
+                Frame.File = TrimFilenameIfRequired(mainImageFileName);
                 Frame.Method = lines[i].Method;
                 Frame.FrameAddress = string.Format("0x{0:X}", nativeAddresses[i].ToInt64());
                 Frame.LoadAddress = "0x0";
@@ -200,6 +200,25 @@ namespace BugsnagUnity
             }
 
             return Trace;
+        }
+
+        private string TrimFilenameIfRequired(string filename)
+        {
+            // trim any excess characters from the filename that may appear after the `.so` extension
+            const string extension = ".so";
+            var lastSlashIndex = filename.LastIndexOf('/');
+            if (lastSlashIndex == -1)
+            {
+                return filename;
+            }
+
+            var extensionIndex = filename.LastIndexOf(extension, lastSlashIndex + 1);
+            if (extensionIndex == -1)
+            {
+                return filename;
+            }
+
+            return filename.Substring(0, extensionIndex + extension.Length);
         }
 
 #if ENABLE_IL2CPP && UNITY_2023_1_OR_NEWER

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/StackTraceLine.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/StackTraceLine.cs
@@ -191,6 +191,18 @@ namespace BugsnagUnity.Payload
             }
         }
 
+        public string LoadAddress
+        {
+            get
+            {
+                return this.Get("loadAddress") as string;
+            }
+            set
+            {
+                this.AddToPayload("loadAddress", value);
+            }
+        }
+
         public string MachoLoadAddress {
             get
             {
@@ -236,9 +248,44 @@ namespace BugsnagUnity.Payload
             }
         }
 
+        public string CodeIdentifier
+        {
+            get
+            {
+                return this.Get("codeIdentifier") as string;
+            }
+            set
+            {
+                this.AddToPayload("codeIdentifier", value);
+            }
+        }
+
+        public string Type
+        {
+            get
+            {
+                return this.Get("type") as string;
+            }
+            set
+            {
+                this.AddToPayload("type", value);
+            }
+        }
+
 
         public bool? IsLr { get; set; }
-        public bool? IsPc { get; set; }
+        public bool? IsPc
+        {
+            get
+            {
+                return this.Get("isPC") as bool?;
+            }
+            set
+            {
+                this.AddToPayload("isPC", value);
+            }
+        }
+
         public string MachoVmAddress { get; set; }
         public string SymbolAddress { get; set; }
     }

--- a/features/android/android_csharp_events.feature
+++ b/features/android/android_csharp_events.feature
@@ -3,6 +3,7 @@ Feature: csharp events on Android have a il2cpp addresses
   Background:
     Given I clear the Bugsnag cache
 
+  @skip_unity_2020
   Scenario: Android Uncaught Exception has il2cpp addresses
     When I run the game in the "UncaughtExceptionSmokeTest" state
     And I wait to receive an error
@@ -37,6 +38,7 @@ Feature: csharp events on Android have a il2cpp addresses
     And expected app metadata is included in the event
     And the error payload field "events.0.severityReason.unhandledOverridden" is false
 
+  @skip_unity_2020
   Scenario: Android Notify Exception has il2cpp addresses
     When I run the game in the "NotifySmokeTest" state
     And I wait to receive an error

--- a/features/android/android_csharp_events.feature
+++ b/features/android/android_csharp_events.feature
@@ -1,0 +1,38 @@
+Feature: csharp events on Android have a il2cpp addresses
+
+  Background:
+    Given I clear the Bugsnag cache
+
+  Scenario: Android Uncaught Exception
+    When I run the game in the "UncaughtExceptionSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "UncaughtExceptionSmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+
+    And the event "exceptions.0.stacktrace.0.loadAddress" equals "0x0"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.file" matches the regex ".*/libil2cpp.so$"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
+    And the event "exceptions.0.stacktrace.0.isPC" is true
+    And the event "exceptions.0.stacktrace.0.type" equals "c"
+
+    And the event "exceptions.0.stacktrace.1.loadAddress" equals "0x0"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.file" matches the regex ".*/libil2cpp.so$"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
+    And the event "exceptions.0.stacktrace.1.isPC" is true
+    And the event "exceptions.0.stacktrace.1.type" equals "c"
+
+    And the event "exceptions.0.stacktrace.2.loadAddress" equals "0x0"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.file" matches the regex ".*/libil2cpp.so$"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
+    And the event "exceptions.0.stacktrace.2.isPC" is true
+    And the event "exceptions.0.stacktrace.2.type" equals "c"
+
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+    And the error payload field "events.0.severityReason.unhandledOverridden" is false

--- a/features/android/android_csharp_events.feature
+++ b/features/android/android_csharp_events.feature
@@ -3,12 +3,46 @@ Feature: csharp events on Android have a il2cpp addresses
   Background:
     Given I clear the Bugsnag cache
 
-  Scenario: Android Uncaught Exception
+  Scenario: Android Uncaught Exception has il2cpp addresses
     When I run the game in the "UncaughtExceptionSmokeTest" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "errorClass" equals "Exception"
     And the exception "message" equals "UncaughtExceptionSmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+
+    And the event "exceptions.0.stacktrace.0.loadAddress" equals "0x0"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.file" matches the regex ".*/libil2cpp.so$"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
+    And the event "exceptions.0.stacktrace.0.isPC" is true
+    And the event "exceptions.0.stacktrace.0.type" equals "c"
+
+    And the event "exceptions.0.stacktrace.1.loadAddress" equals "0x0"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.file" matches the regex ".*/libil2cpp.so$"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
+    And the event "exceptions.0.stacktrace.1.isPC" is true
+    And the event "exceptions.0.stacktrace.1.type" equals "c"
+
+    And the event "exceptions.0.stacktrace.2.loadAddress" equals "0x0"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.file" matches the regex ".*/libil2cpp.so$"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
+    And the event "exceptions.0.stacktrace.2.isPC" is true
+    And the event "exceptions.0.stacktrace.2.type" equals "c"
+
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+    And the error payload field "events.0.severityReason.unhandledOverridden" is false
+
+  Scenario: Android Notify Exception has il2cpp addresses
+    When I run the game in the "NotifySmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "NotifySmokeTest"
     And the event "unhandled" is false
     And custom metadata is included in the event
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/NotifySmokeTest.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/NotifySmokeTest.cs
@@ -6,6 +6,13 @@ public class NotifySmokeTest : Scenario
     public override void Run()
     {
         AddTestingMetadata();
-        Bugsnag.Notify(new Exception("NotifySmokeTest"));
+        try
+        {
+          throw new Exception("NotifySmokeTest");
+        }
+        catch (System.Exception e)
+        {
+          Bugsnag.Notify(e);
+        }
     }
 }


### PR DESCRIPTION
## Goal
Report the native addresses from il2cpp on Android.

## Changes
Report the `FrameAddress` as returned from `il2cpp_native_stack_trace`, along with the `codeIdentifier` and `file` so that the frames can be identified and symbolicated.

## Testing
Manual testing and a new end-to-end feature based on existing smoke test scenarios.