### PR TITLE
add the unity performance library to the test fixture

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs
@@ -1,5 +1,5 @@
 using UnityEditor;
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
 using UnityEditor.Build;
 #endif
 namespace BugsnagUnity.Editor
@@ -9,7 +9,7 @@ namespace BugsnagUnity.Editor
         // Get Scripting Backend
         public static ScriptingImplementation GetScriptingBackend(BuildTargetGroup buildTargetGroup)
         {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
         return PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
             return PlayerSettings.GetScriptingBackend(buildTargetGroup);
@@ -18,7 +18,7 @@ namespace BugsnagUnity.Editor
 
         public static string GetApplicationIdentifier(BuildTargetGroup buildTargetGroup)
         {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
                 return PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
                 return PlayerSettings.GetApplicationIdentifier(buildTargetGroup);
@@ -28,7 +28,7 @@ namespace BugsnagUnity.Editor
         // Get Scripting Define Symbols
         public static string GetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup)
         {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
         return PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
             return PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
@@ -38,7 +38,7 @@ namespace BugsnagUnity.Editor
         // Set Scripting Define Symbols
         public static void SetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup, string defineSymbols)
         {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
         PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), defineSymbols);
 #else
             PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defineSymbols);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+- Update Bugsnag Editor PlayerSettingsCompat to prevent compiler warnings. [#892](https://github.com/bugsnag/bugsnag-unity/pull/892)
+
 ## 8.5.1 (2025-03-03)
 
 ### Dependencies

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs
@@ -1,0 +1,40 @@
+using UnityEditor;
+namespace Mazerunner.Editor
+{
+    [InitializeOnLoad]
+    public class BugsnagAddScriptingSymbol
+    {
+        private const string DEFINE_SYMBOL = "UNITY_ASSERTIONS";
+
+        private static BuildTargetGroup[] _supportedPlatforms = { BuildTargetGroup.Android, BuildTargetGroup.iOS };
+
+        static BugsnagAddScriptingSymbol()
+        {
+            foreach (var target in _supportedPlatforms)
+            {
+                try
+                {
+                    SetScriptingSymbol(target);
+                }
+                catch
+                {
+                    // Some users might not have a platform installed, in that case ignore the error
+                }
+            }
+        }
+
+        static void SetScriptingSymbol(BuildTargetGroup buildTargetGroup)
+        {
+            var existingSymbols = BugsnagPlayerSettingsCompat.GetScriptingDefineSymbols(buildTargetGroup);
+            if (string.IsNullOrEmpty(existingSymbols))
+            {
+                existingSymbols = DEFINE_SYMBOL;
+            }
+            else if (!existingSymbols.Contains(DEFINE_SYMBOL))
+            {
+                existingSymbols += ";" + DEFINE_SYMBOL;
+            }
+            BugsnagPlayerSettingsCompat.SetScriptingDefineSymbols(buildTargetGroup, existingSymbols);
+        }
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e3c9a6b6e3c84299b5a658c6849d7ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8e3c9a6b6e3c84299b5a658c6849d7ac
+guid: 42ce8b448a31e498cab37f3a2495f893
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs
@@ -1,0 +1,48 @@
+using UnityEditor;
+#if UNITY_6000_0_OR_NEWER
+using UnityEditor.Build;
+#endif
+namespace Mazerunner.Editor
+{
+    internal static class BugsnagPlayerSettingsCompat
+    {
+        // Get Scripting Backend
+        public static ScriptingImplementation GetScriptingBackend(BuildTargetGroup buildTargetGroup)
+        {
+#if UNITY_6000_0_OR_NEWER
+        return PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+#else
+            return PlayerSettings.GetScriptingBackend(buildTargetGroup);
+#endif
+        }
+
+        public static string GetApplicationIdentifier(BuildTargetGroup buildTargetGroup)
+        {
+#if UNITY_6000_0_OR_NEWER
+                return PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+#else
+                return PlayerSettings.GetApplicationIdentifier(buildTargetGroup);
+#endif
+        }
+
+        // Get Scripting Define Symbols
+        public static string GetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup)
+        {
+#if UNITY_6000_0_OR_NEWER
+        return PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+#else
+            return PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
+#endif
+        }
+
+        // Set Scripting Define Symbols
+        public static void SetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup, string defineSymbols)
+        {
+#if UNITY_6000_0_OR_NEWER
+        PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), defineSymbols);
+#else
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defineSymbols);
+#endif
+        }
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs
@@ -1,5 +1,5 @@
 using UnityEditor;
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
 using UnityEditor.Build;
 #endif
 namespace Mazerunner.Editor
