### PR TITLE
Il2cpp abstraction & Cocoa

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
@@ -497,6 +497,9 @@ namespace BugsnagUnity
 
             var mainImageFormattedUuid = FormatImageUuid(mainImageUuid);
 
+            // if il2cpp doesn't report a mainImageFileName, we assume the default "UnityFramework" name
+            var safeMainImageFileName = string.IsNullOrEmpty(mainImageFileName) ? "UnityFramework" : mainImageFileName;
+
             var unityTrace = new PayloadStackTrace(exception.StackTrace).StackTraceLines;
             var length = nativeAddresses.Length < unityTrace.Length ? nativeAddresses.Length : unityTrace.Length;
             var stackFrames = new StackTraceLine[length];
@@ -523,7 +526,7 @@ namespace BugsnagUnity
                 }
                 else
                 {
-                    trace.MachoFile = mainImageFileName;
+                    trace.MachoFile = safeMainImageFileName;
                     trace.MachoLoadAddress = "0x0";
                     trace.MachoUuid = mainImageFormattedUuid;
                     trace.InProject = true;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
@@ -9,11 +9,13 @@ using System.Runtime.InteropServices;
 using System.Text;
 using AOT;
 using BugsnagUnity.Payload;
+using BugsnagUnity;
 
 namespace BugsnagUnity
 {
     class NativeClient : INativeClient
     {
+
         public Configuration Configuration { get; }
         public IBreadcrumbs Breadcrumbs { get; }
         private static Session _nativeSession;
@@ -67,7 +69,7 @@ namespace BugsnagUnity
                 NativeCode.bugsnag_registerForSessionCallbacks(obj, HandleSessionCallbacks);
             }
 
-            
+
 
 
             NativeCode.bugsnag_setAppHangThresholdMillis(obj, config.AppHangThresholdMillis);
@@ -227,7 +229,7 @@ namespace BugsnagUnity
         private void SetEnabledErrorTypes(IntPtr obj, Configuration config)
         {
             var enabledTypes = new List<string>();
-           
+
             if (config.EnabledErrorTypes.AppHangs)
             {
                 enabledTypes.Add("AppHangs");
@@ -247,7 +249,7 @@ namespace BugsnagUnity
             {
                 enabledTypes.Add("OOMs");
             }
-            
+
             NativeCode.bugsnag_setEnabledErrorTypes(obj, enabledTypes.ToArray(), enabledTypes.Count);
         }
 
@@ -275,7 +277,7 @@ namespace BugsnagUnity
         public void PopulateAppWithState(AppWithState app)
         {
             PopulateApp(app);
-        }     
+        }
 
         public void PopulateDevice(Device device)
         {
@@ -489,14 +491,12 @@ namespace BugsnagUnity
             NativeCode.bugsnag_registerForSessionCallbacksAfterStart(HandleSessionCallbacks);
         }
 
-        #nullable enable
-        private static string? ExtractString(IntPtr pString)
+        private StackTraceLine[] ToStackFrames(System.Exception exception, IntPtr[] nativeAddresses, String mainImageFileName, String mainImageUuid)
         {
-            return (pString == IntPtr.Zero) ? null : Marshal.PtrToStringAnsi(pString);
-        }
+            loadedImages.Refresh(mainImageFileName);
 
-        private StackTraceLine[] ToStackFrames(System.Exception exception, IntPtr[] nativeAddresses)
-        {
+            var mainImageFormattedUuid = FormatImageUuid(mainImageUuid);
+
             var unityTrace = new PayloadStackTrace(exception.StackTrace).StackTraceLines;
             var length = nativeAddresses.Length < unityTrace.Length ? nativeAddresses.Length : unityTrace.Length;
             var stackFrames = new StackTraceLine[length];
@@ -507,103 +507,56 @@ namespace BugsnagUnity
                 var image = loadedImages.FindImageAtAddress(address);
 
                 var trace = new StackTraceLine();
-                trace.FrameAddress = address.ToString();
+                trace.FrameAddress = string.Format("0x{0:X}", address);
                 trace.Method = method.ToString();
                 if (image != null)
                 {
                     if (address < image.LoadAddress)
                     {
                         // It's a relative address
-                        trace.FrameAddress = (address + image.LoadAddress).ToString();
+                        trace.FrameAddress = string.Format("0x{0:X}", address + image.LoadAddress);
                     }
                     trace.MachoFile = image.FileName;
-                    trace.MachoLoadAddress = image.LoadAddress.ToString();
+                    trace.MachoLoadAddress = string.Format("0x{0:X}", image.LoadAddress);
                     trace.MachoUuid = image.Uuid;
                     trace.InProject = image.IsMainImage;
+                }
+                else
+                {
+                    trace.MachoFile = mainImageFileName;
+                    trace.MachoLoadAddress = "0x0";
+                    trace.MachoUuid = mainImageFormattedUuid;
+                    trace.InProject = true;
                 }
                 stackFrames[i] = trace;
             }
             return stackFrames;
         }
 
-#if ENABLE_IL2CPP && UNITY_2021_3_OR_NEWER
-        [DllImport("__Internal")]
-        private static extern IntPtr il2cpp_gchandle_get_target(int gchandle);
+        private string FormatImageUuid(string imageUuid)
+        {
+            if (imageUuid == null || imageUuid.Length != 32)
+            {
+                return null;
+            }
 
-        [DllImport("__Internal")]
-        private static extern void il2cpp_free(IntPtr ptr);
-
-        [DllImport("__Internal")]
-        private static extern void il2cpp_native_stack_trace(IntPtr exc, out IntPtr addresses, out int numFrames, out IntPtr imageUUID, out IntPtr imageName);
-#endif
+            byte[] mainImageUuidBytes = new byte[16];
+            for (int i = 0; i < 16; i++)
+            {
+                mainImageUuidBytes[i] = Convert.ToByte(imageUuid.Substring(i * 2, 2), 16);
+            }
+            return new Guid(mainImageUuidBytes).ToString();
+        }
 
         public StackTraceLine[] ToStackFrames(System.Exception exception)
         {
-            var notFound = new StackTraceLine[0];
-            return notFound;
-// Disabled until we can get this working with IL2CPP and Unity 6. raised in PLAT-13394
-//             if (exception == null)
-//             {
-//                 return notFound;
-//             }
-
-// #if ENABLE_IL2CPP && UNITY_2021_3_OR_NEWER
-//             var hException = GCHandle.Alloc(exception);
-//             var pNativeAddresses = IntPtr.Zero;
-//             var pImageUuid = IntPtr.Zero;
-//             var pImageName = IntPtr.Zero;
-//             try
-//             {
-//                 if (hException == null)
-//                 {
-//                     return notFound;
-//                 }
-
-//                 var pException = il2cpp_gchandle_get_target(GCHandle.ToIntPtr(hException).ToInt32());
-//                 if (pException == IntPtr.Zero)
-//                 {
-//                     return notFound;
-//                 }
-
-//                 var frameCount = 0;
-//                 string? mainImageFileName = null;
-
-//                 il2cpp_native_stack_trace(pException, out pNativeAddresses, out frameCount, out pImageUuid, out pImageName);
-//                 if (pNativeAddresses == IntPtr.Zero)
-//                 {
-//                     return notFound;
-//                 }
-
-//                 mainImageFileName = ExtractString(pImageName);
-//                 var nativeAddresses = new IntPtr[frameCount];
-//                 Marshal.Copy(pNativeAddresses, nativeAddresses, 0, frameCount);
-
-//                 loadedImages.Refresh(mainImageFileName);
-//                 return ToStackFrames(exception, nativeAddresses);
-//             }
-//             finally
-//             {
-//                 if (pImageUuid != IntPtr.Zero)
-//                 {
-//                     il2cpp_free(pImageUuid);
-//                 }
-//                 if (pImageName != IntPtr.Zero)
-//                 {
-//                     il2cpp_free(pImageName);
-//                 }
-//                 if (pNativeAddresses != IntPtr.Zero)
-//                 {
-//                     il2cpp_free(pNativeAddresses);
-//                 }
-//                 if (hException != null)
-//                 {
-//                     hException.Free();
-//                 }
-//             }
-// #else
-//             return notFound;
-// #endif
+            return Il2cppUtils.ToStackFrames(
+                exception,
+                (exception, nativeAddresses, mainImageFileName, mainImageUuid) =>
+                    ToStackFrames(exception, nativeAddresses, mainImageFileName, mainImageUuid)
+            );
         }
+
     }
 }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Il2cppUtils.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Il2cppUtils.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using AOT;
