### PR TITLE
add compilation platform error type

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
@@ -16,6 +16,14 @@ namespace BugsnagUnity.Payload
 
         internal bool IsAndroidJavaException;
 
+#if ENABLE_IL2CPP
+        const string COMPILATION_PLATFORM = "il2cpp"; 
+#elif ENABLE_MONO
+        const string COMPILATION_PLATFORM = "mono"; 
+#else
+        const string COMPILATION_PLATFORM = "unknown"; 
+#endif
+
         private const string ANDROID_JAVA_EXCEPTION_CLASS = "AndroidJavaException";
         private const string ERROR_CLASS_MESSAGE_PATTERN = @"^(?<errorClass>\S+):\s+(?<message>.*)";
         private const string NATIVE_ANDROID_ERROR_CLASS = "java.lang.Error";
@@ -24,6 +32,7 @@ namespace BugsnagUnity.Payload
         private const string ERROR_CLASS_KEY = "errorClass";
         private const string MESSAGE_KEY = "message";
         private const string STACKTRACE_KEY = "stacktrace";
+        private const string ERROR_TYPE_KEY = "type";
 
         internal Error(Dictionary<string, object> data)
         {
@@ -57,6 +66,7 @@ namespace BugsnagUnity.Payload
             _stacktrace = stackTrace.ToList();
             HandledState = handledState;
             IsAndroidJavaException = isAndroidJavaException;
+            Type = COMPILATION_PLATFORM;
         }
 
 
@@ -76,8 +86,11 @@ namespace BugsnagUnity.Payload
             set => this.AddToPayload(MESSAGE_KEY, value);
         }
 
-        public string Type { get => "Unity"; }
-
+        public string Type 
+        {
+            get => this.Get(ERROR_TYPE_KEY) as string;
+            set => this.AddToPayload(ERROR_TYPE_KEY, value);
+        }
         public static bool ShouldSend(System.Exception exception)
         {
             var errorClass = exception.GetType().Name;

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -17,6 +17,23 @@ Feature: csharp events
     And expected app metadata is included in the event
     And the error payload field "events.0.severityReason.unhandledOverridden" is false
 
+  @mobile_only
+  Scenario: Error type IL2CPP
+    When I run the game in the "NotifySmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "NotifySmokeTest"
+    And the exception "type" equals "il2cpp"
+   
+  @macos_only
+  Scenario: Error type MONO
+    When I run the game in the "NotifySmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "NotifySmokeTest"
+    And the exception "type" equals "mono"
 
   Scenario: Uncaught Exception smoke test
     When I run the game in the "UncaughtExceptionSmokeTest" state

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -78,6 +78,14 @@ Before('@android_only') do |_scenario|
   skip_this_scenario('Skipping scenario') unless Maze::Helper.get_current_platform == 'android'
 end
 
+Before('@mobile_only') do |_scenario|
+  mobile_platforms = %w[android ios]
+  current_platform = Maze::Helper.get_current_platform
+  unless mobile_platforms.include?(current_platform)
+    skip_this_scenario('Skipping scenario, this scenario is only for Android or iOS')
+  end
+end
+
 
 BeforeAll do
   $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'


### PR DESCRIPTION
## Goal

add il2cpp or mono as error type so that the pipeline can attempt to symbolicate IL2CPP errors if possible.

## Testing

Added new E2E tests