### PR TITLE
Migrate to Macos 15 and Update the port used for the test fixture

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -2,22 +2,22 @@ agents:
   queue: macos
 
 steps:
-  - label: 'Append Unity 2020 Pipeline'
-    timeout_in_minutes: 2
-    commands:
-        - buildkite-agent pipeline upload .buildkite/unity.2020.yml
+#  - label: 'Append Unity 2020 Pipeline'
+#    timeout_in_minutes: 2
+#    commands:
+#        - buildkite-agent pipeline upload .buildkite/unity.2020.yml
 
   - label: 'Append Full Unity 2021 Pipeline'
     timeout_in_minutes: 2
     commands:
         - buildkite-agent pipeline upload .buildkite/unity.2021.full.yml
 
-  - label: 'Append Unity 2022 Pipeline'
-    timeout_in_minutes: 2
-    commands:
-        - buildkite-agent pipeline upload .buildkite/unity.2022.yml
-
-  - label: 'Append Unity 6000 Pipeline'
-    timeout_in_minutes: 2
-    commands:
-        - buildkite-agent pipeline upload .buildkite/unity.6000.yml
+#  - label: 'Append Unity 2022 Pipeline'
+#    timeout_in_minutes: 2
+#    commands:
+#        - buildkite-agent pipeline upload .buildkite/unity.2022.yml
+#
+#  - label: 'Append Unity 6000 Pipeline'
+#    timeout_in_minutes: 2
+#    commands:
+#        - buildkite-agent pipeline upload .buildkite/unity.6000.yml

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -12,12 +12,12 @@ steps:
     commands:
         - buildkite-agent pipeline upload .buildkite/unity.2021.full.yml
 
-#  - label: 'Append Unity 2022 Pipeline'
-#    timeout_in_minutes: 2
-#    commands:
-#        - buildkite-agent pipeline upload .buildkite/unity.2022.yml
-#
-#  - label: 'Append Unity 6000 Pipeline'
-#    timeout_in_minutes: 2
-#    commands:
-#        - buildkite-agent pipeline upload .buildkite/unity.6000.yml
+  - label: 'Append Unity 2022 Pipeline'
+    timeout_in_minutes: 2
+    commands:
+        - buildkite-agent pipeline upload .buildkite/unity.2022.yml
+
+  - label: 'Append Unity 6000 Pipeline'
+    timeout_in_minutes: 2
+    commands:
+        - buildkite-agent pipeline upload .buildkite/unity.6000.yml

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -2,10 +2,10 @@ agents:
   queue: macos
 
 steps:
-#  - label: 'Append Unity 2020 Pipeline'
-#    timeout_in_minutes: 2
-#    commands:
-#        - buildkite-agent pipeline upload .buildkite/unity.2020.yml
+  - label: 'Append Unity 2020 Pipeline'
+    timeout_in_minutes: 2
+    commands:
+        - buildkite-agent pipeline upload .buildkite/unity.2020.yml
 
   - label: 'Append Full Unity 2021 Pipeline'
     timeout_in_minutes: 2

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-15
 
 steps:
   - label: Build released notifier artifact
@@ -19,7 +19,6 @@ steps:
       - Bugsnag.unitypackage
       - upm-package.zip
       - upm-edm4u-package.zip
-
     retry:
       automatic:
         - exit_status: "*"
@@ -31,7 +30,6 @@ steps:
       UNITY_VERSION: *2021
     commands:
       - rake code:verify
-
 
   - label: "Test UPM Package Import"
     depends_on: build_unitypackage

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -2,12 +2,14 @@ aliases:
   - &2020 "2020.3.48f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-15
 
 steps:
   - group: ":hammer: Build Unity 2020 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 2020"
+        agents:
+          queue: macos-15-isolated
         timeout_in_minutes: 20
         key: "build-android-fixture-2020"
         env:
@@ -32,11 +34,11 @@ steps:
       #
       - label: ":ios: Build iOS test fixture for Unity 2020"
         agents:
-          queue: macos-14-isolated
+          queue: macos-15-isolated
         timeout_in_minutes: 10
         key: "build-ios-fixture-2020"
         env:
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.3.0"
           UNITY_VERSION: *2020
         plugins:
           artifacts#v1.9.0:
