### PR TITLE
fix --emit-source-mapping addition

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Editor/BuildPreprocessor.cs
+++ b/Bugsnag/Assets/Bugsnag/Editor/BuildPreprocessor.cs
@@ -17,11 +17,15 @@ namespace BugsnagUnity.Editor
             // Causes il2cpp to generate my-build-dir/Classes/Native/Symbols/LineNumberMappings.json
             // Note: It used to be stored in the project root dir as:
             //   my-build-dir_BackUpThisFolder_ButDontShipItWithYourGame/il2cppOutput/Symbols/LineNumberMappings.json
-            const string emitIl2cppSourceMapping = "--emit-source-mapping";
-            var args = PlayerSettings.GetAdditionalIl2CppArgs();
-            if (!args.Contains(emitIl2cppSourceMapping))
+            const string emit = "--emit-source-mapping";
+            var args = (PlayerSettings.GetAdditionalIl2CppArgs() ?? string.Empty).Trim();
+
+            // token-aware check: flag present as a standalone token?
+            var hasToken = System.Text.RegularExpressions.Regex.IsMatch(args, @"(?<!\S)--emit-source-mapping(?!\S)");
+            if (!hasToken)
             {
-                PlayerSettings.SetAdditionalIl2CppArgs(args + emitIl2cppSourceMapping);
+                var updated = string.IsNullOrEmpty(args) ? emit : $"{args} {emit}";
+                PlayerSettings.SetAdditionalIl2CppArgs(updated);
             }
         }
     }


### PR DESCRIPTION
This pull request updates the logic for checking and setting the `--emit-source-mapping` flag in the IL2CPP build arguments. The main improvement is to ensure that the flag is only added if it's not already present as a standalone token, preventing accidental duplicates and handling edge cases in argument formatting.

Improvements to IL2CPP argument handling:

* Enhanced detection of the `--emit-source-mapping` flag by using a regular expression to check for its presence as a standalone token in the IL2CPP arguments, rather than a simple substring search. This prevents false positives when the flag is part of another argument or word.
* Ensured that the build arguments are trimmed and defaulted to an empty string if null, improving robustness when manipulating the argument string.
* Updated the logic to append the flag only if necessary, using a space separator when other arguments are present, or setting it directly if the argument string is empty.