+using BugsnagUnity.Payload;
+
+namespace BugsnagUnity
+{
+    internal class Il2cppUtils
+    {
+
+#if UNITY_ANDROID
+        private const int IL2CPP_BUILD_ID_MAX_LENGTH = 40;
+#endif
+
+#if ENABLE_IL2CPP && UNITY_2023_1_OR_NEWER
+
+        [DllImport("__Internal")]
+        private static extern IntPtr il2cpp_gchandle_get_target(IntPtr gchandle);
+        private static IntPtr GHandle_Get_Target(IntPtr gchandle) => il2cpp_gchandle_get_target(gchandle);
+
+#elif ENABLE_IL2CPP && UNITY_2021_3_OR_NEWER
+
+        [DllImport("__Internal")]
+        private static extern IntPtr il2cpp_gchandle_get_target(int gchandle);
+        private static IntPtr GHandle_Get_Target(IntPtr gchandle) => il2cpp_gchandle_get_target(gchandle.ToInt32());
+
+#endif
+
+#if ENABLE_IL2CPP && UNITY_2021_3_OR_NEWER
+
+        [DllImport("__Internal")]
+        private static extern void il2cpp_free(IntPtr ptr);
+
+        [DllImport("__Internal")]
+        private static extern void il2cpp_native_stack_trace(IntPtr exc, out IntPtr addresses, out int numFrames, out IntPtr imageUUID, out IntPtr imageName);
+
+        private static void NativeStackTrace(IntPtr exc, out IntPtr addresses, out int numFrames, out IntPtr imageUUID, out IntPtr imageName) =>
+            il2cpp_native_stack_trace(exc, out addresses, out numFrames, out imageUUID, out imageName);
+
+        private static void Free(IntPtr ptr) => il2cpp_free(ptr);
+
+#else
+
+        private static void Free(IntPtr ptr) {}
+
+#endif
+
+        #nullable enable
+        private static string? ExtractString(IntPtr pString, Int32 iLimit)
+        {
+            return (pString == IntPtr.Zero) ? null : Marshal.PtrToStringAnsi(pString, iLimit);
+        }
+
+        private static string? ExtractString(IntPtr pString)
+        {
+            return (pString == IntPtr.Zero) ? null : Marshal.PtrToStringAnsi(pString);
+        }
+
+        private static Int32 FindStringTerminator(IntPtr pString, string terminator)
+        {
+            if (pString == IntPtr.Zero)
+            {
+                return 0;
+            }
+
+            var i = 0;
+            var terminatorIndex = 0;
+            while (true)
+            {
+                var b = Marshal.ReadByte(pString, i);
+
+                if (b == 0)
+                {
+                    break;
+                }
+
+                // next index
+                i++;
+
+                var ch = Convert.ToChar(b);
+
+                if (terminator[terminatorIndex] == ch)
+                {
+                    terminatorIndex++;
+
+                    if (terminatorIndex == terminator.Length)
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    terminatorIndex = 0;
+                }
+            }
+
+            return i;
+        }
+
+        internal static StackTraceLine[] ToStackFrames(System.Exception exception, Func<System.Exception, IntPtr[], String, String, StackTraceLine[]> stackTransformer)
+        {
+             var notFound = new StackTraceLine[0];
+             if (exception == null)
+             {
+                 return notFound;
+             }
+
+ #if ENABLE_IL2CPP && UNITY_2021_3_OR_NEWER
+             var hException = GCHandle.Alloc(exception);
+             var pNativeAddresses = IntPtr.Zero;
+             var pImageUuid = IntPtr.Zero;
+             var pImageName = IntPtr.Zero;
+             try
+             {
+                 if (hException == null)
+                 {
+                     return notFound;
+                 }
+
+                 var pException = Il2cppUtils.GHandle_Get_Target(GCHandle.ToIntPtr(hException));
+
+                 if (pException == IntPtr.Zero)
+                 {
+                     return notFound;
+                 }
+
+                 var frameCount = 0;
+                 string? mainImageFileName = null;
+                 string? mainImageUuid = null;
+
+                 NativeStackTrace(pException, out pNativeAddresses, out frameCount, out pImageUuid, out pImageName);
+                 if (pNativeAddresses == IntPtr.Zero)
+                 {
+                     return notFound;
+                 }
+
+#if UNITY_ANDROID
+
+                 // Marshal.PtrToStringAnsi without a limit is unsafe due to an off-by-one error where `strncpy` is
+                 // incorrectly given `strlen` instead of `strlen + 1`, so we look for ".so" as a terminator (or NULL
+                 // whichever comes first)
+                 var iMainImageFileNameLimit = Il2cppUtils.FindStringTerminator(pImageName, ".so");
+                 mainImageFileName = Il2cppUtils.ExtractString(pImageName, iMainImageFileNameLimit);
+                 mainImageUuid = Il2cppUtils.ExtractString(pImageUuid, IL2CPP_BUILD_ID_MAX_LENGTH);
+
+#else
+
+                 mainImageFileName = Il2cppUtils.ExtractString(pImageName);
+                 mainImageUuid = Il2cppUtils.ExtractString(pImageUuid);
+
+#endif
+
+                 var nativeAddresses = new IntPtr[frameCount];
+                 Marshal.Copy(pNativeAddresses, nativeAddresses, 0, frameCount);
+
+                 return stackTransformer(exception, nativeAddresses, mainImageFileName, mainImageUuid);
+             }
+             finally
+             {
+                 if (pImageUuid != IntPtr.Zero)
+                 {
+                     Il2cppUtils.Free(pImageUuid);
+                 }
+                 if (pImageName != IntPtr.Zero)
+                 {
+                     Il2cppUtils.Free(pImageName);
+                 }
+                 if (pNativeAddresses != IntPtr.Zero)
+                 {
+                     Il2cppUtils.Free(pNativeAddresses);
+                 }
+                 if (hException != null)
+                 {
+                     hException.Free();
+                 }
+             }
+ #else
+             return notFound;
+ #endif
+        }
+    }
+}

