### PR TITLE
Remove direct uses of Maze.driver

### DIFF
--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -1,11 +1,5 @@
 require 'cgi'
 
-When('On Mobile I relaunch the app') do
-  next unless %w[android ios].include? Maze::Helper.get_current_platform
-  Maze.driver.launch_app
-  sleep 3
-end
-
 def execute_command(action, scenario_name = '')
   command = {
     action: action,
@@ -342,21 +336,6 @@ Then("expected app metadata is included in the event") do
     And the event "metaData.app.companyName" equals "bugsnag"
     And the event "metaData.app.name" equals "Mazerunner"
   }
-end
-
-When("I clear any error dialogue") do
-  click_if_present 'android:id/button1'
-  click_if_present 'android:id/aerr_close'
-  click_if_present 'android:id/aerr_restart'
-end
-
-def click_if_present(element)
-  return false unless Maze.driver.wait_for_element(element, 1)
-
-  Maze.driver.click_element_if_present(element)
-rescue Selenium::WebDriver::Error::UnknownError
-  # Ignore Appium errors (e.g. during an ANR)
-  return false
 end
 
 def switch_run_on_target


### PR DESCRIPTION
## Goal

Remove direct uses of Maze.driver, as it does not handle failed drivers.  

## Design

Maze Runner's new API methods should be used instead - but as it turns out, these steps are not used anyway and so I'm just removing them as a cleanup operation.

## Testing

Covered by a basic CI run.