### PR TITLE
Release v8.6.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,6 +25,14 @@ steps:
         - exit_status: "*"
           limit: 1
 
+  - label: Verify code formatting
+    timeout_in_minutes: 5
+    env:
+      UNITY_VERSION: *2021
+    commands:
+      - rake code:verify
+
+
   - label: "Test UPM Package Import"
     depends_on: build_unitypackage
     timeout_in_minutes: 10

--- a/.buildkite/pipeline_trigger.sh
+++ b/.buildkite/pipeline_trigger.sh
@@ -3,6 +3,7 @@
 if [[ "$BUILDKITE_MESSAGE" == *"[full ci]"* ||
   "$BUILDKITE_BRANCH" == "next" ||
   "$BUILDKITE_BRANCH" == "master" ||
+  "$BUILDKITE_BRANCH" == releases/* ||
   ! -z "$FULL_SCHEDULED_BUILD" ||
   "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" == "master" ]]; then
   echo "Running full build"

--- a/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BugsnagPlayerSettingsCompat.cs
@@ -10,7 +10,7 @@ namespace BugsnagUnity.Editor
         public static ScriptingImplementation GetScriptingBackend(BuildTargetGroup buildTargetGroup)
         {
 #if UNITY_2021_2_OR_NEWER
-        return PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+            return PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
             return PlayerSettings.GetScriptingBackend(buildTargetGroup);
 #endif
@@ -19,7 +19,7 @@ namespace BugsnagUnity.Editor
         public static string GetApplicationIdentifier(BuildTargetGroup buildTargetGroup)
         {
 #if UNITY_2021_2_OR_NEWER
-                return PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+            return PlayerSettings.GetApplicationIdentifier(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
                 return PlayerSettings.GetApplicationIdentifier(buildTargetGroup);
 #endif
@@ -29,7 +29,7 @@ namespace BugsnagUnity.Editor
         public static string GetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup)
         {
 #if UNITY_2021_2_OR_NEWER
-        return PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
+            return PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup));
 #else
             return PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup);
 #endif
@@ -39,7 +39,7 @@ namespace BugsnagUnity.Editor
         public static void SetScriptingDefineSymbols(BuildTargetGroup buildTargetGroup, string defineSymbols)
         {
 #if UNITY_2021_2_OR_NEWER
-        PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), defineSymbols);
+            PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup), defineSymbols);
 #else
             PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, defineSymbols);
 #endif

--- a/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/AutoSymbolUploadToggleMenu.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/AutoSymbolUploadToggleMenu.cs
@@ -8,7 +8,7 @@ namespace BugsnagUnity.Editor
     {
         private const string MENU_PATH = "Window/BugSnag/Enable Symbol Uploads";
 
-        [MenuItem(MENU_PATH,false,50)]
+        [MenuItem(MENU_PATH, false, 50)]
         private static void ToggleAutoUpload()
         {
             SetEnabled(!IsEnabled());
@@ -22,7 +22,7 @@ namespace BugsnagUnity.Editor
         }
 
         static bool IsEnabled()
-        {   
+        {
             var settings = GetSettingsObject();
             return settings != null && settings.AutoUploadSymbols;
         }
@@ -30,7 +30,7 @@ namespace BugsnagUnity.Editor
         static void SetEnabled(bool enabled)
         {
             var settings = GetSettingsObject();
-            if(settings != null)
+            if (settings != null)
             {
                 settings.AutoUploadSymbols = enabled;
                 EditorUtility.SetDirty(settings);

--- a/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagSymbolUploader.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagSymbolUploader.cs
@@ -57,7 +57,7 @@ fi
             }
             EditorUtility.ClearProgressBar();
 #elif UNITY_IOS || UNITY_STANDALONE_OSX
-            AddXcodePostBuildScript(report.summary.outputPath , config);
+            AddXcodePostBuildScript(report.summary.outputPath, config);
 #endif
 
         }
@@ -105,7 +105,7 @@ fi
 #endif
 #if UNITY_STANDALONE_OSX
             var pbxProjectPath = GetMacosXcodeProjectPath(pathToBuiltProject);
-             if (!File.Exists(pbxProjectPath))
+            if (!File.Exists(pbxProjectPath))
             {
                 //Xcode export not enabled, do nothing
                 return;

--- a/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
@@ -1,2 +1,2 @@
 using System.Reflection;
-[assembly: AssemblyVersion("8.5.2.0")]
+[assembly: AssemblyVersion("8.6.0.0")]

--- a/Bugsnag/Assets/Bugsnag/Runtime/AutomaticDataCollector.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/AutomaticDataCollector.cs
@@ -14,7 +14,7 @@ namespace BugsnagUnity
             var appMetadata = new Dictionary<string, object>();
             appMetadata.Add("companyName", Application.companyName);
             appMetadata.Add("name", Application.productName);
-            nativeClient.AddNativeMetadata("app",appMetadata);
+            nativeClient.AddNativeMetadata("app", appMetadata);
 
             //data added to metadata.device
             var deviceMetadata = new Dictionary<string, object>();
@@ -42,7 +42,7 @@ namespace BugsnagUnity
                 deviceMetadata.Add("batteryLevel", SystemInfo.batteryLevel);
             }
             deviceMetadata.Add("charging", SystemInfo.batteryStatus.Equals(BatteryStatus.Charging));
-            metadata.AddMetadata("device", deviceMetadata);            
+            metadata.AddMetadata("device", deviceMetadata);
         }
 
     }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
@@ -25,6 +25,8 @@ namespace BugsnagUnity
                 if (InternalClient == null)
                 {
                     var configClone = configuration.Clone();
+                    //endpoints must be configured before the native client is created
+                    configClone.Endpoints.Configure(configClone.ApiKey);
                     var nativeClient = new NativeClient(configClone);
                     InternalClient = new Client(nativeClient);
                 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
@@ -54,7 +54,7 @@ namespace BugsnagUnity
 
         public static List<Breadcrumb> Breadcrumbs => Client.Breadcrumbs.Retrieve();
 
-        public static void LeaveBreadcrumb(string message, Dictionary<string, object> metadata = null, BreadcrumbType type = BreadcrumbType.Manual ) => InternalClient.Breadcrumbs.Leave(message, metadata, type);
+        public static void LeaveBreadcrumb(string message, Dictionary<string, object> metadata = null, BreadcrumbType type = BreadcrumbType.Manual) => InternalClient.Breadcrumbs.Leave(message, metadata, type);
 
         public static void LeaveBreadcrumb(UnityWebRequest request, TimeSpan? duration) => InternalClient.LeaveNetworkBreadcrumb(request, duration);
 
@@ -76,9 +76,9 @@ namespace BugsnagUnity
         /// <param name="inFocus"></param>
         public static void SetApplicationState(bool inFocus)
         {
-            if(Client != null)
+            if (Client != null)
             {
-                 Client.SetApplicationState(inFocus);
+                Client.SetApplicationState(inFocus);
             }
         }
 
@@ -103,12 +103,12 @@ namespace BugsnagUnity
         /// Setting Configuration.LaunchDurationMillis to 0 will cause Bugsnag to consider the app to be launching until Bugsnag.MarkLaunchCompleted() has been called.
         /// </summary>
         public static void MarkLaunchCompleted() => Client.MarkLaunchCompleted();
-      
+
         /// <summary>
         /// Get information regarding the last application run. This will be null on non mobile platforms.
         /// </summary>
         public static LastRunInfo GetLastRunInfo() => Client.LastRunInfo;
-       
+
 
         /// <summary>
         /// Add an OnError callback to run when an error occurs
@@ -119,12 +119,12 @@ namespace BugsnagUnity
         /// Remove an OnError callback
         /// </summary>
         public static void RemoveOnError(Func<IEvent, bool> bugsnagCallback) => Client.RemoveOnError(bugsnagCallback);
-       
+
         /// <summary>
         /// Add an OnSession callback to run when an session is created
         /// </summary>
         public static void AddOnSession(Func<ISession, bool> callback) => Client.AddOnSession(callback);
-       
+
         /// <summary>
         /// Remove an OnSession callback
         /// </summary>
@@ -160,7 +160,7 @@ namespace BugsnagUnity
         /// </summary>
         public static object GetMetadata(string section, string key) => Client.GetMetadata(section, key);
 
-        public static void AddFeatureFlag(string name, string variant = null) => Client.AddFeatureFlag(name,variant);
+        public static void AddFeatureFlag(string name, string variant = null) => Client.AddFeatureFlag(name, variant);
 
         public static void AddFeatureFlags(FeatureFlag[] featureFlags) => Client.AddFeatureFlags(featureFlags);
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/BugsnagAutoInit.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/BugsnagAutoInit.cs
@@ -10,7 +10,7 @@ namespace BugsnagUnity
             var settings = Resources.Load<BugsnagSettingsObject>("Bugsnag/BugsnagSettingsObject");
             if (settings != null && settings.StartAutomaticallyAtLaunch)
             {
-                if(string.IsNullOrEmpty(settings.ApiKey))
+                if (string.IsNullOrEmpty(settings.ApiKey))
                 {
                     Debug.LogError("Bugsnag not auto started as the API key is not set in the Bugsnag Settings window.");
                     return;

--- a/Bugsnag/Assets/Bugsnag/Runtime/BugsnagSettingsObject.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/BugsnagSettingsObject.cs
@@ -98,9 +98,10 @@ namespace BugsnagUnity
             }
             config.BundleVersion = BundleVersion;
 
-            config.BreadcrumbLogLevel = GetLogTypeFromLogLevel( BreadcrumbLogLevel );
+            config.BreadcrumbLogLevel = GetLogTypeFromLogLevel(BreadcrumbLogLevel);
             config.Context = Context;
-            foreach(string discardedClass in DiscardClasses){
+            foreach (string discardedClass in DiscardClasses)
+            {
                 try
                 {
                     config.DiscardClasses.Add(new System.Text.RegularExpressions.Regex(discardedClass));
@@ -122,13 +123,13 @@ namespace BugsnagUnity
             config.MaxPersistedSessions = MaxPersistedSessions;
             config.MaxReportedThreads = MaxReportedThreads;
             config.MaxStringValueLength = MaxStringValueLength;
-            config.NotifyLogLevel = GetLogTypeFromLogLevel( NotifyLogLevel );
+            config.NotifyLogLevel = GetLogTypeFromLogLevel(NotifyLogLevel);
             config.SendThreads = SendThreads;
             if (!string.IsNullOrEmpty(NotifyEndpoint) && !string.IsNullOrEmpty(SessionEndpoint))
             {
                 config.Endpoints = new EndpointConfiguration(NotifyEndpoint, SessionEndpoint);
             }
-            foreach(string key in RedactedKeys)
+            foreach (string key in RedactedKeys)
             {
                 try
                 {
@@ -212,11 +213,11 @@ namespace BugsnagUnity
         [Serializable]
         public enum EditorLogLevel
         {
-           Exception,
-           Error,
-           Assert,
-           Warning,
-           Log
+            Exception,
+            Error,
+            Assert,
+            Warning,
+            Log
         }
 
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/BugsnagSettingsObject.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/BugsnagSettingsObject.cs
@@ -39,10 +39,10 @@ namespace BugsnagUnity
         public int MaxPersistedSessions = 128;
         public int MaxReportedThreads = 200;
         public int MaxStringValueLength = 10000;
-        public string NotifyEndpoint = "https://notify.bugsnag.com";
+        public string NotifyEndpoint = string.Empty;
         public EditorLogLevel NotifyLogLevel = EditorLogLevel.Exception;
         public bool PersistUser = true;
-        public string SessionEndpoint = "https://sessions.bugsnag.com";
+        public string SessionEndpoint = string.Empty;
         public ThreadSendPolicy SendThreads = ThreadSendPolicy.UnhandledOnly;
         public string[] RedactedKeys = new string[] { ".*password.*" };
         public string ReleaseStage;

--- a/Bugsnag/Assets/Bugsnag/Runtime/BugsnagUnityWebRequest/BugsnagUnityWebRequest.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/BugsnagUnityWebRequest/BugsnagUnityWebRequest.cs
@@ -66,18 +66,18 @@ namespace BugsnagNetworking
         }
 
         // Post
-    #if UNITY_2022_2_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
         public static BugsnagUnityWebRequest PostWwwForm(string uri, string form)
         {
             return new BugsnagUnityWebRequest(UnityWebRequest.PostWwwForm(uri, form));
         }
-    #else
+#else
         public static BugsnagUnityWebRequest Post(string uri, string postData)
         {
             return new BugsnagUnityWebRequest(UnityWebRequest.Post(uri, postData));
         }
-    #endif
-        
+#endif
+
 
         public static BugsnagUnityWebRequest Post(string uri, WWWForm formData)
         {
@@ -94,18 +94,18 @@ namespace BugsnagNetworking
             return new BugsnagUnityWebRequest(UnityWebRequest.Post(uri, formFields));
         }
 
-    #if UNITY_2022_2_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
         public static BugsnagUnityWebRequest PostWwwForm(Uri uri, string form)
         {
             return new BugsnagUnityWebRequest(UnityWebRequest.PostWwwForm(uri, form));
         }
-    #else
+#else
         public static BugsnagUnityWebRequest Post(Uri uri, string postData)
         {
             return new BugsnagUnityWebRequest(UnityWebRequest.Post(uri, postData));
         }
-    #endif
-       
+#endif
+
 
         public static BugsnagUnityWebRequest Post(Uri uri, WWWForm formData)
         {
@@ -354,7 +354,7 @@ namespace BugsnagNetworking
         public long responseCode => UnityWebRequest.responseCode;
 
         public float uploadProgress => UnityWebRequest.uploadProgress;
-        
+
 
     }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
@@ -135,7 +135,6 @@ namespace BugsnagUnity
             }
             InitTimingTracker();
             StartInitialSession();
-            CheckForMisconfiguredEndpointsWarning();
             AddBugsnagLoadedBreadcrumb();
             _delivery.StartDeliveringCachedPayloads();
             ListenForSceneLoad();
@@ -224,23 +223,6 @@ namespace BugsnagUnity
             }
             // listen for changes and pass the data to the native layer
             _cachedUser.PropertyChanged.AddListener(() => { NativeClient.SetUser(_cachedUser); });
-        }
-
-        private void CheckForMisconfiguredEndpointsWarning()
-        {
-            var endpoints = Configuration.Endpoints;
-            if (endpoints.IsValid)
-            {
-                return;
-            }
-            if (endpoints.NotifyIsCustom && !endpoints.SessionIsCustom)
-            {
-                UnityEngine.Debug.LogWarning("Invalid configuration. endpoints.Notify cannot be set without also setting endpoints.Session. Events will not be sent to Bugsnag.");
-            }
-            if (!endpoints.NotifyIsCustom && endpoints.SessionIsCustom)
-            {
-                UnityEngine.Debug.LogWarning("Invalid configuration. endpoints.Session cannot be set without also setting endpoints.Notify. Sessions will not be sent to Bugsnag.");
-            }
         }
 
         private void AddBugsnagLoadedBreadcrumb()
@@ -368,7 +350,7 @@ namespace BugsnagUnity
 
         private void Notify(Error[] exceptions, HandledState handledState, Func<IEvent, bool> callback, LogType? logType)
         {
-            if (!ShouldSendRequests() || EventContainsDiscardedClass(exceptions) || !Configuration.Endpoints.IsValid)
+            if (!ShouldSendRequests() || EventContainsDiscardedClass(exceptions) || !Configuration.Endpoints.IsConfigured)
             {
                 return;
             }
@@ -393,7 +375,7 @@ namespace BugsnagUnity
 
         private void NotifyOnMainThread(Error[] exceptions, HandledState handledState, Func<IEvent, bool> callback, LogType? logType, Correlation correlation)
         {
-            if (!ShouldSendRequests() || EventContainsDiscardedClass(exceptions) || !Configuration.Endpoints.IsValid)
+            if (!ShouldSendRequests() || EventContainsDiscardedClass(exceptions) || !Configuration.Endpoints.IsConfigured)
             {
                 return;
             }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
@@ -378,7 +378,7 @@ namespace BugsnagUnity
             {
                 try
                 {
-                    MainThreadDispatchBehaviour.Enqueue(() => { NotifyOnMainThread(exceptions, handledState, callback,logType, correlation); });
+                    MainThreadDispatchBehaviour.Enqueue(() => { NotifyOnMainThread(exceptions, handledState, callback, logType, correlation); });
                 }
                 catch
                 {
@@ -388,7 +388,7 @@ namespace BugsnagUnity
             else
             {
                 NotifyOnMainThread(exceptions, handledState, callback, logType, correlation);
-            }            
+            }
         }
 
         private void NotifyOnMainThread(Error[] exceptions, HandledState handledState, Func<IEvent, bool> callback, LogType? logType, Correlation correlation)

--- a/Bugsnag/Assets/Bugsnag/Runtime/Configuration.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Configuration.cs
@@ -334,10 +334,7 @@ namespace BugsnagUnity
             {
                 clone._user = _user.Clone();
             }
-            if (Endpoints.IsValid)
-            {
-                clone.Endpoints = Endpoints.Clone();
-            }
+            clone.Endpoints = Endpoints.Clone();
             return clone;
         }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Configuration.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Configuration.cs
@@ -58,7 +58,7 @@ namespace BugsnagUnity
         internal OrderedDictionary FeatureFlags = new OrderedDictionary();
 
 
-        public List<Regex> RedactedKeys = new List<Regex>{new Regex(".*password.*",RegexOptions.IgnoreCase)};
+        public List<Regex> RedactedKeys = new List<Regex> { new Regex(".*password.*", RegexOptions.IgnoreCase) };
         public bool KeyIsRedacted(string key)
         {
             if (RedactedKeys == null)
@@ -350,7 +350,7 @@ namespace BugsnagUnity
         {
             foreach (var flag in featureFlags)
             {
-                AddFeatureFlag(flag.Name,flag.Variant);
+                AddFeatureFlag(flag.Name, flag.Variant);
             }
         }
 
@@ -364,8 +364,9 @@ namespace BugsnagUnity
             FeatureFlags.Clear();
         }
 
-        public static AssemblyName GetAssemblyName() {
-            return typeof(Configuration).Assembly.GetName(); 
+        public static AssemblyName GetAssemblyName()
+        {
+            return typeof(Configuration).Assembly.GetName();
         }
     }
 
@@ -378,7 +379,7 @@ namespace BugsnagUnity
         public bool Crashes = true;
         public bool ThermalKills = true;
         public bool UnityLog = true;
-        
+
         public EnabledErrorTypes()
         { }
     }

--- a/Bugsnag/Assets/Bugsnag/Runtime/EndpointConfiguration.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/EndpointConfiguration.cs
@@ -14,9 +14,9 @@ namespace BugsnagUnity
 
         internal Uri Session;
 
-        internal bool NotifyIsCustom => Notify != null && Notify.ToString() != new Uri( DefaultNotifyEndpoint ).ToString();
+        internal bool NotifyIsCustom => Notify != null && Notify.ToString() != new Uri(DefaultNotifyEndpoint).ToString();
 
-        internal bool SessionIsCustom => Session != null && Session.ToString() != new Uri ( DefaultSessionEndpoint ).ToString();
+        internal bool SessionIsCustom => Session != null && Session.ToString() != new Uri(DefaultSessionEndpoint).ToString();
 
         internal bool IsValid
         {
@@ -24,7 +24,7 @@ namespace BugsnagUnity
             {
                 return Notify != null && Session != null && (NotifyIsCustom && SessionIsCustom || !NotifyIsCustom && !SessionIsCustom);
             }
-        }        
+        }
 
         internal EndpointConfiguration()
         {
@@ -40,7 +40,7 @@ namespace BugsnagUnity
             }
             catch (Exception e)
             {
-                UnityEngine.Debug.LogWarning( string.Format("Invalid configuration. Endpoints.Notify should be a valid URI. Error message: {0}. Events will not be sent to Bugsnag. " , e.Message));
+                UnityEngine.Debug.LogWarning(string.Format("Invalid configuration. Endpoints.Notify should be a valid URI. Error message: {0}. Events will not be sent to Bugsnag. ", e.Message));
             }
             try
             {
@@ -57,6 +57,6 @@ namespace BugsnagUnity
         {
             return (EndpointConfiguration)MemberwiseClone();
         }
-       
+
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/EndpointConfiguration.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/EndpointConfiguration.cs
@@ -5,52 +5,91 @@ namespace BugsnagUnity
 {
     public class EndpointConfiguration
     {
-
         private const string DefaultNotifyEndpoint = "https://notify.bugsnag.com";
-
+        private const string HubNotifyEndpoint = "https://notify.insighthub.smartbear.com";
         private const string DefaultSessionEndpoint = "https://sessions.bugsnag.com";
+        private const string HubSessionEndpoint = "https://sessions.insighthub.smartbear.com";
+        private const string HubApiPrefix = "00000";
+        private string _customNotifyEndpoint = string.Empty;
+        private string _customSessionEndpoint = string.Empty;
+        internal Uri NotifyEndpoint;
+        internal Uri SessionEndpoint;
+        internal bool IsConfigured = false;
 
-        internal Uri Notify;
-
-        internal Uri Session;
-
-        internal bool NotifyIsCustom => Notify != null && Notify.ToString() != new Uri(DefaultNotifyEndpoint).ToString();
-
-        internal bool SessionIsCustom => Session != null && Session.ToString() != new Uri(DefaultSessionEndpoint).ToString();
-
-        internal bool IsValid
+        internal void Configure(string apiKey)
         {
-            get
+            if (IsConfigured || string.IsNullOrEmpty(apiKey))
             {
-                return Notify != null && Session != null && (NotifyIsCustom && SessionIsCustom || !NotifyIsCustom && !SessionIsCustom);
+                return;
             }
+            // Check that if one endpoint is customised the other is also customised
+            if (!string.IsNullOrEmpty(_customNotifyEndpoint) && string.IsNullOrEmpty(_customSessionEndpoint))
+            {
+                UnityEngine.Debug.LogWarning("Invalid configuration. endpoints.NotifyEndpoint cannot be set without also setting endpoints.SessionEndpoint. Events will not be sent.");
+                return;
+            }
+            if (!string.IsNullOrEmpty(_customSessionEndpoint) && string.IsNullOrEmpty(_customNotifyEndpoint))
+            {
+                UnityEngine.Debug.LogWarning("Invalid configuration. endpoints.SessionEndpoint cannot be set without also setting endpoints.NotifyEndpoint. Sessions will not be sent.");
+                return;
+            }
+            try
+            {
+                if (!string.IsNullOrEmpty(_customNotifyEndpoint))
+                {
+                    NotifyEndpoint = new Uri(_customNotifyEndpoint);
+                }
+                else if (apiKey.StartsWith("00000"))
+                {
+                    NotifyEndpoint = new Uri(HubNotifyEndpoint);
+                }
+                else
+                {
+                    NotifyEndpoint = new Uri(DefaultNotifyEndpoint);
+                }
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning(string.Format("Invalid configuration. Endpoints.NotifyEndpoint should be a valid URI. Error message: {0}. Events will not be sent. ", e.Message));
+                return;
+            }
+
+            try
+            {
+                if (!string.IsNullOrEmpty(_customSessionEndpoint))
+                {
+                    SessionEndpoint = new Uri(_customSessionEndpoint);
+                }
+                else if (IsHubApiKey(apiKey))
+                {
+                    SessionEndpoint = new Uri(HubSessionEndpoint);
+                }
+                else
+                {
+                    SessionEndpoint = new Uri(DefaultSessionEndpoint);
+                }
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogWarning(string.Format("Invalid configuration. Endpoints.SessionEndpoint should be a valid URI. Error message:  {0}. Sessions will not be sent. ", e.Message));
+                return;
+            }
+            IsConfigured = true;
         }
 
-        internal EndpointConfiguration()
+        private bool IsHubApiKey(string apiKey)
         {
-            Notify = new Uri(DefaultNotifyEndpoint);
-            Session = new Uri(DefaultSessionEndpoint);
+            return apiKey.StartsWith(HubApiPrefix);
+        }
+
+        public EndpointConfiguration()
+        {
         }
 
         public EndpointConfiguration(string notifyEndpoint, string sessionEndpoint)
         {
-            try
-            {
-                Notify = new Uri(notifyEndpoint);
-            }
-            catch (Exception e)
-            {
-                UnityEngine.Debug.LogWarning(string.Format("Invalid configuration. Endpoints.Notify should be a valid URI. Error message: {0}. Events will not be sent to Bugsnag. ", e.Message));
-            }
-            try
-            {
-                Session = new Uri(sessionEndpoint);
-            }
-            catch (Exception e)
-            {
-                UnityEngine.Debug.LogWarning(string.Format("Invalid configuration. Endpoints.Session should be a valid URI. Error message:  {0}. Sessions will not be sent to Bugsnag. ", e.Message));
-
-            }
+            _customNotifyEndpoint = notifyEndpoint;
+            _customSessionEndpoint = sessionEndpoint;
         }
 
         internal EndpointConfiguration Clone()

--- a/Bugsnag/Assets/Bugsnag/Runtime/IClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/IClient.cs
@@ -51,7 +51,7 @@ namespace BugsnagUnity
 
         User GetUser();
 
-        void SetUser(string id,string email,string name);
+        void SetUser(string id, string email, string name);
 
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/MaximumLogTypeCounter.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/MaximumLogTypeCounter.cs
@@ -10,7 +10,7 @@ namespace BugsnagUnity
 
         private Dictionary<LogType, int> CurrentCounts { get; }
 
-        private double FlushAt { get; set; } = -1; 
+        private double FlushAt { get; set; } = -1;
 
         private double MaximumLogsTimePeriod => Configuration.MaximumLogsTimePeriod.TotalSeconds;
 
@@ -20,7 +20,7 @@ namespace BugsnagUnity
 
         private void EnsureFlushTimeIsSet()
         {
-            if (FlushAt < 0) 
+            if (FlushAt < 0)
             {
                 FlushAt = Time.ElapsedSeconds + MaximumLogsTimePeriod;
             }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeInterface.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeInterface.cs
@@ -368,8 +368,8 @@ namespace BugsnagUnity
             }
 
             // set endpoints
-            var notify = config.Endpoints.Notify.ToString();
-            var sessions = config.Endpoints.Session.ToString();
+            var notify = config.Endpoints.NotifyEndpoint.ToString();
+            var sessions = config.Endpoints.SessionEndpoint.ToString();
             using (AndroidJavaObject endpointConfig = new AndroidJavaObject("com.bugsnag.android.EndpointConfiguration", notify, sessions))
             {
                 obj.Call("setEndpoints", endpointConfig);

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/LoadedImages.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/LoadedImages.cs
@@ -17,7 +17,7 @@ namespace BugsnagUnity
         /// <remarks>
         /// Note: If anything goes wrong during the refresh, the currently cached state won't change.
         /// </remarks>
-        #nullable enable
+#nullable enable
         public void Refresh(String? mainImageFileName)
         {
             UInt64 loadedNativeImagesAt = NativeCode.bugsnag_lastChangedLoadedImages();
@@ -84,7 +84,7 @@ namespace BugsnagUnity
         /// </summary>
         /// <param name="address">The address to find the corresponding image of</param>
         /// <returns>The corresponding image, or null</returns>
-        #nullable enable
+#nullable enable
         public LoadedImage? FindImageAtAddress(UInt64 address)
         {
             if (address < LowestImageLoadAddress)

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
@@ -43,7 +43,7 @@ namespace BugsnagUnity
             NativeCode.bugsnag_setAutoNotifyConfig(obj, config.AutoDetectErrors);
             NativeCode.bugsnag_setReleaseStage(obj, config.ReleaseStage);
             NativeCode.bugsnag_setAppVersion(obj, config.AppVersion);
-            NativeCode.bugsnag_setEndpoints(obj, config.Endpoints.Notify.ToString(), config.Endpoints.Session.ToString());
+            NativeCode.bugsnag_setEndpoints(obj, config.Endpoints.NotifyEndpoint.ToString(), config.Endpoints.SessionEndpoint.ToString());
             NativeCode.bugsnag_setMaxBreadcrumbs(obj, config.MaximumBreadcrumbs);
             if (!string.IsNullOrEmpty(config.BundleVersion))
             {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/Breadcrumbs.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/Breadcrumbs.cs
@@ -24,7 +24,7 @@ namespace BugsnagUnity
         /// <summary>
         /// Add a breadcrumb to the collection with the specified type and metadata
         /// </summary>
-        public void Leave(string message, Dictionary<string, object> metadata,BreadcrumbType type )
+        public void Leave(string message, Dictionary<string, object> metadata, BreadcrumbType type)
         {
             Leave(new Breadcrumb(message, metadata, type));
         }
@@ -61,7 +61,7 @@ namespace BugsnagUnity
             }
         }
 
-      
+
     }
 }
 #endif

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/CacheManager.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/CacheManager.cs
@@ -52,7 +52,7 @@ namespace BugsnagUnity
         private string[] GetCachedSessionFiles()
         {
 
-            return GetFilesBySuffix(_sessionsDirectory,SESSION_FILE_SUFFIX);
+            return GetFilesBySuffix(_sessionsDirectory, SESSION_FILE_SUFFIX);
         }
 
         private string[] GetFilesBySuffix(string path, string suffix)
@@ -120,7 +120,7 @@ namespace BugsnagUnity
             }
         }
 
-        public void SaveSessionToCache(string id,string json)
+        public void SaveSessionToCache(string id, string json)
         {
             var path = _sessionsDirectory + "/" + id + SESSION_FILE_SUFFIX;
             WritePayloadToDisk(json, path);
@@ -153,7 +153,7 @@ namespace BugsnagUnity
             foreach (var file in ordered.Take(numToRemove))
             {
                 DeleteFile(file);
-            }            
+            }
         }
 
         public void RemoveCachedEvent(string id)
@@ -183,7 +183,8 @@ namespace BugsnagUnity
             try
             {
                 File.Delete(path);
-            }catch{}
+            }
+            catch { }
         }
 
         private void WriteFile(string path, string data)
@@ -195,20 +196,23 @@ namespace BugsnagUnity
                 file.Write(System.Text.Encoding.UTF8.GetBytes(data), 0, data.Length);
                 file.Flush();
                 file.Close();
-            }catch { }
+            }
+            catch { }
         }
 
         private string GetJsonFromCachePath(string path)
         {
-            try {
+            try
+            {
                 if (File.Exists(path))
                 {
                     return File.ReadAllText(path);
                 }
-            } catch { }
+            }
+            catch { }
             return null;
         }
-       
+
         private static void CheckForDirectoryCreation()
         {
             try

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Il2cppUtils.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Il2cppUtils.cs
@@ -46,11 +46,11 @@ namespace BugsnagUnity
 
 #else
 
-        private static void Free(IntPtr ptr) {}
+        private static void Free(IntPtr ptr) { }
 
 #endif
 
-        #nullable enable
+#nullable enable
         private static string? ExtractString(IntPtr pString, Int32 iLimit)
         {
             return (pString == IntPtr.Zero) ? null : Marshal.PtrToStringAnsi(pString, iLimit);
@@ -104,13 +104,13 @@ namespace BugsnagUnity
 
         internal static StackTraceLine[] ToStackFrames(System.Exception exception, Func<System.Exception, IntPtr[], String, String, StackTraceLine[]> stackTransformer)
         {
-             var notFound = new StackTraceLine[0];
-             if (exception == null)
-             {
-                 return notFound;
-             }
+            var notFound = new StackTraceLine[0];
+            if (exception == null)
+            {
+                return notFound;
+            }
 
- #if ENABLE_IL2CPP && UNITY_2021_3_OR_NEWER
+#if ENABLE_IL2CPP && UNITY_2021_3_OR_NEWER
              var hException = GCHandle.Alloc(exception);
              var pNativeAddresses = IntPtr.Zero;
              var pImageUuid = IntPtr.Zero;
@@ -179,9 +179,9 @@ namespace BugsnagUnity
                      hException.Free();
                  }
              }
- #else
-             return notFound;
- #endif
+#else
+            return notFound;
+#endif
         }
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Il2cppUtils.cs.meta
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Il2cppUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3beaf0145fc07462ca27feb534cac26d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/AppWithState.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/AppWithState.cs
@@ -52,7 +52,7 @@ namespace BugsnagUnity.Payload
             set => Add(IS_LAUNCHING_KEY, value);
         }
 
-        internal AppWithState(Dictionary<string, object> cachedData) : base(cachedData){}
+        internal AppWithState(Dictionary<string, object> cachedData) : base(cachedData) { }
 
         internal AppWithState(Configuration configuration) : base(configuration)
         {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Breadcrumb.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Breadcrumb.cs
@@ -46,7 +46,7 @@ namespace BugsnagUnity.Payload
         /// </summary>
         internal Breadcrumb(string message, string timestamp, string type, IDictionary<string, object> metadata)
         {
-            Timestamp = DateTimeOffset.Parse( timestamp );
+            Timestamp = DateTimeOffset.Parse(timestamp);
             Metadata = metadata;
             if (string.IsNullOrEmpty(type))
             {
@@ -59,7 +59,7 @@ namespace BugsnagUnity.Payload
             Message = message;
         }
 
-        internal Breadcrumb(string message,IDictionary<string, object> metadata, BreadcrumbType type)
+        internal Breadcrumb(string message, IDictionary<string, object> metadata, BreadcrumbType type)
         {
             Timestamp = DateTime.UtcNow;
             Metadata = metadata;
@@ -89,17 +89,20 @@ namespace BugsnagUnity.Payload
             set { Add(MESSAGE_KEY, value); }
         }
 
-        public BreadcrumbType Type {
-            get {
+        public BreadcrumbType Type
+        {
+            get
+            {
                 var stringValue = (string)Get(TYPE_KEY);
                 return ParseBreadcrumbType(stringValue);
             }
             set { Add(TYPE_KEY, value.ToString().ToLowerInvariant()); }
         }
 
-        public DateTimeOffset? Timestamp {
+        public DateTimeOffset? Timestamp
+        {
             get { return (DateTimeOffset)Get(TIMESTAMP_KEY); }
-            set { Add(TIMESTAMP_KEY,value); }
+            set { Add(TIMESTAMP_KEY, value); }
         }
 
         internal static BreadcrumbType ParseBreadcrumbType(string name)
@@ -136,7 +139,7 @@ namespace BugsnagUnity.Payload
             {
                 return BreadcrumbType.Manual;
             }
-            return BreadcrumbType.Manual;            
+            return BreadcrumbType.Manual;
         }
 
     }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Correlation.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Correlation.cs
@@ -7,30 +7,31 @@ namespace BugsnagUnity.Payload
 {
     public class Correlation : PayloadContainer
     {
-       
+
         private const string TRACE_ID_KEY = "traceId";
         private const string SPAN_ID_KEY = "spanId";
 
         internal Correlation(string traceId, string spanId)
         {
             TraceId = traceId;
-            SpanId = spanId;  
+            SpanId = spanId;
         }
 
         public string TraceId
         {
-            get {
+            get
+            {
                 var @object = Get(TRACE_ID_KEY);
                 if (@object == null)
                 {
                     return string.Empty;
                 }
                 return (string)@object;
-            } 
+            }
             set
             {
                 Add(TRACE_ID_KEY, value);
-            }  
+            }
         }
 
         public string SpanId

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Device.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Device.cs
@@ -127,7 +127,7 @@ namespace BugsnagUnity.Payload
             Model = SystemInfo.deviceModel;
         }
 
-      
+
 
         private void AddOsInfo()
         {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
@@ -48,9 +48,9 @@ namespace BugsnagUnity.Payload
         }
 
         internal Error(string errorClass, string message, StackTraceLine[] stackTrace)
-          : this(errorClass, message, stackTrace, HandledState.ForHandledException(),false) { }
+          : this(errorClass, message, stackTrace, HandledState.ForHandledException(), false) { }
 
-        internal Error(string errorClass, string message, IStackframe[] stackTrace, HandledState handledState,bool isAndroidJavaException)
+        internal Error(string errorClass, string message, IStackframe[] stackTrace, HandledState handledState, bool isAndroidJavaException)
         {
             ErrorClass = errorClass;
             ErrorMessage = message;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
@@ -16,6 +16,16 @@ namespace BugsnagUnity.Payload
 
         internal bool IsAndroidJavaException;
 
+        private const string COMPILATION_PLATFORM =
+#if ENABLE_IL2CPP
+        "il2cpp"
+#elif ENABLE_MONO
+            "mono"
+#else
+        "unknown" 
+#endif
+            ;
+
         private const string ANDROID_JAVA_EXCEPTION_CLASS = "AndroidJavaException";
         private const string ERROR_CLASS_MESSAGE_PATTERN = @"^(?<errorClass>\S+):\s+(?<message>.*)";
         private const string NATIVE_ANDROID_ERROR_CLASS = "java.lang.Error";
@@ -24,6 +34,7 @@ namespace BugsnagUnity.Payload
         private const string ERROR_CLASS_KEY = "errorClass";
         private const string MESSAGE_KEY = "message";
         private const string STACKTRACE_KEY = "stacktrace";
+        private const string ERROR_TYPE_KEY = "type";
 
         internal Error(Dictionary<string, object> data)
         {
@@ -57,6 +68,7 @@ namespace BugsnagUnity.Payload
             _stacktrace = stackTrace.ToList();
             HandledState = handledState;
             IsAndroidJavaException = isAndroidJavaException;
+            Type = COMPILATION_PLATFORM;
         }
 
 
@@ -76,8 +88,11 @@ namespace BugsnagUnity.Payload
             set => this.AddToPayload(MESSAGE_KEY, value);
         }
 
-        public string Type { get => "Unity"; }
-
+        public string Type
+        {
+            get => this.Get(ERROR_TYPE_KEY) as string;
+            set => this.AddToPayload(ERROR_TYPE_KEY, value);
+        }
         public static bool ShouldSend(System.Exception exception)
         {
             var errorClass = exception.GetType().Name;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Event.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Event.cs
@@ -38,7 +38,7 @@ namespace BugsnagUnity.Payload
             Breadcrumbs = new ReadOnlyCollection<IBreadcrumb>(breadcrumbsList);
             if (session != null)
             {
-                if(handledState.Handled)
+                if (handledState.Handled)
                 {
                     session.Events.UpdateHandledCount(true);
                 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/FeatureFlag.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/FeatureFlag.cs
@@ -6,7 +6,7 @@ namespace BugsnagUnity.Payload
     public class FeatureFlag : PayloadContainer
     {
 
-        internal FeatureFlag(Dictionary<string,object> data)
+        internal FeatureFlag(Dictionary<string, object> data)
         {
             Add(data);
         }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/HandledState.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/HandledState.cs
@@ -151,7 +151,7 @@ namespace BugsnagUnity.Payload
             {
                 this.AddToPayload("type", type);
                 this.AddToPayload("attributes", attributes);
-                this.AddToPayload("unhandledOverridden",false);
+                this.AddToPayload("unhandledOverridden", false);
             }
         }
     }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/IEvent.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/IEvent.cs
@@ -5,7 +5,7 @@ using BugsnagUnity.Payload;
 
 namespace BugsnagUnity
 {
-    public interface IEvent: IMetadataEditor, IUserEditor, IFeatureFlagStore
+    public interface IEvent : IMetadataEditor, IUserEditor, IFeatureFlagStore
     {
         string ApiKey { get; set; }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/IUser.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/IUser.cs
@@ -6,7 +6,7 @@ namespace BugsnagUnity
         string Id { get; }
 
         string Name { get; }
-      
+
         string Email { get; }
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
@@ -21,7 +21,7 @@ namespace BugsnagUnity.Payload
 
         public void AddMetadata(string section, string key, object value)
         {
-            AddMetadata(section, new Dictionary<string, object>{{ key, value }});
+            AddMetadata(section, new Dictionary<string, object> { { key, value } });
         }
 
         public void AddMetadata(string section, IDictionary<string, object> metadataSection)
@@ -50,15 +50,15 @@ namespace BugsnagUnity.Payload
             }
             else
             {
-                Add(section,metadataSection);
+                Add(section, metadataSection);
             }
             if (_nativeClient != null)
             {
-                _nativeClient.AddNativeMetadata(section,metadataSection);
+                _nativeClient.AddNativeMetadata(section, metadataSection);
             }
         }
 
-       
+
 
         public void ClearMetadata(string section)
         {
@@ -80,11 +80,11 @@ namespace BugsnagUnity.Payload
                 if (existingSection.ContainsKey(key))
                 {
                     existingSection.Remove(key);
-                }                
+                }
             }
             if (_nativeClient != null)
             {
-                _nativeClient.ClearNativeMetadata(section,key);
+                _nativeClient.ClearNativeMetadata(section, key);
             }
         }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/PayloadContainer.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/PayloadContainer.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace BugsnagUnity.Payload
 {
-   
+
     public class PayloadContainer
     {
         internal PayloadDictionary Payload = new PayloadDictionary();
@@ -37,7 +37,7 @@ namespace BugsnagUnity.Payload
                 return null;
             }
         }
-       
+
     }
 
     internal class PayloadDictionary : Dictionary<string, object?>, IFilterable

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Report.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Report.cs
@@ -21,7 +21,7 @@ namespace BugsnagUnity.Payload
         {
             Id = Guid.NewGuid().ToString();
             Ignored = false;
-            Endpoint = configuration.Endpoints.Notify;
+            Endpoint = configuration.Endpoints.NotifyEndpoint;
             Headers = new[] {
                 new KeyValuePair<string, string>("Bugsnag-Api-Key", @event.ApiKey),
                 new KeyValuePair<string, string>("Bugsnag-Payload-Version", configuration.PayloadVersion),
@@ -34,7 +34,7 @@ namespace BugsnagUnity.Payload
         internal Report(Configuration configuration, Dictionary<string, object> serialisedPayload)
         {
             Id = serialisedPayload["id"].ToString();
-            Endpoint = configuration.Endpoints.Notify;
+            Endpoint = configuration.Endpoints.NotifyEndpoint;
             var apiKey = serialisedPayload["apiKey"].ToString();
             Headers = new[] {
                 new KeyValuePair<string, string>("Bugsnag-Api-Key", apiKey),

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Session.cs
@@ -74,7 +74,7 @@ namespace BugsnagUnity.Payload
 
         internal void AddException(Report report)
         {
-            if(report.IsHandled)
+            if (report.IsHandled)
             {
                 Events.UpdateHandledCount(true);
             }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/SessionReport.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/SessionReport.cs
@@ -30,11 +30,11 @@ namespace BugsnagUnity.Payload
             this.AddToPayload("notifier", NotifierInfo.Instance);
             this.AddToPayload("app", ((App)session.App).Payload);
             this.AddToPayload("device", ((Device)session.Device).Payload);
-            var sessionObject = new Dictionary<string,object>();
+            var sessionObject = new Dictionary<string, object>();
             sessionObject.AddToPayload("id", session.Id);
             sessionObject.AddToPayload("startedAt", session.StartedAt);
             sessionObject.AddToPayload("user", session.User.Payload);
-            this.AddToPayload("sessions", new [] { sessionObject });
+            this.AddToPayload("sessions", new[] { sessionObject });
             Id = session.Id;
         }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/SessionReport.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/SessionReport.cs
@@ -17,7 +17,7 @@ namespace BugsnagUnity.Payload
 
         private void SetRequestInfo(Configuration configuration)
         {
-            Endpoint = configuration.Endpoints.Session;
+            Endpoint = configuration.Endpoints.SessionEndpoint;
             Headers = new KeyValuePair<string, string>[] {
                 new KeyValuePair<string, string>("Bugsnag-Api-Key", configuration.ApiKey),
                 new KeyValuePair<string, string>("Bugsnag-Payload-Version", configuration.SessionPayloadVersion),

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/StackTraceLine.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/StackTraceLine.cs
@@ -31,7 +31,7 @@ namespace BugsnagUnity.Payload
 
         internal PayloadStackTrace(string stackTrace, StackTraceFormat format)
         {
-            string[] lines = stackTrace.Split(new[] {"\r\n","\r","\n", System.Environment.NewLine },
+            string[] lines = stackTrace.Split(new[] { "\r\n", "\r", "\n", System.Environment.NewLine },
                                               System.StringSplitOptions.RemoveEmptyEntries);
             var frames = new List<StackTraceLine>();
             for (int i = 0; i < lines.Length; i++)
@@ -180,7 +180,8 @@ namespace BugsnagUnity.Payload
             }
         }
 
-        public string FrameAddress {
+        public string FrameAddress
+        {
             get
             {
                 return this.Get("frameAddress") as string;
@@ -203,7 +204,8 @@ namespace BugsnagUnity.Payload
             }
         }
 
-        public string MachoLoadAddress {
+        public string MachoLoadAddress
+        {
             get
             {
                 return this.Get("machoLoadAddress") as string;
@@ -214,7 +216,8 @@ namespace BugsnagUnity.Payload
             }
         }
 
-        public string MachoFile {
+        public string MachoFile
+        {
             get
             {
                 return this.Get("machoFile") as string;
@@ -225,7 +228,8 @@ namespace BugsnagUnity.Payload
             }
         }
 
-        public string MachoUuid {
+        public string MachoUuid
+        {
             get
             {
                 return this.Get("machoUUID") as string;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/User.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/User.cs
@@ -19,7 +19,7 @@ namespace BugsnagUnity.Payload
 
         }
 
-        public User(string id,  string email, string name)
+        public User(string id, string email, string name)
         {
             Id = id;
             Name = name;
@@ -28,19 +28,20 @@ namespace BugsnagUnity.Payload
 
         public string Id
         {
-            get {
+            get
+            {
                 var @object = Get(ID_KEY);
                 if (@object == null)
                 {
                     return string.Empty;
                 }
                 return (string)@object;
-            } 
+            }
             set
             {
                 Add(ID_KEY, value);
                 PropertyChanged.Invoke();
-            }  
+            }
         }
 
         public string Name

--- a/Bugsnag/Assets/Bugsnag/Runtime/PayloadManager.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/PayloadManager.cs
@@ -128,6 +128,6 @@ namespace BugsnagUnity
         {
             _cacheManager.RemoveCachedSession(id);
         }
-      
+
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/PerformanceHelper.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/PerformanceHelper.cs
@@ -55,7 +55,7 @@ namespace BugsnagUnity
 
                 return correlation;
             }
-            catch 
+            catch
             {
                 // Silently handle case where performance library is not available or out of date
                 _isPerformanceLibraryAvailable = false;

--- a/Bugsnag/Assets/Bugsnag/Runtime/SessionTracker.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/SessionTracker.cs
@@ -101,7 +101,7 @@ namespace BugsnagUnity
                 }
             }
 
-            if (Client.Configuration.Endpoints.IsValid)
+            if (Client.Configuration.Endpoints.IsConfigured)
             {
                 var payload = new SessionReport(Client.Configuration, session);
                 if (Client.PayloadManager.AddPendingPayload(payload))

--- a/Bugsnag/Assets/Bugsnag/Runtime/SessionTracker.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/SessionTracker.cs
@@ -51,7 +51,7 @@ namespace BugsnagUnity
             {
                 return Client.NativeClient.GetCurrentSession();
             }
-            
+
         }
 
         internal SessionTracker(Client client)
@@ -88,12 +88,15 @@ namespace BugsnagUnity
 
             foreach (var sessionCallback in Client.Configuration.GetOnSessionCallbacks())
             {
-                try {
+                try
+                {
                     if (!sessionCallback.Invoke(session))
                     {
                         return;
                     }
-                } catch {
+                }
+                catch
+                {
                     // If the callback causes an exception, ignore it and execute the next one
                 }
             }
@@ -145,7 +148,7 @@ namespace BugsnagUnity
             {
                 return Client.NativeClient.ResumeSession();
             }
-             
+
         }
 
         private bool ResumeManagedSession()

--- a/Bugsnag/Assets/Bugsnag/Runtime/UnityLogMessage.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/UnityLogMessage.cs
@@ -32,6 +32,6 @@ namespace BugsnagUnity
 
         public double CreatedAt { get; }
 
-        
+
     }
 }

--- a/Bugsnag/Assets/Scripts/Testing.cs
+++ b/Bugsnag/Assets/Scripts/Testing.cs
@@ -8,22 +8,22 @@ using UnityEngine;
 
 public class Testing : MonoBehaviour
 {
-   // Start is called before the first frame update
-   public void Throw()
-   {
-      throw new System.Exception("This is an exception");
-   }
+    // Start is called before the first frame update
+    public void Throw()
+    {
+        throw new System.Exception("This is an exception");
+    }
 
-   public void DoTriggerCocoaCppException()
-   {
-#if UNITY_IOS 
+    public void DoTriggerCocoaCppException()
+    {
+#if UNITY_IOS
       TriggerCocoaCppException();
 #endif
 
 #if UNITY_STANDALONE_OSX
-    crashy_signal_runner(8);
+        crashy_signal_runner(8);
 #endif
-   }
+    }
 
 #if UNITY_STANDALONE_OSX
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,13 @@
 
 ## TBD
 
-### Dependencies
-
-- Update bugsnag-cocoa to [v6.32.2](https://github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.32.2) [#895](https://github.com/bugsnag/bugsnag-unity/pull/895)
-
 ### Enhancements
 
 - Update Bugsnag Editor PlayerSettingsCompat to prevent compiler warnings. [#892](https://github.com/bugsnag/bugsnag-unity/pull/892)
 
 ### Dependencies
+
+- Update bugsnag-cocoa to [v6.32.2](https://github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.32.2) [#895](https://github.com/bugsnag/bugsnag-unity/pull/895)
 
 - Update bugsnag-android to [v6.12.1](https://github.com/bugsnag/bugsnag-android/releases/tag/v6.12.1) [#888](https://github.com/bugsnag/bugsnag-unity/pull/888)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 8.6.0 (2025-06-03)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+- Add compilation platform as `error.type` to event payloads to enable IL2CPP symbolication in future [#904](https://github.com/bugsnag/bugsnag-unity/pull/904)
+
 ## 8.5.2 (2025-03-31)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+- Set default endpoints based on API key [#905](https://github.com/bugsnag/bugsnag-unity/pull/905)
+
 - Add compilation platform as `error.type` to event payloads to enable IL2CPP symbolication in future [#904](https://github.com/bugsnag/bugsnag-unity/pull/904)
 
 ## 8.5.2 (2025-03-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+- Update Bugsnag Editor PlayerSettingsCompat to prevent compiler warnings. [#892](https://github.com/bugsnag/bugsnag-unity/pull/892)
+
 ## 8.5.1 (2025-03-03)
 
 ### Dependencies

--- a/Rakefile
+++ b/Rakefile
@@ -561,3 +561,17 @@ namespace :test do
     end
   end
 end 
+
+namespace :code do
+  desc "Verify code formatting (dotnet format --verify-no-changes)"
+  task :verify do
+    # Call your script with the --verify argument
+    sh "scripts/code_format.sh --verify"
+  end
+
+  desc "Apply code formatting (dotnet format)"
+  task :format do
+    # Call your script without the --verify argument
+    sh "scripts/code_format.sh"
+  end
+end

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -17,6 +17,23 @@ Feature: csharp events
     And expected app metadata is included in the event
     And the error payload field "events.0.severityReason.unhandledOverridden" is false
 
+  @mobile_only
+  Scenario: Error type IL2CPP
+    When I run the game in the "NotifySmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "NotifySmokeTest"
+    And the exception "type" equals "il2cpp"
+   
+  @macos_only
+  Scenario: Error type MONO
+    When I run the game in the "NotifySmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "NotifySmokeTest"
+    And the exception "type" equals "mono"
 
   Scenario: Uncaught Exception smoke test
     When I run the game in the "UncaughtExceptionSmokeTest" state

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs
@@ -1,0 +1,40 @@
+using UnityEditor;
+namespace Mazerunner.Editor
+{
+    [InitializeOnLoad]
+    public class BugsnagAddScriptingSymbol
+    {
+        private const string DEFINE_SYMBOL = "UNITY_ASSERTIONS";
+
+        private static BuildTargetGroup[] _supportedPlatforms = { BuildTargetGroup.Android, BuildTargetGroup.iOS };
+
+        static BugsnagAddScriptingSymbol()
+        {
+            foreach (var target in _supportedPlatforms)
+            {
+                try
+                {
+                    SetScriptingSymbol(target);
+                }
+                catch
+                {
+                    // Some users might not have a platform installed, in that case ignore the error
+                }
+            }
+        }
+
+        static void SetScriptingSymbol(BuildTargetGroup buildTargetGroup)
+        {
+            var existingSymbols = BugsnagPlayerSettingsCompat.GetScriptingDefineSymbols(buildTargetGroup);
+            if (string.IsNullOrEmpty(existingSymbols))
+            {
+                existingSymbols = DEFINE_SYMBOL;
+            }
+            else if (!existingSymbols.Contains(DEFINE_SYMBOL))
+            {
+                existingSymbols += ";" + DEFINE_SYMBOL;
+            }
+            BugsnagPlayerSettingsCompat.SetScriptingDefineSymbols(buildTargetGroup, existingSymbols);
+        }
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagAddScriptingSymbol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42ce8b448a31e498cab37f3a2495f893
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs
@@ -2,7 +2,7 @@ using UnityEditor;
 #if UNITY_2021_2_OR_NEWER
 using UnityEditor.Build;
 #endif
-namespace BugsnagUnity.Editor
+namespace Mazerunner.Editor
 {
     internal static class BugsnagPlayerSettingsCompat
     {

--- a/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Editor/BugsnagPlayerSettingsCompat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f409526a50b1a41d78539f009c44ce73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Editor/Builder.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/Builder.cs
@@ -167,8 +167,6 @@ public class Builder : MonoBehaviour
         var scenes = EditorBuildSettings.scenes.Where(s => s.enabled).Select(s => s.path).ToArray();
 
         PlayerSettings.defaultInterfaceOrientation = UIOrientation.Portrait;
-        PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Android, "UNITY_ASSERTIONS");
-        PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.iOS, "UNITY_ASSERTIONS");
 
         BuildPlayerOptions opts = new BuildPlayerOptions();
         opts.scenes = scenes;

--- a/features/scripts/prepare_fixture.sh
+++ b/features/scripts/prepare_fixture.sh
@@ -40,3 +40,9 @@ $UNITY_PATH/Unity $DEFAULT_CLI_ARGS \
                   -importPackage $script_path/../../Bugsnag.unitypackage
 RESULT=$?
 if [ $RESULT -ne 0 ]; then exit $RESULT; fi
+
+
+#import performance to ensure no breaking changes
+echo "Cloning latest perf release into packages"
+rm -rf "$project_path/packages/performance-package"
+git clone https://github.com/bugsnag/bugsnag-unity-performance-upm.git "$project_path/packages/performance-package"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -78,6 +78,14 @@ Before('@android_only') do |_scenario|
   skip_this_scenario('Skipping scenario') unless Maze::Helper.get_current_platform == 'android'
 end
 
+Before('@mobile_only') do |_scenario|
+  mobile_platforms = %w[android ios]
+  current_platform = Maze::Helper.get_current_platform
+  unless mobile_platforms.include?(current_platform)
+    skip_this_scenario('Skipping scenario, this scenario is only for Android or iOS')
+  end
+end
+
 
 BeforeAll do
   $api_key = 'a35a2a72bd230ac0aa0f52715bbdc6aa'

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e  
+
+if [ -z "$UNITY_VERSION" ]; then
+  echo "UNITY_VERSION must be set"
+  exit 1
+fi
+
+UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS"
+DEFAULT_CLI_ARGS="-quit -batchmode -nographics"
+PROJECT_PATH="Bugsnag"
+
+# Generate .sln and project files
+$UNITY_PATH/Unity $DEFAULT_CLI_ARGS -projectPath "$PROJECT_PATH" -executeMethod "UnityEditor.SyncVS.SyncSolution"
+RESULT=$?
+if [ $RESULT -ne 0 ]; then
+  exit $RESULT
+fi
+
+# Decide which dotnet format command to run based on the argument
+FORMAT_COMMAND="dotnet format"
+if [ "$1" == "--verify" ]; then
+  FORMAT_COMMAND="dotnet format --verify-no-changes"
+fi
+
+# Execute dotnet format
+$FORMAT_COMMAND "$PROJECT_PATH/Bugsnag.sln"
+EXIT_CODE=$?
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo "Error: Code formatting verification found issues."
+  exit "$EXIT_CODE"
+fi
+
+echo "Done."


### PR DESCRIPTION
## 8.6.0 (2025-06-03)

### Enhancements

- Set default endpoints based on API key [#905](https://github.com/bugsnag/bugsnag-unity/pull/905)

- Add compilation platform as `error.type` to event payloads to enable IL2CPP symbolication in future [#904](https://github.com/bugsnag/bugsnag-unity/pull/904)

### Notes 
The dif is larger than the changelog would suggest because this is the first release since we started applying auto formatting to our C# code.