### PR TITLE
final IL2CPP symbolication changes 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,6 +12,10 @@ steps:
       UNITY_VERSION: *2021
     commands:
       - rake code:verify
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1
 
   - label: Run Unit Tests
     timeout_in_minutes: 5

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -23,7 +23,7 @@ steps:
               - features/fixtures/build_android_apk.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os=macos features/build/build_android.feature"
+              - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_android.feature"
         retry:
           automatic:
             - exit_status: "*"
@@ -49,7 +49,7 @@ steps:
               - features/fixtures/unity.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os=macos features/build/build_ios.feature"
+              - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_ios.feature"
         retry:
           automatic:
             - exit_status: "*"

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -23,7 +23,7 @@ steps:
               - features/fixtures/build_android_apk.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os macos features/build/build_android.feature"
+              - "bundle exec maze-runner --os=macos features/build/build_android.feature"
         retry:
           automatic:
             - exit_status: "*"
@@ -49,7 +49,7 @@ steps:
               - features/fixtures/unity.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os macos features/build/build_ios.feature"
+              - "bundle exec maze-runner --os=macos features/build/build_ios.feature"
         retry:
           automatic:
             - exit_status: "*"

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -39,6 +39,7 @@ steps:
               - Bugsnag.unitypackage
             upload:
               - features/fixtures/maze_runner/mazerunner_2021.ipa
+              - features/fixtures/maze_runner/build.xcresult
               - features/fixtures/unity.log
         command:
               - "bundle install"

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -21,7 +21,7 @@ steps:
               - features/fixtures/build_android_apk.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os=macos features/build/build_android.feature"
+              - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_android.feature"
         retry:
           automatic:
             - exit_status: "*"
@@ -42,7 +42,7 @@ steps:
               - features/fixtures/unity.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os=macos features/build/build_ios.feature"
+              - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_ios.feature"
         retry:
           automatic:
             - exit_status: "*"

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -21,7 +21,7 @@ steps:
               - features/fixtures/build_android_apk.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os macos features/build/build_android.feature"
+              - "bundle exec maze-runner --os=macos features/build/build_android.feature"
         retry:
           automatic:
             - exit_status: "*"
@@ -42,7 +42,7 @@ steps:
               - features/fixtures/unity.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os macos features/build/build_ios.feature"
+              - "bundle exec maze-runner --os=macos features/build/build_ios.feature"
         retry:
           automatic:
             - exit_status: "*"

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -23,7 +23,7 @@ steps:
               - features/fixtures/build_android_apk.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os macos features/build/build_android.feature"
+              - "bundle exec maze-runner --os=macos features/build/build_android.feature"
         retry:
           automatic:
             - exit_status: "*"
@@ -44,7 +44,7 @@ steps:
               - features/fixtures/unity.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os macos features/build/build_ios.feature"
+              - "bundle exec maze-runner --os=macos features/build/build_ios.feature"
         retry:
           automatic:
             - exit_status: "*"

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -23,7 +23,7 @@ steps:
               - features/fixtures/build_android_apk.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os=macos features/build/build_android.feature"
+              - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_android.feature"
         retry:
           automatic:
             - exit_status: "*"
@@ -44,7 +44,7 @@ steps:
               - features/fixtures/unity.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os=macos features/build/build_ios.feature"
+              - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_ios.feature"
         retry:
           automatic:
             - exit_status: "*"

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -23,7 +23,7 @@ steps:
               - features/fixtures/build_android_apk.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os macos features/build/build_android.feature"
+              - "bundle exec maze-runner --os=macos features/build/build_android.feature"
         retry:
           automatic:
             - exit_status: "*"
@@ -44,7 +44,7 @@ steps:
               - features/fixtures/unity.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os macos features/build/build_ios.feature"
+              - "bundle exec maze-runner --os=macos features/build/build_ios.feature"
         retry:
           automatic:
             - exit_status: "*"

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -23,7 +23,7 @@ steps:
               - features/fixtures/build_android_apk.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os=macos features/build/build_android.feature"
+              - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_android.feature"
         retry:
           automatic:
             - exit_status: "*"
@@ -44,7 +44,7 @@ steps:
               - features/fixtures/unity.log
         command:
               - "bundle install"