@@ -58,7 +60,7 @@ steps:
         key: "macos-2020-fixture"
         env:
           UNITY_VERSION: *2020
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.3.0"
           # Python2 needed for WebGL to build
           EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
         plugins:
@@ -76,13 +78,11 @@ steps:
               limit: 1
 
       - label: Build Unity 2020 WebGL test fixture
-        agents:
-          queue: macos-14-isolated
         timeout_in_minutes: 20
         key: "webgl-2020-fixture"
         env:
           UNITY_VERSION: *2020
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.3.0"
           # Python2 needed for WebGL to build
           EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
         plugins:

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -195,6 +195,8 @@ steps:
         concurrency_method: eager
 
       - label: Run MacOS e2e tests for Unity 2020
+        agents:
+          queue: macos-15-isolated
         timeout_in_minutes: 60
         depends_on: "macos-2020-fixture"
         env:

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -215,6 +215,8 @@ steps:
           - scripts/ci-run-macos-tests.sh release
 
       - label: Run WebGL e2e tests for Unity 2020
+        agents:
+          queue: macos-15-isolated
         timeout_in_minutes: 30
         depends_on: "webgl-2020-fixture"
         env:

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -34,11 +34,11 @@ steps:
       #
       - label: ":ios: Build iOS test fixture for Unity 2020"
         agents:
-          queue: macos-15
+          queue: macos-14
         timeout_in_minutes: 10
         key: "build-ios-fixture-2020"
         env:
-          XCODE_VERSION: "16.3.0"
+          XCODE_VERSION: "15.3.0"
           UNITY_VERSION: *2020
         plugins:
           artifacts#v1.9.0:

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -196,7 +196,7 @@ steps:
 
       - label: Run MacOS e2e tests for Unity 2020
         agents:
-          queue: macos-15
+          queue: macos-15-isolated
         timeout_in_minutes: 60
         depends_on: "macos-2020-fixture"
         env:
@@ -218,7 +218,7 @@ steps:
 
       - label: Run WebGL e2e tests for Unity 2020
         agents:
-          queue: macos-15
+          queue: macos-15-isolated
         timeout_in_minutes: 30
         depends_on: "webgl-2020-fixture"
         env:

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -9,7 +9,7 @@ steps:
     steps:
       - label: ":android: Build Android test fixture for Unity 2020"
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 20
         key: "build-android-fixture-2020"
         env:
@@ -34,7 +34,7 @@ steps:
       #
       - label: ":ios: Build iOS test fixture for Unity 2020"
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 10
         key: "build-ios-fixture-2020"
         env:
@@ -196,7 +196,7 @@ steps:
 
       - label: Run MacOS e2e tests for Unity 2020
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 60
         depends_on: "macos-2020-fixture"
         env:
@@ -218,7 +218,7 @@ steps:
 
       - label: Run WebGL e2e tests for Unity 2020
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 30
         depends_on: "webgl-2020-fixture"
         env:

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -299,7 +299,6 @@ steps:
             upload:
               - "maze_output/**/*"
               - "maze_output/metrics.csv"
-
           docker-compose#v4.7.0:
             pull: maze-runner-bitbar
             run: maze-runner-bitbar
@@ -323,10 +322,10 @@ steps:
         concurrency_method: eager
 
       - label: Run MacOS e2e tests for Unity 2021
+        agents:
+          queue: macos-15-isolated
         timeout_in_minutes: 30
         depends_on: 'macos-2021-fixture'
-        agents:
-          queue: macos-14-isolated
         env:
           UNITY_VERSION: *2021
         plugins:
@@ -344,10 +343,10 @@ steps:
           - scripts/ci-run-macos-tests.sh release
 
       - label: Run MacOS e2e DEV tests for Unity 2021
+        agents:
+          queue: macos-15-isolated
         timeout_in_minutes: 60
         depends_on: 'macos-2021-dev-fixture'
-        agents:
-          queue: macos-14-isolated
         env:
           UNITY_VERSION: *2021
         plugins:

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -323,7 +323,7 @@ steps:
 
       - label: Run MacOS e2e tests for Unity 2021
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 30
         depends_on: 'macos-2021-fixture'
         env:
