### PR TITLE
Detect WebGL test fixture build failures

### DIFF
--- a/scripts/ci-build-webgl-fixture.sh
+++ b/scripts/ci-build-webgl-fixture.sh
@@ -17,8 +17,16 @@ BUILD_TYPE=$1
 
 pushd features/fixtures/maze_runner/build
   if [ "$BUILD_TYPE" == "release" ]; then
-    zip -r WebGL-release-${UNITY_VERSION:0:4}.zip WebGL
+    FIXTURE_NAME=Mazerunner
+    BUILD_FOLDER=WebGL-release-${UNITY_VERSION:0:4}
   else
-    zip -r WebGL-dev-${UNITY_VERSION:0:4}.zip WebGL
+    FIXTURE_NAME=Mazerunner_dev
+    BUILD_FOLDER=WebGL-dev-${UNITY_VERSION:0:4}
+  fi
+  zip -r "${BUILD_FOLDER}.zip" WebGL
+  # Check if index.html exists in the build folder
+  if [ ! -f "WebGL/${FIXTURE_NAME}/index.html" ]; then
+    echo "index.html not found in the build folder"
+    exit 3
   fi
 popd


### PR DESCRIPTION
## Goal

Detect WebGL test fixture build failures by checking if `index.html` is in the build folder.  

## Design

The build folder is still zipped and attached to the Buildkite job for inspection should a failure be detected.  Returning non-zero means that Buildkite fails the job correctly and it can be retried either automatically or manually.

## Testing

Naturally tested as part of preparing this PR - the Unity build failed twice on macos-14-5, it was detected and the Buildkite job failed as a result.