### PR TITLE
enable fallback implementation for linux builds

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/Breadcrumbs.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/Breadcrumbs.cs
@@ -1,4 +1,4 @@
-﻿#if (UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_WEBGL || BSG_WIN_DEV) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV)
+﻿#if (UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_WEBGL || BSG_WIN_DEV || UNITY_STANDALONE_LINUX) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV)
 using System.Collections.Generic;
 using System.Linq;
 using BugsnagUnity.Payload;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/NativeClient.cs
@@ -1,4 +1,4 @@
-﻿#if (UNITY_EDITOR || UNITY_WEBGL) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV || BSG_WIN_DEV)
+﻿#if (UNITY_EDITOR || UNITY_WEBGL || UNITY_STANDALONE_LINUX) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV || BSG_WIN_DEV)
 using BugsnagUnity.Payload;
 using System;
 using System.Collections.Generic;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+- Enable fallback support for linux builds [#916](https://github.com/bugsnag/bugsnag-unity/pull/916)
+
 ## 8.6.1 (2025-07-10)
 
 ### Bug Fixes


### PR DESCRIPTION
## Goal

Whilst we cannot offer full platform support for linux this PR allows the fallback implementation of the notifier (as used in the editor and WebGL builds) to build and function well on Linux.

## Changeset

- Added UNITY_STANDALONE_LINUX compiler flags to the required fallback classes. 

## Testing

Manually tested that builds succeed on a local Linux machine and that events from that build show in the dashboard.