@@ -344,7 +344,7 @@ steps:
 
       - label: Run MacOS e2e DEV tests for Unity 2021
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 60
         depends_on: 'macos-2021-dev-fixture'
         env:
@@ -365,7 +365,7 @@ steps:
 
       - label: Run WebGL e2e tests for Unity 2021
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 20
         depends_on: 'webgl-2021-fixture'
         env:
@@ -386,7 +386,7 @@ steps:
 
       - label: Run WebGL e2e DEV tests for Unity 2021
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 20
         depends_on: 'webgl-2021-dev-fixture'
         env:

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-15
 
 steps:
   - group: ":hammer: Build Unity 2021 full test fixtures"
@@ -48,8 +48,6 @@ steps:
               limit: 1
 
       - label: ":ios: Generate Xcode DEV project - Unity 2021"
-        agents:
-          queue: macos-14-isolated
         timeout_in_minutes: 10
         key: "generate-dev-fixture-project-2021"
         env:
@@ -76,7 +74,7 @@ steps:
         depends_on: "generate-dev-fixture-project-2021"
         env:
           UNITY_VERSION: *2021
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.2.0"
         plugins:
           artifacts#v1.5.0:
             download:
@@ -99,7 +97,7 @@ steps:
         key: "macos-2021-fixture"
         env:
           UNITY_VERSION: *2021
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.2.0"
         plugins:
           artifacts#v1.9.0:
             download:
@@ -119,7 +117,7 @@ steps:
         key: "macos-2021-dev-fixture"
         env:
           UNITY_VERSION: *2021
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.2.0"
         plugins:
           artifacts#v1.9.0:
             download:
@@ -139,7 +137,7 @@ steps:
         key: "webgl-2021-fixture"
         env:
           UNITY_VERSION: *2021
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.2.0"
         plugins:
           artifacts#v1.9.0:
             download:
@@ -159,7 +157,7 @@ steps:
         key: "webgl-2021-dev-fixture"
         env:
           UNITY_VERSION: *2021
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.2.0"
         plugins:
           artifacts#v1.9.0:
             download:

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -365,6 +365,8 @@ steps:
           - scripts/ci-run-macos-tests.sh dev
 
       - label: Run WebGL e2e tests for Unity 2021
+        agents:
+          queue: macos-15-isolated
         timeout_in_minutes: 20
         depends_on: 'webgl-2021-fixture'
         env:
@@ -384,6 +386,8 @@ steps:
           - scripts/ci-run-webgl-tests.sh release
 
       - label: Run WebGL e2e DEV tests for Unity 2021
+        agents:
+          queue: macos-15-isolated
         timeout_in_minutes: 20
         depends_on: 'webgl-2021-dev-fixture'
         env:

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -323,7 +323,7 @@ steps:
 
       - label: Run MacOS e2e tests for Unity 2021
         agents:
-          queue: macos-15
+          queue: macos-15-isolated
         timeout_in_minutes: 30
         depends_on: 'macos-2021-fixture'
         env:
@@ -344,7 +344,7 @@ steps:
 
       - label: Run MacOS e2e DEV tests for Unity 2021
         agents:
-          queue: macos-15
+          queue: macos-15-isolated
         timeout_in_minutes: 60
         depends_on: 'macos-2021-dev-fixture'
         env:
@@ -365,7 +365,7 @@ steps:
 
       - label: Run WebGL e2e tests for Unity 2021
         agents:
-          queue: macos-15
+          queue: macos-15-isolated
         timeout_in_minutes: 20
         depends_on: 'webgl-2021-fixture'
         env:
@@ -386,7 +386,7 @@ steps:
 
       - label: Run WebGL e2e DEV tests for Unity 2021
         agents:
-          queue: macos-15
+          queue: macos-15-isolated
         timeout_in_minutes: 20
         depends_on: 'webgl-2021-dev-fixture'
         env:

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-15-isolated
+  queue: macos-15
 
 steps:
   - group: ":hammer: Build Unity 2021 test fixtures"

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-15
+  queue: macos-15-isolated
 
 steps:
   - group: ":hammer: Build Unity 2021 test fixtures"

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-15
 
 steps:
   - group: ":hammer: Build Unity 2021 test fixtures"