-              - "bundle exec maze-runner --os=macos features/build/build_ios.feature"
+              - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_ios.feature"
         retry:
           automatic:
             - exit_status: "*"

--- a/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
@@ -8,7 +8,7 @@ namespace BugsnagUnity.Editor
 {
     internal class BugsnagCLI
     {
-        private const string DOWNLOADED_CLI_VERSION = "3.3.0";
+        private const string DOWNLOADED_CLI_VERSION = "3.3.1";
         private readonly string DOWNLOADED_CLI_PATH = Path.Combine(Application.dataPath, "../bugsnag/bin/bugsnag_cli");
         private readonly string DOWNLOADED_CLI_URL = $"https://github.com/bugsnag/bugsnag-cli/releases/download/v{DOWNLOADED_CLI_VERSION}/";
         private readonly string _cliExecutablePath;

--- a/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
@@ -50,6 +50,9 @@ namespace BugsnagUnity.Editor
             {
                 args += $" --application-id={bundleId}";
             }
+#if !UNITY_2021_1_OR_NEWER
+            args += " --no-upload-il2cpp-mapping";
+#endif
             int exitCode = StartProcess(_cliExecutablePath, args, out string output, out string error);
 
             if (exitCode != 0)
@@ -193,10 +196,9 @@ namespace BugsnagUnity.Editor
 
         public string GetIosDsymUploadCommand(string apiKey, string uploadEndpoint)
         {
-#if UNITY_2021_1_OR_NEWER
             var command = $"{_cliExecutablePath} upload unity-ios --api-key={apiKey} --dsym-path=$DWARF_DSYM_FOLDER_PATH --project-root={Application.dataPath} {Application.dataPath.Replace("/Assets", string.Empty)}";
-#else
-            var command = $"{_cliExecutablePath} upload unity-ios --api-key={apiKey} --dsym-path=$DWARF_DSYM_FOLDER_PATH --no-upload-il2cpp-mapping --project-root={Application.dataPath} {Application.dataPath.Replace("/Assets", string.Empty)}";
+#if !UNITY_2021_1_OR_NEWER
+            command += " --no-upload-il2cpp-mapping";
 #endif
             if (!string.IsNullOrEmpty(uploadEndpoint))
             {

--- a/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
@@ -193,7 +193,7 @@ namespace BugsnagUnity.Editor
 
         public string GetIosDsymUploadCommand(string apiKey, string uploadEndpoint)
         {
-            var command = $"{_cliExecutablePath} upload unity-ios --api-key={apiKey} --dsym-path=$DWARF_DSYM_FOLDER_PATH --project-root={Application.dataPath} {Application.dataPath.Replace("/Assets",string.Empty)}" ;
+            var command = $"{_cliExecutablePath} upload unity-ios --api-key={apiKey} --dsym-path=$DWARF_DSYM_FOLDER_PATH --project-root={Application.dataPath} {Application.dataPath.Replace("/Assets", string.Empty)}";
             if (!string.IsNullOrEmpty(uploadEndpoint))
             {
                 command += $" --upload-api-root-url={uploadEndpoint}";

--- a/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
@@ -193,7 +193,7 @@ namespace BugsnagUnity.Editor
 
         public string GetIosDsymUploadCommand(string apiKey, string uploadEndpoint)
         {
-            var command = $"{_cliExecutablePath} upload xcode-build --api-key={apiKey} $DWARF_DSYM_FOLDER_PATH";
+            var command = $"{_cliExecutablePath} upload unity-ios --api-key={apiKey} --dsym-path=$DWARF_DSYM_FOLDER_PATH --project-root={Application.dataPath} {Application.dataPath.Replace("/Assets",string.Empty)}" ;
             if (!string.IsNullOrEmpty(uploadEndpoint))
             {
                 command += $" --upload-api-root-url={uploadEndpoint}";

--- a/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
@@ -8,7 +8,7 @@ namespace BugsnagUnity.Editor
 {
     internal class BugsnagCLI
     {
-        private const string DOWNLOADED_CLI_VERSION = "2.9.1";
+        private const string DOWNLOADED_CLI_VERSION = "3.3.0";
         private readonly string DOWNLOADED_CLI_PATH = Path.Combine(Application.dataPath, "../bugsnag/bin/bugsnag_cli");
         private readonly string DOWNLOADED_CLI_URL = $"https://github.com/bugsnag/bugsnag-cli/releases/download/v{DOWNLOADED_CLI_VERSION}/";
         private readonly string _cliExecutablePath;

--- a/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/SymbolUpload/BugsnagCLI.cs
@@ -193,7 +193,11 @@ namespace BugsnagUnity.Editor
 
         public string GetIosDsymUploadCommand(string apiKey, string uploadEndpoint)
         {
+#if UNITY_2021_1_OR_NEWER
             var command = $"{_cliExecutablePath} upload unity-ios --api-key={apiKey} --dsym-path=$DWARF_DSYM_FOLDER_PATH --project-root={Application.dataPath} {Application.dataPath.Replace("/Assets", string.Empty)}";
+#else
+            var command = $"{_cliExecutablePath} upload unity-ios --api-key={apiKey} --dsym-path=$DWARF_DSYM_FOLDER_PATH --no-upload-il2cpp-mapping --project-root={Application.dataPath} {Application.dataPath.Replace("/Assets", string.Empty)}";
+#endif
             if (!string.IsNullOrEmpty(uploadEndpoint))
             {
                 command += $" --upload-api-root-url={uploadEndpoint}";

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/LoadedImages.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/LoadedImages.cs
@@ -79,7 +79,7 @@ namespace BugsnagUnity
                     var image = new LoadedImage(nativeImage.LoadAddress,
                                                 nativeImage.Size,
                                                 fileName,
-                                                uuidText,          // <- was: new Guid(uuid).ToString()
+                                                uuidText,
                                                 isMainImage);
 
                     if (isMainImage)

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/LoadedImages.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/LoadedImages.cs
@@ -18,23 +18,6 @@ namespace BugsnagUnity
         /// Note: If anything goes wrong during the refresh, the currently cached state won't change.
         /// </remarks>
 #nullable enable
-        private static string UuidTextFromBigEndianBytes(ReadOnlySpan<byte> b)
-        {
-            if (b.Length != 16) throw new ArgumentException(nameof(b));
-
-            Span<char> s = stackalloc char[36];
-            int j = 0;
-            for (int i = 0; i < 16; i++)
-            {
-                if (i == 4 || i == 6 || i == 8 || i == 10) s[j++] = '-';
-                byte v = b[i];
-                int hi = v >> 4, lo = v & 0xF;
-                s[j++] = (char)(hi < 10 ? '0' + hi : 'A' + (hi - 10));
-                s[j++] = (char)(lo < 10 ? '0' + lo : 'A' + (lo - 10));
-            }
-            return new string(s);
-        }
-
         public void Refresh(String? mainImageFileName)
         {
             UInt64 loadedNativeImagesAt = NativeCode.bugsnag_lastChangedLoadedImages();
@@ -146,6 +129,24 @@ namespace BugsnagUnity
                 return 0;
             }
         }
+
+        private static string UuidTextFromBigEndianBytes(ReadOnlySpan<byte> b)
+        {
+            if (b.Length != 16) throw new ArgumentException(nameof(b));
+
+            Span<char> s = stackalloc char[36];
+            int j = 0;
+            for (int i = 0; i < 16; i++)
+            {
+                if (i == 4 || i == 6 || i == 8 || i == 10) s[j++] = '-';
+                byte v = b[i];
+                int hi = v >> 4, lo = v & 0xF;
+                s[j++] = (char)(hi < 10 ? '0' + hi : 'A' + (hi - 10));
+                s[j++] = (char)(lo < 10 ? '0' + lo : 'A' + (lo - 10));
+            }
+            return new string(s);
+        }
+
     }
 }
 #endif

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/LoadedImages.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/LoadedImages.cs
@@ -129,22 +129,24 @@ namespace BugsnagUnity
                 return 0;
             }
         }
-
-        private static string UuidTextFromBigEndianBytes(ReadOnlySpan<byte> b)
+        
+        private static string UuidTextFromBigEndianBytes(byte[] b)
         {
-            if (b.Length != 16) throw new ArgumentException(nameof(b));
+            if (b == null || b.Length != 16) throw new ArgumentException(nameof(b));
 
-            Span<char> s = stackalloc char[36];
+            char[] chars = new char[36];
             int j = 0;
             for (int i = 0; i < 16; i++)
             {
-                if (i == 4 || i == 6 || i == 8 || i == 10) s[j++] = '-';
+                if (i == 4 || i == 6 || i == 8 || i == 10)
+                    chars[j++] = '-';
+
                 byte v = b[i];
                 int hi = v >> 4, lo = v & 0xF;
-                s[j++] = (char)(hi < 10 ? '0' + hi : 'A' + (hi - 10));
-                s[j++] = (char)(lo < 10 ? '0' + lo : 'A' + (lo - 10));
+                chars[j++] = (char)(hi < 10 ? '0' + hi : 'A' + (hi - 10));
+                chars[j++] = (char)(lo < 10 ? '0' + lo : 'A' + (lo - 10));
             }
-            return new string(s);
+            return new string(chars);
         }
 
     }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
@@ -544,7 +544,6 @@ namespace BugsnagUnity
             string hex = uuid.Replace("-", "").Trim();
             if (hex.Length != 32) return uuid; // leave unexpected formats alone
 
-            // validate hex chars if you like
             for (int i = 0; i < 32; i++)
             {
                 char c = hex[i];

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
@@ -537,52 +537,23 @@ namespace BugsnagUnity
             return stackFrames;
         }
 
-        private string FormatImageUuid(string imageUuid)
+        private static string FormatImageUuid(string uuid)
         {
-            if (string.IsNullOrEmpty(imageUuid))
+            if (string.IsNullOrEmpty(uuid)) return uuid;
+
+            string hex = uuid.Replace("-", "").Trim();
+            if (hex.Length != 32) return uuid; // leave unexpected formats alone
+
+            // validate hex chars if you like
+            for (int i = 0; i < 32; i++)
             {
-                return imageUuid; // Return the original value (null or empty)
+                char c = hex[i];
+                bool ok = (c >= '0' && c <= '9') || (c | 0x20) >= 'a' && (c | 0x20) <= 'f';
+                if (!ok) return uuid;
             }
 
-            // Remove any existing dashes and convert to lowercase for processing
-            string cleanUuid = imageUuid.Replace("-", "").ToLower();
-            
-            // If it's not 32 hex characters, return the original value
-            if (cleanUuid.Length != 32)
-            {
-                return imageUuid;
-            }
-
-            // Check if all characters are hex digits
-            foreach (char c in cleanUuid)
-            {
-                if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
-                {
-                    return imageUuid; // Return original if not valid hex
-                }
-            }
-
-            // Parse the UUID string and rearrange bytes for big-endian format
-            // Input format: f3b24c50e8f98330b0b1be8986b51d78
-            // Expected:     504cb2f3f9e83083b0b1be8986b51d78 -> 504CB2F3-F9E8-3083-90B1-BE8986B51D78
-            
-            string reorderedUuid = 
-                // First 4 bytes reversed: f3b24c50 -> 504cb2f3
-                cleanUuid.Substring(6, 2) + cleanUuid.Substring(4, 2) + cleanUuid.Substring(2, 2) + cleanUuid.Substring(0, 2) +
-                // Next 2 bytes reversed: e8f9 -> f9e8  
-                cleanUuid.Substring(10, 2) + cleanUuid.Substring(8, 2) +
-                // Next 2 bytes reversed: 8330 -> 3083
-                cleanUuid.Substring(14, 2) + cleanUuid.Substring(12, 2) +
-                // Last 8 bytes unchanged: b0b1be8986b51d78
-                cleanUuid.Substring(16);
-
-            // Convert to proper GUID format
-            if (reorderedUuid.Length == 32)
-            {
-                return $"{reorderedUuid.Substring(0, 8)}-{reorderedUuid.Substring(8, 4)}-{reorderedUuid.Substring(12, 4)}-{reorderedUuid.Substring(16, 4)}-{reorderedUuid.Substring(20)}".ToUpper();
-            }
-            
-            return imageUuid; // Fallback to original
+            hex = hex.ToUpperInvariant();
+            return $"{hex.Substring(0,8)}-{hex.Substring(8,4)}-{hex.Substring(12,4)}-{hex.Substring(16,4)}-{hex.Substring(20)}";
         }
 
         public StackTraceLine[] ToStackFrames(System.Exception exception)

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
@@ -509,29 +509,30 @@ namespace BugsnagUnity
                 var address = (UInt64)nativeAddresses[i].ToInt64();
                 var image = loadedImages.FindImageAtAddress(address);
 
-                var trace = new StackTraceLine();
-                trace.FrameAddress = string.Format("0x{0:X}", address);
-                trace.Method = method.ToString();
+                var frame = new StackTraceLine();
+                frame.FrameAddress = string.Format("0x{0:X}", address);
+                frame.Method = method.ToString();
+                frame.Type = "cocoa";
                 if (image != null)
                 {
                     if (address < image.LoadAddress)
                     {
                         // It's a relative address
-                        trace.FrameAddress = string.Format("0x{0:X}", address + image.LoadAddress);
+                        frame.FrameAddress = string.Format("0x{0:X}", address + image.LoadAddress);
                     }
-                    trace.MachoFile = image.FileName;
-                    trace.MachoLoadAddress = string.Format("0x{0:X}", image.LoadAddress);
-                    trace.MachoUuid = image.Uuid;
-                    trace.InProject = image.IsMainImage;
+                    frame.MachoFile = image.FileName;
+                    frame.MachoLoadAddress = string.Format("0x{0:X}", image.LoadAddress);
+                    frame.MachoUuid = image.Uuid;
+                    frame.InProject = image.IsMainImage;
                 }
                 else
                 {
-                    trace.MachoFile = safeMainImageFileName;
-                    trace.MachoLoadAddress = "0x0";
-                    trace.MachoUuid = mainImageFormattedUuid;
-                    trace.InProject = true;
+                    frame.MachoFile = safeMainImageFileName;
+                    frame.MachoLoadAddress = "0x0";
+                    frame.MachoUuid = mainImageFormattedUuid;
+                    frame.InProject = true;
                 }
-                stackFrames[i] = trace;
+                stackFrames[i] = frame;
             }
             return stackFrames;
         }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
@@ -25,7 +25,7 @@ namespace BugsnagUnity.Payload
         private const string MESSAGE_KEY = "message";
         private const string STACKTRACE_KEY = "stacktrace";
         private const string ERROR_TYPE_KEY = "type";
-        
+
         private static string _cachedErrorType;
 
         internal Error(Dictionary<string, object> data)

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Error.cs
@@ -152,9 +152,7 @@ namespace BugsnagUnity.Payload
                 default:
                     _cachedErrorType = null;
                     break;
-            }
-#else
-            _cachedErrorType = null;
+            }      
 #endif
             return _cachedErrorType;
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Enhancements
+
+- Enable IL2CPP line number symbolication fo riOS and Android via the BugSnag CLI [#920](https://github.com/bugsnag/bugsnag-unity/pull/920)
+
 ## 8.6.2 (2025-07-16)
 
 ### Enhancements

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -17,14 +17,23 @@ Feature: csharp events
     And expected app metadata is included in the event
     And the error payload field "events.0.severityReason.unhandledOverridden" is false
 
-  @mobile_only
-  Scenario: Error type IL2CPP
+  @android_only
+  Scenario: Error type Android IL2CPP
     When I run the game in the "NotifySmokeTest" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "errorClass" equals "Exception"
     And the exception "message" equals "NotifySmokeTest"
-    And the exception "type" equals "il2cpp"
+    And the exception "type" equals "c"
+
+  @ios_only
+  Scenario: Error type iOS IL2CPP
+    When I run the game in the "NotifySmokeTest" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "errorClass" equals "Exception"
+    And the exception "message" equals "NotifySmokeTest"
+    And the exception "type" equals "cocoa"
    
   @macos_only
   Scenario: Error type MONO

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -34,15 +34,6 @@ Feature: csharp events
     And the exception "errorClass" equals "Exception"
     And the exception "message" equals "NotifySmokeTest"
     And the exception "type" equals "cocoa"
-   
-  @macos_only
-  Scenario: Error type MONO
-    When I run the game in the "NotifySmokeTest" state
-    And I wait to receive an error
-    Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "errorClass" equals "Exception"
-    And the exception "message" equals "NotifySmokeTest"
-    And the exception "type" equals "mono"
 
   Scenario: Uncaught Exception smoke test
     When I run the game in the "UncaughtExceptionSmokeTest" state

--- a/features/ios/ios_csharp_events.feature
+++ b/features/ios/ios_csharp_events.feature
@@ -19,12 +19,12 @@ Feature: csharp events on iOS have a il2cpp addresses
     And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
 
     And the error payload field "events.0.exceptions.0.stacktrace.1.machoFile" matches the regex ".*UnityFramework.*"
-    And the error payload field "events.0.exceptions.0.stacktrace.1.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.machoUUID" matches the regex "^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$"
     And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
     And the error payload field "events.0.exceptions.0.stacktrace.1.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
 
     And the error payload field "events.0.exceptions.0.stacktrace.2.machoFile" matches the regex ".*UnityFramework.*"
-    And the error payload field "events.0.exceptions.0.stacktrace.2.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.machoUUID" matches the regex "^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$"
     And the error payload field "events.0.exceptions.0.stacktrace.2.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
     And the error payload field "events.0.exceptions.0.stacktrace.2.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
 

--- a/features/ios/ios_csharp_events.feature
+++ b/features/ios/ios_csharp_events.feature
@@ -14,7 +14,7 @@ Feature: csharp events on iOS have a il2cpp addresses
     And custom metadata is included in the event
 
     And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" matches the regex ".*UnityFramework.*"
-    And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" matches the regex "^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$"
     And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
     And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
 

--- a/features/ios/ios_csharp_events.feature
+++ b/features/ios/ios_csharp_events.feature
@@ -33,7 +33,7 @@ Feature: csharp events on iOS have a il2cpp addresses
     And the error payload field "events.0.severityReason.unhandledOverridden" is false
 
   @skip_unity_2020
-  Scenario: Android Notify Exception has il2cpp addresses
+  Scenario: ios Notify Exception has il2cpp addresses
     When I run the game in the "NotifySmokeTest" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
@@ -43,17 +43,17 @@ Feature: csharp events on iOS have a il2cpp addresses
     And custom metadata is included in the event
 
     And the error payload field "events.0.exceptions.0.stacktrace.0.machoFile" matches the regex ".*UnityFramework.*"
-    And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.0.machoUUID" matches the regex "^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$"
     And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
     And the error payload field "events.0.exceptions.0.stacktrace.0.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
 
     And the error payload field "events.0.exceptions.0.stacktrace.1.machoFile" matches the regex ".*UnityFramework.*"
-    And the error payload field "events.0.exceptions.0.stacktrace.1.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.1.machoUUID" matches the regex "^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$"
     And the error payload field "events.0.exceptions.0.stacktrace.1.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
     And the error payload field "events.0.exceptions.0.stacktrace.1.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
 
     And the error payload field "events.0.exceptions.0.stacktrace.2.machoFile" matches the regex ".*UnityFramework.*"
-    And the error payload field "events.0.exceptions.0.stacktrace.2.machoUUID" matches the regex "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    And the error payload field "events.0.exceptions.0.stacktrace.2.machoUUID" matches the regex "^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$"
     And the error payload field "events.0.exceptions.0.stacktrace.2.frameAddress" matches the regex "[0-9a-fA-F]{1,32}"
     And the error payload field "events.0.exceptions.0.stacktrace.2.machoLoadAddress" matches the regex "[0-9a-fA-F]{1,32}"
 

--- a/features/scripts/build_ios.sh
+++ b/features/scripts/build_ios.sh
@@ -46,6 +46,7 @@ xcrun xcodebuild \
   -allowProvisioningUpdates \
   -allowProvisioningDeviceRegistration \
   -quiet \
+  -resultBundlePath "$project_path/build.xcresult" \
   GCC_WARN_INHIBIT_ALL_WARNINGS=YES
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Changeset

- set iOS frame type to 'cocoa' and android to 'c'
- format the ios image uuid correctly to match the dsym uuid
- remove mono and il2cpp error types
- update the auto upload script to use the new unity-ios cli command. Android remains unchanged.

## Testing

updated existing tests.