### PR TITLE
Do not use Maze.driver directly

### DIFF
--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -1,8 +1,9 @@
 require 'cgi'
 
 When('On Mobile I relaunch the app') do
-  next unless %w[android ios].include? Maze::Helper.get_current_platform
-  Maze.driver.launch_app
+  next unless Maze.config.device
+  manager = Maze::Api::Appium::AppManager.new
+  manager.launch
   sleep 3
 end
 
@@ -351,9 +352,10 @@ When("I clear any error dialogue") do
 end
 
 def click_if_present(element)
-  return false unless Maze.driver.wait_for_element(element, 1)
+  manager = Maze::Api::Appium::UiManager.new
+  return false unless manager.wait_for_element(element, 1)
 
-  Maze.driver.click_element_if_present(element)
+  manager.click_element_if_present(element)
 rescue Selenium::WebDriver::Error::UnknownError
   # Ignore Appium errors (e.g. during an ANR)
   return false

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -165,7 +165,7 @@ end
 
 device_logs = []
 After do |scenario|
-  if Maze.driver && Maze.driver.is_a?(Maze::Driver::Appium)
+  if Maze.config.device
     log_file = Maze::Api::Appium::FileManager.new.read_app_file('mazerunner-unity.log')
     device_logs << {
       file: log_file,


### PR DESCRIPTION
## Goal

Change the e2e tests to use the new Maze Runner Appium API, meaning that we detect and report driver failures.

## Testing

Covered by a full CI run to ensure the updated condition works correctly.