@@ -26,18 +26,13 @@ steps:
           automatic:
             - exit_status: "*"
               limit: 1
-        agents:
-          queue: macos-14-unity-isolated
-        concurrency: 1
-        concurrency_group: "unity-license-server"
-        concurrency_method: eager
 
       - label: ":ios: Build iOS test fixture for Unity 2021"
         timeout_in_minutes: 10
         key: "build-ios-fixture-2021"
         env:
           UNITY_VERSION: *2021
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.2.0"
         plugins:
           artifacts#v1.5.0:
             download:
@@ -52,12 +47,6 @@ steps:
           automatic:
             - exit_status: "*"
               limit: 1
-        agents:
-          queue: macos-14-unity-isolated
-        concurrency: 1
-        concurrency_group: "unity-license-server"
-        concurrency_method: eager
-
 
   - group: ":test_tube: E2E tests Unity 2021"
     steps:

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -34,7 +34,7 @@ steps:
         key: "build-ios-fixture-2022"
         env:
           UNITY_VERSION: *2022
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.3.0"
         plugins:
           artifacts#v1.9.0:
             download:
@@ -55,7 +55,7 @@ steps:
         key: "macos-2022-fixture"
         env:
           UNITY_VERSION: *2022
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.3.0"
         plugins:
           artifacts#v1.9.0:
             download:
@@ -75,7 +75,7 @@ steps:
         key: "webgl-2022-fixture"
         env:
           UNITY_VERSION: *2022
-          XCODE_VERSION: "15.3.0"
+          XCODE_VERSION: "16.3.0"
         plugins:
           artifacts#v1.9.0:
             download:

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -187,6 +187,8 @@ steps:
       - label: Run MacOS e2e tests for Unity 2022
         timeout_in_minutes: 60
         depends_on: 'macos-2022-fixture'
+        agents:
+          queue: macos-15-isolated
         env:
           UNITY_VERSION: *2022
         plugins:
@@ -206,6 +208,8 @@ steps:
       - label: Run WebGL e2e tests for Unity 2022
         timeout_in_minutes: 30
         depends_on: 'webgl-2022-fixture'
+        agents:
+          queue: macos-15-isolated
         env:
           UNITY_VERSION: *2022
         plugins:

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -1,15 +1,15 @@
 aliases:
-  - &2022 "2022.3.61f1"
+  - &2022 "2022.3.62f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-15-isolated
 
 steps:
   - group: ":hammer: Build Unity 2022 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 2022"
         agents:
-          queue: macos-14-isolated
+          queue: macos-15-isolated
         timeout_in_minutes: 30
         key: "build-android-fixture-2022"
         env:

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -2,14 +2,14 @@ aliases:
   - &2022 "2022.3.62f1"
 
 agents:
-  queue: macos-15-isolated
+  queue: macos-15
 
 steps:
   - group: ":hammer: Build Unity 2022 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 2022"
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 30
         key: "build-android-fixture-2022"
         env:

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -1,15 +1,15 @@
 aliases:
-  - &6000 "6000.0.47f1"
+  - &6000 "6000.0.49f1"
 
 agents:
-  queue: macos-14-isolated
+  queue: macos-15-isolated
 
 steps:
   - group: ":hammer: Build Unity 6000 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 6000"
         agents:
-          queue: macos-14-isolated
+          queue: macos-15-isolated
         timeout_in_minutes: 20
         key: "build-android-fixture-6000"
         env:
@@ -52,7 +52,7 @@ steps:
 
       - label: Build Unity 6000 MacOS test fixture
         agents:
-          queue: macos-14-isolated
+          queue: macos-15-isolated
         timeout_in_minutes: 10
         key: "macos-6000-fixture"
         env:
@@ -191,7 +191,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: 'macos-6000-fixture'
         agents:
-          queue: macos-14-isolated
+          queue: macos-15-isolated
         env:
           UNITY_VERSION: *6000
         plugins:

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -2,14 +2,14 @@ aliases:
   - &6000 "6000.0.49f1"
 
 agents:
