### PR TITLE
Release v8.6.2

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
@@ -1,2 +1,2 @@
 using System.Reflection;
-[assembly: AssemblyVersion("8.6.1.0")]
+[assembly: AssemblyVersion("8.6.2.0")]

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/Breadcrumbs.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/Breadcrumbs.cs
@@ -1,4 +1,4 @@
-﻿#if (UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_WEBGL || BSG_WIN_DEV) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV)
+﻿#if (UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_WEBGL || BSG_WIN_DEV || UNITY_STANDALONE_LINUX) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV)
 using System.Collections.Generic;
 using System.Linq;
 using BugsnagUnity.Payload;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/NativeClient.cs
@@ -1,4 +1,4 @@
-﻿#if (UNITY_EDITOR || UNITY_WEBGL) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV || BSG_WIN_DEV)
+﻿#if (UNITY_EDITOR || UNITY_WEBGL || UNITY_STANDALONE_LINUX) && !(BSG_COCOA_DEV || BSG_ANDROID_DEV || BSG_WIN_DEV)
 using BugsnagUnity.Payload;
 using System;
 using System.Collections.Generic;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/StackTraceLine.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/StackTraceLine.cs
@@ -113,7 +113,7 @@ namespace BugsnagUnity.Payload
             return FromLogMessage(message);
         }
 
-        internal static StackTraceLine FromStackFrame(StackFrame stackFrame)
+        public static StackTraceLine FromStackFrame(StackFrame stackFrame)
         {
             var method = stackFrame.GetMethod();
             var file = stackFrame.GetFileName();

--- a/Bugsnag/Assets/Tests/StackFrameParsingTests.cs
+++ b/Bugsnag/Assets/Tests/StackFrameParsingTests.cs
@@ -122,5 +122,28 @@ namespace BugsnagUnityTests
             Assert.AreEqual("BugsnagCrash.java", stackframe.File);
             Assert.AreEqual(14, stackframe.LineNumber);
         }
+
+        [Test]
+        public void ConvertSystemStackTraceFrames()
+        {
+            var systemStackTrace = new System.Diagnostics.StackTrace(true);
+            var systemFrames = systemStackTrace.GetFrames();
+
+            Assert.IsNotNull(systemFrames, "Expected non-null StackFrame array from System.Diagnostics.StackTrace");
+            Assert.IsNotEmpty(systemFrames, "Expected at least one frame in the captured stack trace");
+
+            foreach (var frame in systemFrames)
+            {
+                var expectedMethod = new Method(frame.GetMethod()).DisplayName();
+                var expectedFile = frame.GetFileName();
+                var expectedLine = frame.GetFileLineNumber();
+
+                var bugsnagFrame = StackTraceLine.FromStackFrame(frame);
+
+                Assert.AreEqual(expectedMethod, bugsnagFrame.Method, "Method name did not match for frame {0}", expectedMethod);
+                Assert.AreEqual(expectedFile, bugsnagFrame.File, "File path did not match for method {0}", expectedMethod);
+                Assert.AreEqual(expectedLine, bugsnagFrame.LineNumber, "Line number did not match for method {0}", expectedMethod);
+            }
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Enable fallback support for linux builds [#916](https://github.com/bugsnag/bugsnag-unity/pull/916)
 
+- Add helper method for converting system stacktraces [#917](https://github.com/bugsnag/bugsnag-unity/pull/917)
+
 ## 8.6.1 (2025-07-10)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 8.6.2 (2025-07-16)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+- Enable fallback support for linux builds [#916](https://github.com/bugsnag/bugsnag-unity/pull/916)
+
 ## 8.6.1 (2025-07-10)
 
 ### Bug Fixes


### PR DESCRIPTION
## 8.6.2 (2025-07-16)

### Enhancements

- Enable fallback support for linux builds [#916](https://github.com/bugsnag/bugsnag-unity/pull/916)

- Add helper method for converting system stacktraces [#917](https://github.com/bugsnag/bugsnag-unity/pull/917)