@@ -9,7 +9,7 @@ namespace Mazerunner.Editor
         // Get Scripting Backend
         public static ScriptingImplementation GetScriptingBackend(BuildTargetGroup buildTargetGroup)
         {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
         return PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
             return PlayerSettings.GetScriptingBackend(buildTargetGroup);
@@ -18,7 +18,7 @@ namespace Mazerunner.Editor
 
         public static string GetApplicationIdentifier(BuildTargetGroup buildTargetGroup)
         {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
                 return PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
                 return PlayerSettings.GetApplicationIdentifier(buildTargetGroup);
@@ -28,7 +28,7 @@ namespace Mazerunner.Editor
         // Get Scripting Define Symbols
         public static string GetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup)
         {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
         return PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
             return PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
@@ -38,7 +38,7 @@ namespace Mazerunner.Editor
         // Set Scripting Define Symbols
         public static void SetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup, string defineSymbols)
         {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2021_2_OR_NEWER
         PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), defineSymbols);
 #else
             PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defineSymbols);

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7bbe25803445b4eb1803630ed345f4ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7bbe25803445b4eb1803630ed345f4ba
+guid: f409526a50b1a41d78539f009c44ce73
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/features/fixtures/maze_runner/Assets/Editor/Builder.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/Builder.cs
@@ -167,8 +167,6 @@ public class Builder : MonoBehaviour
         var scenes = EditorBuildSettings.scenes.Where(s => s.enabled).Select(s => s.path).ToArray();
 
         PlayerSettings.defaultInterfaceOrientation = UIOrientation.Portrait;
-        PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Android, "UNITY_ASSERTIONS");
-        PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.iOS, "UNITY_ASSERTIONS");
 
         BuildPlayerOptions opts = new BuildPlayerOptions();
         opts.scenes = scenes;

--- a/features/scripts/prepare_fixture.sh
+++ b/features/scripts/prepare_fixture.sh
@@ -45,4 +45,4 @@ if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 #import performance to ensure no breaking changes
 echo "Cloning latest perf release into packages"
 rm -rf "$project_path/packages/performance-package"
-git clone https://github.com/bugsnag/bugsnag-unity-performance-upm.git "$project_path/packages/performance-package"
+git clone --branch playerSettingsCompact https://github.com/bugsnag/bugsnag-unity-performance-upm.git "$project_path/packages/performance-package"

--- a/features/scripts/prepare_fixture.sh
+++ b/features/scripts/prepare_fixture.sh
@@ -45,4 +45,4 @@ if [ $RESULT -ne 0 ]; then exit $RESULT; fi
 #import performance to ensure no breaking changes
 echo "Cloning latest perf release into packages"
 rm -rf "$project_path/packages/performance-package"
-git clone --branch playerSettingsCompact https://github.com/bugsnag/bugsnag-unity-performance-upm.git "$project_path/packages/performance-package"
+git clone https://github.com/bugsnag/bugsnag-unity-performance-upm.git "$project_path/packages/performance-package"

--- a/features/scripts/prepare_fixture.sh
+++ b/features/scripts/prepare_fixture.sh
@@ -40,3 +40,9 @@ $UNITY_PATH/Unity $DEFAULT_CLI_ARGS \
                   -importPackage $script_path/../../Bugsnag.unitypackage
 RESULT=$?
 if [ $RESULT -ne 0 ]; then exit $RESULT; fi
+
+
+#import performance to ensure no breaking changes
+echo "Cloning latest perf release into packages"
+rm -rf "$project_path/packages/performance-package"
+git clone https://github.com/bugsnag/bugsnag-unity-performance-upm.git "$project_path/packages/performance-package"


### PR DESCRIPTION
# NOTE: REQUIRES PERFORMANCE RELEASE BEFORE MERGING

## Goal

add the unity performance library to the test fixture so that we have more coverage and are more likely to detect breaking changes between both libs.

## Changeset

- add the latest performance release to the fixture on build.
- updated the PlayerSettingsCompat class to have a more specific unity version check. 
- added the PlayerSettingsCompat class to the fixture so it can also set UNITY_ASSERTIONS scripting symbol.

## Testing

Covered by E2E tests