-  queue: macos-15-isolated
+  queue: macos-15
 
 steps:
   - group: ":hammer: Build Unity 6000 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 6000"
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 20
         key: "build-android-fixture-6000"
         env:
@@ -52,7 +52,7 @@ steps:
 
       - label: Build Unity 6000 MacOS test fixture
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         timeout_in_minutes: 10
         key: "macos-6000-fixture"
         env:
@@ -191,7 +191,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: 'macos-6000-fixture'
         agents:
-          queue: macos-15-isolated
+          queue: macos-15
         env:
           UNITY_VERSION: *6000
         plugins:

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -34,7 +34,7 @@ steps:
         key: "build-ios-fixture-6000"
         env:
           UNITY_VERSION: *6000
-          XCODE_VERSION: "16.0.0"
+          XCODE_VERSION: "16.3.0"
         plugins:
           artifacts#v1.9.0:
             download:
@@ -57,7 +57,7 @@ steps:
         key: "macos-6000-fixture"
         env:
           UNITY_VERSION: *6000
-          XCODE_VERSION: "16.0.0"
+          XCODE_VERSION: "16.3.0"
         plugins:
           artifacts#v1.9.0:
             download:
@@ -77,7 +77,7 @@ steps:
         key: "webgl-6000-fixture"
         env:
           UNITY_VERSION: *6000
-          XCODE_VERSION: "16.0.0"
+          XCODE_VERSION: "16.3.0"
         plugins:
           artifacts#v1.9.0:
             download:

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -191,7 +191,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: 'macos-6000-fixture'
         agents:
-          queue: macos-15
+          queue: macos-15-isolated
         env:
           UNITY_VERSION: *6000
         plugins:
@@ -211,6 +211,8 @@ steps:
       - label: Run WebGL e2e tests for Unity 6000
         timeout_in_minutes: 30
         depends_on: 'webgl-6000-fixture'
+        agents:
+          queue: macos-15-isolated
         env:
           UNITY_VERSION: *6000
         plugins:

--- a/features/fixtures/maze_runner/Assets/Editor/Builder.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/Builder.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using UnityEngine;
 using BugsnagUnity;
 using UnityEditor;

--- a/features/fixtures/maze_runner/Assets/Editor/Builder.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/Builder.cs
@@ -82,7 +82,15 @@ public class Builder : MonoBehaviour
         settingsObject.ApiKey = "a35a2a72bd230ac0aa0f52715bbdc6aa";
         settingsObject.StartAutomaticallyAtLaunch = false;
         settingsObject.AutoUploadSymbols = true;
-        settingsObject.UploadEndpoint = "http://localhost:9339";
+        string port = Environment.GetEnvironmentVariable("MAZE_RUNNER_PORT");
+        if (!string.IsNullOrEmpty(port))
+        {
+            settingsObject.UploadEndpoint = $"http://localhost:{port}";
+        }
+        else
+        {
+            settingsObject.UploadEndpoint = "http://localhost:9339";
+        }
         settingsObject.AppVersion = "1.2.3";
         settingsObject.VersionCode = 123;
         EditorUtility.SetDirty(settingsObject);
@@ -133,7 +141,15 @@ public class Builder : MonoBehaviour
         settingsObject.ApiKey = "a35a2a72bd230ac0aa0f52715bbdc6aa";
         settingsObject.StartAutomaticallyAtLaunch = false;
         settingsObject.AutoUploadSymbols = true;
-        settingsObject.UploadEndpoint = "http://localhost:9339";
+        string port = Environment.GetEnvironmentVariable("MAZE_RUNNER_PORT");
+        if (!string.IsNullOrEmpty(port))
+        {
+            settingsObject.UploadEndpoint = $"http://localhost:{port}";
+        }
+        else
+        {
+            settingsObject.UploadEndpoint = "http://localhost:9339";
+        }
         settingsObject.AppVersion = "1.2.3";
         EditorUtility.SetDirty(settingsObject);
     }


### PR DESCRIPTION
## Goal
Migrate the CI steps to Macos 15
Update the port used for the mock server in the test fixture to set it from the ENV or default to the Maze Runner default (9339)
Unity 2020 iOS step is staying on Macos-14 due to a bug with Unity 2020 and Xcode 16.x 

## Testing

Covred by CI