--- a/features/android/android_csharp_events.feature
+++ b/features/android/android_csharp_events.feature
@@ -28,9 +28,9 @@ Feature: csharp events on Android have a il2cpp addresses
     And the event "exceptions.0.stacktrace.1.type" equals "c"
 
     And the event "exceptions.0.stacktrace.2.loadAddress" equals "0x0"
-    And the error payload field "events.0.exceptions.0.stacktrace.1.file" matches the regex ".*/libil2cpp.so$"
-    And the error payload field "events.0.exceptions.0.stacktrace.1.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
-    And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.file" matches the regex ".*/libil2cpp.so$"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
     And the event "exceptions.0.stacktrace.2.isPC" is true
     And the event "exceptions.0.stacktrace.2.type" equals "c"
 
@@ -63,9 +63,9 @@ Feature: csharp events on Android have a il2cpp addresses
     And the event "exceptions.0.stacktrace.1.type" equals "c"
 
     And the event "exceptions.0.stacktrace.2.loadAddress" equals "0x0"
-    And the error payload field "events.0.exceptions.0.stacktrace.1.file" matches the regex ".*/libil2cpp.so$"
-    And the error payload field "events.0.exceptions.0.stacktrace.1.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
-    And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.file" matches the regex ".*/libil2cpp.so$"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.codeIdentifier" matches the regex "[0-9a-fA-F]{40}"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.frameAddress" matches the regex "0x[0-9a-fA-F]{1,16}"
     And the event "exceptions.0.stacktrace.2.isPC" is true
     And the event "exceptions.0.stacktrace.2.type" equals "c"
 

--- a/features/ios/ios_csharp_events.feature
+++ b/features/ios/ios_csharp_events.feature
@@ -1,0 +1,62 @@
+Feature: csharp events on iOS have a il2cpp addresses
+
+  Background:
+    Given I clear the Bugsnag cache
+
+  @skip_unity_2020
+  Scenario: iOS Uncaught Exception has il2cpp addresses
+    When I run the game in the "UncaughtExceptionSmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "UncaughtExceptionSmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+
+    And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" matches the regex ".*UnityFramework.*"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
+
+    And the error payload field "events.0.exceptions.0.stacktrace.1.machoFile" matches the regex ".*UnityFramework.*"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
+
+    And the error payload field "events.0.exceptions.0.stacktrace.2.machoFile" matches the regex ".*UnityFramework.*"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
+
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+    And the error payload field "events.0.severityReason.unhandledOverridden" is false
+
+  @skip_unity_2020
+  Scenario: Android Notify Exception has il2cpp addresses
+    When I run the game in the "NotifySmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "NotifySmokeTest"
+    And the event "unhandled" is false
+    And custom metadata is included in the event
+
+    And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" matches the regex ".*UnityFramework.*"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
+
+    And the error payload field "events.0.exceptions.0.stacktrace.1.machoFile" matches the regex ".*UnityFramework.*"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
+
+    And the error payload field "events.0.exceptions.0.stacktrace.2.machoFile" matches the regex ".*UnityFramework.*"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
+
+    And expected device metadata is included in the event
+    And expected app metadata is included in the event
+    And the error payload field "events.0.severityReason.unhandledOverridden" is false


### PR DESCRIPTION
## Goal
Abstract the common il2cpp stacktrace logic into a common class used by both Android & Cocoa to report native stack frames

## Testing
Introduced a new end-to-end scenario for iOS with il2cpp stack frames