### PR TITLE
Release v8.8.0

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -20,4 +20,9 @@ steps:
   - label: 'Append Unity 6000 Pipeline'
     timeout_in_minutes: 2
     commands:
-        - buildkite-agent pipeline upload .buildkite/unity.6000.yml
+      - buildkite-agent pipeline upload .buildkite/unity.6000.yml
+
+  - label: 'Append Unity 6.2 Pipeline'
+    timeout_in_minutes: 2
+    commands:
+      - buildkite-agent pipeline upload .buildkite/unity.6.2.yml

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -21,8 +21,3 @@ steps:
     timeout_in_minutes: 2
     commands:
       - buildkite-agent pipeline upload .buildkite/unity.6000.yml
-
-  - label: 'Append Unity 6.2 Pipeline'
-    timeout_in_minutes: 2
-    commands:
-      - buildkite-agent pipeline upload .buildkite/unity.6.2.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,10 +12,6 @@ steps:
       UNITY_VERSION: *2021
     commands:
       - rake code:verify
-    retry:
-      automatic:
-        - exit_status: "*"
-          limit: 3
 
   - label: Run Unit Tests
     timeout_in_minutes: 5

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -14,6 +14,7 @@ steps:
         key: "build-android-fixture-2020"
         env:
           UNITY_VERSION: *2020
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -40,6 +41,8 @@ steps:
         env:
           XCODE_VERSION: "15.3.0"
           UNITY_VERSION: *2020
+          JAVA_VERSION: 17
+
         plugins:
           artifacts#v1.9.0:
             download:
@@ -61,6 +64,8 @@ steps:
         env:
           UNITY_VERSION: *2020
           XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: 17
+
           # Python2 needed for WebGL to build
           EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
         plugins:
@@ -83,6 +88,7 @@ steps:
         env:
           UNITY_VERSION: *2020
           XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: 17
           # Python2 needed for WebGL to build
           EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
         plugins:
@@ -106,6 +112,7 @@ steps:
           queue: windows-general-wsl
         env:
           UNITY_VERSION: *2020
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -12,6 +12,7 @@ steps:
         key: "build-android-dev-fixture-2021"
         env:
           UNITY_VERSION: *2021
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -32,6 +33,7 @@ steps:
         key: "build-android-edm4u-fixture-2021"
         env:
           UNITY_VERSION: *2021
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -52,6 +54,7 @@ steps:
         key: "generate-dev-fixture-project-2021"
         env:
           UNITY_VERSION: *2021
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.5.0:
             download:
@@ -75,6 +78,7 @@ steps:
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.5.0:
             download:
@@ -98,6 +102,7 @@ steps:
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -118,6 +123,7 @@ steps:
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -138,6 +144,7 @@ steps:
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -158,6 +165,7 @@ steps:
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -179,6 +187,7 @@ steps:
           queue: windows-general-wsl
         env:
           UNITY_VERSION: *2021
+          JAVA_VERSION: 17
         commands:
           - scripts/ci-build-windows-fixture-wsl.sh release
         plugins:
@@ -201,6 +210,7 @@ steps:
           queue: windows-general-wsl
         env:
           UNITY_VERSION: *2021
+          JAVA_VERSION: 17
         commands:
           - scripts/ci-build-windows-fixture-wsl.sh dev
         plugins:

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -12,6 +12,7 @@ steps:
         key: "build-android-fixture-2021"
         env:
           UNITY_VERSION: *2021
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -33,6 +34,7 @@ steps:
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.5.0:
             download:

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -14,6 +14,7 @@ steps:
         key: "build-android-fixture-2022"
         env:
           UNITY_VERSION: *2022
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -35,6 +36,7 @@ steps:
         env:
           UNITY_VERSION: *2022
           XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -56,6 +58,7 @@ steps:
         env:
           UNITY_VERSION: *2022
           XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -76,6 +79,7 @@ steps:
         env:
           UNITY_VERSION: *2022
           XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -97,6 +101,7 @@ steps:
           queue: windows-general-wsl
         env:
           UNITY_VERSION: *2022
+          JAVA_VERSION: 17
         commands:
           - scripts/ci-build-windows-fixture-wsl.sh release
         plugins:

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -14,6 +14,7 @@ steps:
         key: "build-android-fixture-6000"
         env:
           UNITY_VERSION: *6000
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -35,6 +36,7 @@ steps:
         env:
           UNITY_VERSION: *6000
           XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -58,6 +60,7 @@ steps:
         env:
           UNITY_VERSION: *6000
           XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -78,6 +81,7 @@ steps:
         env:
           UNITY_VERSION: *6000
           XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: 17
         plugins:
           artifacts#v1.9.0:
             download:
@@ -100,6 +104,7 @@ steps:
           queue: windows-general-wsl
         env:
           UNITY_VERSION: *6000
+          JAVA_VERSION: 17
         commands:
           - scripts/ci-build-windows-fixture-wsl.sh release
         plugins:

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -1,5 +1,5 @@
 aliases:
-  - &6000 "6000.0.49f1"
+  - &6000 "6000.2.2f1"
 
 agents:
   queue: macos-15

--- a/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
@@ -1,2 +1,2 @@
 using System.Reflection;
-[assembly: AssemblyVersion("8.7.1.0")]
+[assembly: AssemblyVersion("8.8.0.0")]

--- a/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
@@ -102,6 +102,21 @@ namespace BugsnagUnity
         }
 
         /// <summary>
+        /// Gets or sets the grouping discriminator for the Bugsnag client.
+        /// </summary>
+        public static string GroupingDiscriminator
+        {
+            get
+            {
+                return Client.GetGroupingDiscriminator();
+            }
+            set
+            {
+                Client.SetGroupingDiscriminator(value);
+            }
+        }
+
+        /// <summary>
         /// Setting Configuration.LaunchDurationMillis to 0 will cause Bugsnag to consider the app to be launching until Bugsnag.MarkLaunchCompleted() has been called.
         /// </summary>
         public static void MarkLaunchCompleted() => Client.MarkLaunchCompleted();

--- a/Bugsnag/Assets/Bugsnag/Runtime/IClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/IClient.cs
@@ -53,5 +53,9 @@ namespace BugsnagUnity
 
         void SetUser(string id, string email, string name);
 
+        string SetGroupingDiscriminator(string groupingDiscriminator);
+
+        string GetGroupingDiscriminator();
+
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/INativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/INativeClient.cs
@@ -112,5 +112,10 @@ namespace BugsnagUnity
         /// </summary>
         void RegisterForOnSessionCallbacks();
 
+        /// <summary>
+        /// Sets the grouping discriminator for native crash reports synchronization
+        /// </summary>
+        void SetGroupingDiscriminator(string groupingDiscriminator);
+
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeClient.cs
@@ -225,6 +225,11 @@ namespace BugsnagUnity
                     ToStackFrames(exception, nativeAddresses, mainImageFileName, mainImageUuid)
             );
         }
+
+        public void SetGroupingDiscriminator(string groupingDiscriminator)
+        {
+            NativeInterface.SetGroupingDiscriminator(groupingDiscriminator);
+        }
     }
 
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeEvent.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeEvent.cs
@@ -25,6 +25,16 @@ namespace BugsnagUnity
 
         public string GroupingHash { get => GetNativeString("getGroupingHash"); set =>  SetNativeString("setGroupingHash", value); }
 
+        public string GroupingDiscriminator
+        {
+            get => GetNativeString("getGroupingDiscriminator");
+            set
+            {
+                // Special case because setGroupingDiscriminator also returns a string and the usual SetNativeString call will not work 
+                NativePointer.Call<string>("setGroupingDiscriminator", value);
+            }
+        }
+
         public Severity Severity { get => GetSeverity(); set => SetSeverity(value); }
 
         public List<IThread> Threads => GetThreads();

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeInterface.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeInterface.cs
@@ -611,6 +611,11 @@ namespace BugsnagUnity
             }
         }
 
+        public void SetGroupingDiscriminator(string groupingDiscriminator)
+        {
+            CallNativeStringMethod("setGroupingDiscriminator", "(Ljava/lang/String;)Ljava/lang/String;", new object[] { groupingDiscriminator });
+        }
+
         public void StartSession()
         {
             CallNativeVoidMethod("startSession", "()V", new object[] { });
@@ -1005,7 +1010,7 @@ namespace BugsnagUnity
             jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(convertedArgs);
             IntPtr methodID = AndroidJNI.GetStaticMethodID(BugsnagNativeInterface, methodName, methodSig);
             IntPtr nativeValue = AndroidJNI.CallStaticObjectMethod(BugsnagNativeInterface, methodID, jargs);
-            AndroidJNIHelper.DeleteJNIArgArray(args, jargs);
+            AndroidJNIHelper.DeleteJNIArgArray(convertedArgs, jargs);
             ReleaseConvertedStringArgs(args, convertedArgs);
 
             if (!isAttached)
@@ -1057,7 +1062,7 @@ namespace BugsnagUnity
             jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(convertedArgs);
             IntPtr methodID = AndroidJNI.GetStaticMethodID(BugsnagNativeInterface, methodName, methodSig);
             IntPtr nativeValue = AndroidJNI.CallStaticObjectMethod(BugsnagNativeInterface, methodID, jargs);
-            AndroidJNIHelper.DeleteJNIArgArray(args, jargs);
+            AndroidJNIHelper.DeleteJNIArgArray(convertedArgs, jargs);
             ReleaseConvertedStringArgs(args, convertedArgs);
 
             string value = null;
@@ -1090,7 +1095,7 @@ namespace BugsnagUnity
             jvalue[] jargs = AndroidJNIHelper.CreateJNIArgArray(convertedArgs);
             IntPtr methodID = AndroidJNI.GetStaticMethodID(BugsnagNativeInterface, methodName, methodSig);
             bool nativeValue = AndroidJNI.CallStaticBooleanMethod(BugsnagNativeInterface, methodID, jargs);
-            AndroidJNIHelper.DeleteJNIArgArray(args, jargs);
+            AndroidJNIHelper.DeleteJNIArgArray(convertedArgs, jargs);
             ReleaseConvertedStringArgs(args, convertedArgs);
             if (!isAttached)
             {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeClient.cs
@@ -564,6 +564,11 @@ namespace BugsnagUnity
             );
         }
 
+        public void SetGroupingDiscriminator(string groupingDiscriminator)
+        {
+            NativeCode.bugsnag_setGroupingDiscriminator(groupingDiscriminator);
+        }
+
     }
 }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeCode.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeCode.cs
@@ -220,6 +220,9 @@ namespace BugsnagUnity
         internal static extern void bugsnag_setUser(string id, string email, string name);
 
         [DllImport(Import)]
+        internal static extern void bugsnag_setGroupingDiscriminator(string groupingDiscriminator);
+
+        [DllImport(Import)]
         internal static extern void bugsnag_startSession();
 
         [DllImport(Import)]

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeEvent.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeEvent.cs
@@ -18,6 +18,7 @@ namespace BugsnagUnity
         private const string CONTEXT_KEY = "context";
         private const string API_KEY_KEY = "apiKey";
         private const string GROUPING_HASH_KEY = "groupingHash";
+        private const string GROUPING_DISCRIMINATOR_KEY = "groupingDiscriminator";
         private const string UNHANDLED_KEY = "unhandled";
 
         public string Context { get => GetNativeString(CONTEXT_KEY); set => SetNativeString(CONTEXT_KEY, value); }
@@ -29,6 +30,8 @@ namespace BugsnagUnity
         public string ApiKey { get => GetNativeString(API_KEY_KEY); set => SetNativeString(API_KEY_KEY, value); }
 
         public string GroupingHash { get => GetNativeString(GROUPING_HASH_KEY); set => SetNativeString(GROUPING_HASH_KEY, value); }
+
+        public string GroupingDiscriminator { get => GetNativeString(GROUPING_DISCRIMINATOR_KEY); set => SetNativeString(GROUPING_DISCRIMINATOR_KEY, value); }
 
         public bool Unhandled { 
             get {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Fallback/NativeClient.cs
@@ -175,6 +175,11 @@ namespace BugsnagUnity
         {
             return new StackTraceLine[0];
         }
+
+        public void SetGroupingDiscriminator(string groupingDiscriminator)
+        {
+            // No-op on fallback platform
+        }
     }
 }
 #endif

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Windows/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Windows/NativeClient.cs
@@ -222,6 +222,11 @@ namespace BugsnagUnity
         {
             return new StackTraceLine[0];
         }
+
+        public void SetGroupingDiscriminator(string groupingDiscriminator)
+        {
+            // No-op on Windows platform
+        }
     }
 }
 #endif

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Event.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Event.cs
@@ -10,7 +10,7 @@ namespace BugsnagUnity.Payload
     public class Event : PayloadContainer, IEvent
     {
 
-        internal Event(string context, Metadata metadata, AppWithState app, DeviceWithState device, User user, Error[] errors, HandledState handledState, List<Breadcrumb> breadcrumbs, Session session, string apiKey, OrderedDictionary featureFlags, Correlation correlation, LogType? logType = null)
+        internal Event(string context, Metadata metadata, AppWithState app, DeviceWithState device, User user, Error[] errors, HandledState handledState, List<Breadcrumb> breadcrumbs, Session session, string apiKey, OrderedDictionary featureFlags, Correlation correlation, string groupingDiscriminator = null, LogType? logType = null)
         {
             ApiKey = apiKey;
             OriginalSeverity = handledState;
@@ -24,6 +24,7 @@ namespace BugsnagUnity.Payload
             _errors = errors.ToList();
             Errors = new List<IError>();
             Correlation = correlation;
+            GroupingDiscriminator = groupingDiscriminator;
             foreach (var error in _errors)
             {
                 Errors.Add(error);
@@ -122,6 +123,11 @@ namespace BugsnagUnity.Payload
             if (eventObject.ContainsKey("groupingHash"))
             {
                 GroupingHash = eventObject["groupingHash"].ToString();
+            }
+
+            if (eventObject.ContainsKey("groupingDiscriminator"))
+            {
+                GroupingDiscriminator = eventObject["groupingDiscriminator"].ToString();
             }
 
             _errors = new List<Error>();
@@ -248,6 +254,8 @@ namespace BugsnagUnity.Payload
 
         public string GroupingHash { get; set; }
 
+        public string GroupingDiscriminator { get; set; }
+
         public Severity Severity
         {
             set => HandledState = HandledState.ForCallbackSpecifiedSeverity(value, _handledState);
@@ -324,6 +332,7 @@ namespace BugsnagUnity.Payload
             Add("user", _user.Payload);
             Add("context", Context);
             Add("groupingHash", GroupingHash);
+            Add("groupingDiscriminator", GroupingDiscriminator);
             Add("payloadVersion", PayloadVersion);
             Add("exceptions", _errors);
             if (Correlation != null)

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/IEvent.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/IEvent.cs
@@ -23,6 +23,8 @@ namespace BugsnagUnity
 
         string GroupingHash { get; set; }
 
+        string GroupingDiscriminator { get; set; }
+
         Severity Severity { get; set; }
 
         List<IThread> Threads { get; }

--- a/Bugsnag/Assets/Scripts/Testing.cs
+++ b/Bugsnag/Assets/Scripts/Testing.cs
@@ -42,4 +42,13 @@ public class Testing : MonoBehaviour
    [DllImport("__Internal")]
    private static extern void TriggerCocoaAppHang();
 #endif
+
+    void Update()
+    {
+        // Check for Android back button (mapped to Escape in Unity)
+        if (Input.GetKeyDown(KeyCode.Escape))
+        {
+            Application.Quit();
+        }
+    }
 }

--- a/Bugsnag/NativeSrc/Cocoa/BugsnagUnity.mm
+++ b/Bugsnag/NativeSrc/Cocoa/BugsnagUnity.mm
@@ -223,6 +223,14 @@ static const char * getJson(id obj) {
     return NULL;
 }
 
+void bugsnag_setGroupingDiscriminator(char *groupingDiscriminator) {
+    // Passing NULL clears the custom discriminator
+    NSString *value = groupingDiscriminator == NULL
+                      ? nil
+                      : [NSString stringWithUTF8String:groupingDiscriminator];
+    [Bugsnag setGroupingDiscriminator:value];
+}
+
 void bugsnag_clearMetadata(const char * section){
     if(section == NULL)
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+- Added `GroupingDiscriminator` property to events and methods for setting and getting the global `GroupingDiscriminator` to `Bugsnag` [#925](https://github.com/bugsnag/bugsnag-unity/pull/925)
+
+### Dependencies
+
+- Update bugsnag-cocoa to [v6.33.1](https://github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.33.1) [#934](https://github.com/bugsnag/bugsnag-unity/pull/934)
+
+- Update bugsnag-android to [v6.18.0](https://github.com/bugsnag/bugsnag-android/releases/tag/v6.18.0) [#934](https://github.com/bugsnag/bugsnag-unity/pull/934)
+
 ## 8.7.1 (2025-09-08)
 
 - Fix an issue where additional IL2CPP arguments were added without proper whitespace checks [#928](https://github.com/bugsnag/bugsnag-unity/pull/928)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 8.8.0 (2025-09-16)
 
 ### Enhancements
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ unless Gem.win_platform?
   # Use official Maze Runner release
   # TODO Temporary workaround for uri 1.0.0 causing requests to fail
   gem 'uri', '0.13.1'
-  gem 'bugsnag-maze-runner', '~>9.0'
+  gem 'bugsnag-maze-runner', '~>9.36'
 
   # Use a specific Maze Runner branch
   # gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/example/Assets/Scripts/Main.cs
+++ b/example/Assets/Scripts/Main.cs
@@ -48,6 +48,15 @@ public class Main : MonoBehaviour
 	private static extern void TriggerCocoaAppHang();
 #endif
 
+	void Update()
+	{
+		// Check for Android back button (mapped to Escape in Unity)
+		if (Input.GetKeyDown(KeyCode.Escape))
+		{
+			Application.Quit();
+		}
+	}
+
 	public Button
 		ManagedCrash,
 		BugsnagNotify,

--- a/features/android/android_callbacks.feature
+++ b/features/android/android_callbacks.feature
@@ -18,6 +18,8 @@ Feature: Callbacks
     And the event "context" equals "Custom Context"
     And the event "severity" equals "info"
     And the event "unhandled" is false
+    And the event "groupingDiscriminator" equals "Custom GroupingDiscriminator"
+
 
         # metadata
     And the event "metaData.test.scoop" equals "dewoop"

--- a/features/build/build_android.feature
+++ b/features/build/build_android.feature
@@ -4,13 +4,82 @@ Feature: Build Android
   Scenario: Auto Symbol Upload
   	When I run the script "features/scripts/prepare_fixture.sh" synchronously
   	When I run the script "features/scripts/build_android.sh release" synchronously
-  	Then I wait to receive 6 sourcemaps
+
+  	Then I wait to receive 8 sourcemaps
+
+    And I sort the sourcemaps by path
+
+    Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the sourcemap payload field "versionCode" equals "123"
     And the sourcemap payload field "versionName" equals "1.2.3"
     And the sourcemap payload field "appId" equals "com.bugsnag.fixtures.unity.notifier.android"
-    
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the sourcemap payload field "versionCode" equals "123"
+    And the sourcemap payload field "versionName" equals "1.2.3"
+    And the sourcemap payload field "appId" equals "com.bugsnag.fixtures.unity.notifier.android"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the sourcemap payload field "versionCode" equals "123"
+    And the sourcemap payload field "versionName" equals "1.2.3"
+    And the sourcemap payload field "appId" equals "com.bugsnag.fixtures.unity.notifier.android"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the sourcemap payload field "versionCode" equals "123"
+    And the sourcemap payload field "versionName" equals "1.2.3"
+    And the sourcemap payload field "appId" equals "com.bugsnag.fixtures.unity.notifier.android"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the sourcemap payload field "versionCode" equals "123"
+    And the sourcemap payload field "versionName" equals "1.2.3"
+    And the sourcemap payload field "appId" equals "com.bugsnag.fixtures.unity.notifier.android"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the sourcemap payload field "versionCode" equals "123"
+    And the sourcemap payload field "versionName" equals "1.2.3"
+    And the sourcemap payload field "appId" equals "com.bugsnag.fixtures.unity.notifier.android"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the sourcemap payload field "appVersion" equals "1.2.3"
+    And the sourcemap payload field "appVersionCode" equals "123"
+    And the sourcemap payload field "soBuildId" is not null
+    And the sourcemap payload field "appId" equals "com.bugsnag.fixtures.unity.notifier.android"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Unity Line Mapping API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the sourcemap payload field "appVersion" equals "1.2.3"
+    And the sourcemap payload field "appVersionCode" equals "123"
+    And the sourcemap payload field "soBuildId" is not null
+    And the sourcemap payload field "appId" equals "com.bugsnag.fixtures.unity.notifier.android"
 
   @unity_2020_only
   Scenario: Auto Symbol Upload Unity 2020

--- a/features/build/build_ios.feature
+++ b/features/build/build_ios.feature
@@ -1,6 +1,7 @@
 Feature: Build iOS
 
-  Scenario: Auto Symbol Upload
+  @skip_unity_2020 # Unity 2020 only produces 2 symbol files
+  Scenario: Auto Symbol Upload 2021+
   	When I run the script "features/scripts/prepare_fixture.sh" synchronously
     When I run the script "features/scripts/generate_xcode_project.sh release" synchronously
   	When I run the script "features/scripts/build_ios.sh release" synchronously
@@ -21,3 +22,12 @@ Feature: Build iOS
     And the sourcemap payload field "appBundleVersion" equals "333"
     And the sourcemap payload field "dsymUUID" is not null
     And the sourcemap payload field "appId" equals "com.apple.xcode.dsym.com.bugsnag.fixtures.unity.notifier.ios"
+
+  @unity_2020_only
+  Scenario: Auto Symbol Upload 2020
+    When I run the script "features/scripts/prepare_fixture.sh" synchronously
+    When I run the script "features/scripts/generate_xcode_project.sh release" synchronously
+    When I run the script "features/scripts/build_ios.sh release" synchronously
+    Then I wait to receive 2 sourcemaps
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/build/build_ios.feature
+++ b/features/build/build_ios.feature
@@ -4,6 +4,20 @@ Feature: Build iOS
   	When I run the script "features/scripts/prepare_fixture.sh" synchronously
     When I run the script "features/scripts/generate_xcode_project.sh release" synchronously
   	When I run the script "features/scripts/build_ios.sh release" synchronously
-  	Then I wait to receive 2 sourcemaps
+  	Then I wait to receive 3 sourcemaps
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Unity Line Mapping API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "appVersion" equals "1.0"
+    And the sourcemap payload field "appBundleVersion" equals "333"
+    And the sourcemap payload field "dsymUUID" is not null
+    And the sourcemap payload field "appId" equals "com.apple.xcode.dsym.com.bugsnag.fixtures.unity.notifier.ios"

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -209,5 +209,22 @@ Feature: csharp events
     And I wait to receive 1 error
     And the exception "message" equals "SerialisationError"
 
+  Scenario: Grouping Discriminator
+    When I run the game in the "GroupingDiscriminator" state
+    And I wait to receive 3 errors
+    And I sort the errors by the payload field "events.0.exceptions.0.message"
+
+    And the exception "message" equals "GroupingDiscriminator-1"
+    And the event "groupingDiscriminator" is null
+    And I discard the oldest error
+    And the exception "message" equals "GroupingDiscriminator-2"
+    And the event "groupingDiscriminator" equals "Global GroupingDiscriminator"
+    And I discard the oldest error
+    And the exception "message" equals "GroupingDiscriminator-3"
+    And the event "groupingDiscriminator" equals "Callback GroupingDiscriminator"
+
+
+    
+
 
 

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -1276,6 +1276,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: df293b62197504f21a7d582167548183, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2
+    () (at Assets/Scripts/Main.cs:123)'
 --- !u!1 &1338701864
 GameObject:
   m_ObjectHideFlags: 0
@@ -2324,6 +2328,7 @@ GameObject:
   - component: {fileID: 2039813475}
   - component: {fileID: 2039813474}
   - component: {fileID: 2039813477}
+  - component: {fileID: 2039813478}
   m_Layer: 0
   m_Name: Events
   m_TagString: Untagged
@@ -2602,6 +2607,18 @@ MonoBehaviour:
 
     Main.CUSTOM2
     () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &2039813478
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2039813460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 46d1b367baa7b44d09fd2de8ba62c4e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2059449697
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidOnSendCallback.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidOnSendCallback.cs
@@ -10,7 +10,8 @@ public class AndroidOnSendCallback : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.AddOnSendError((@event) => {
+        Configuration.AddOnSendError((@event) =>
+        {
             @event.ApiKey = "Custom ApiKey";
             // AppWithState
             var app = @event.App;
@@ -71,6 +72,8 @@ public class AndroidOnSendCallback : Scenario
 
             @event.Unhandled = false;
 
+            @event.GroupingDiscriminator = "Custom GroupingDiscriminator";
+
             // Threads
             foreach (var thread in @event.Threads)
             {
@@ -90,7 +93,7 @@ public class AndroidOnSendCallback : Scenario
 
             @event.AddMetadata("test", "scoop", "dewoop");
 
-            @event.AddFeatureFlag("test","variant");
+            @event.AddFeatureFlag("test", "variant");
             @event.AddFeatureFlag("deleteMe");
             @event.ClearFeatureFlag("deleteMe");
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/GroupingDiscriminator.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/GroupingDiscriminator.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using BugsnagUnity;
+
+public class GroupingDiscriminator : Scenario
+{
+    public override void Run()
+    {
+        Bugsnag.Notify(new System.Exception("GroupingDiscriminator-1"));
+        Bugsnag.GroupingDiscriminator = "Global GroupingDiscriminator";
+        Bugsnag.Notify(new System.Exception("GroupingDiscriminator-2"));
+        Bugsnag.Notify(new System.Exception("GroupingDiscriminator-3"), (@event) =>
+        {
+            @event.GroupingDiscriminator = "Callback GroupingDiscriminator";
+            return true;
+        });
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/GroupingDiscriminator.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/GroupingDiscriminator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46d1b367baa7b44d09fd2de8ba62c4e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosNativeOnSendCallback.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/iOS/IosNativeOnSendCallback.cs
@@ -10,7 +10,8 @@ public class IosNativeOnSendCallback : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.AddOnSendError((@event) => {
+        Configuration.AddOnSendError((@event) =>
+        {
             try
             {
                 //AppWithState
@@ -42,7 +43,7 @@ public class IosNativeOnSendCallback : Scenario
                 device.Time = new DateTimeOffset(1985, 08, 21, 01, 01, 01, TimeSpan.Zero);
                 device.TotalMemory = 999;
                 device.ModelNumber = "Custom ModelNumber";
-                
+
                 // breadcrumbs
                 foreach (var crumb in @event.Breadcrumbs)
                 {
@@ -71,6 +72,8 @@ public class IosNativeOnSendCallback : Scenario
 
                 @event.Unhandled = false;
 
+                @event.GroupingDiscriminator = "Custom GroupingDiscriminator";
+
                 // Threads
                 foreach (var thread in @event.Threads)
                 {
@@ -96,7 +99,8 @@ public class IosNativeOnSendCallback : Scenario
 
                 return true;
             }
-            catch (Exception e){
+            catch (Exception e)
+            {
                 Debug.Log("ERROR");
                 Debug.LogException(e);
             }

--- a/features/fixtures/maze_runner/nativeplugin/android/build.gradle
+++ b/features/fixtures/maze_runner/nativeplugin/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.1"
+        classpath "com.android.tools.build:gradle:8.5.2"
     }
 }
 
@@ -16,13 +16,26 @@ repositories {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdk 34
+    buildToolsVersion "34.0.0"
+
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 30
-        ndkVersion = "21.4.7075529"
+        minSdkVersion 21
+        targetSdkVersion 34
+        ndkVersion = "26.3.11579264"
         consumerProguardFiles 'proguard-rules.pro'
     }
-    externalNativeBuild.cmake.path "CMakeLists.txt"
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "CMakeLists.txt"
+        }
+    }
+
+    namespace 'com.example.bugsnagcrashplugin'
 }

--- a/features/fixtures/maze_runner/nativeplugin/android/gradle/wrapper/gradle-wrapper.properties
+++ b/features/fixtures/maze_runner/nativeplugin/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip

--- a/features/fixtures/maze_runner/nativeplugin/android/src/main/AndroidManifest.xml
+++ b/features/fixtures/maze_runner/nativeplugin/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.bugsnagcrashplugin" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+

--- a/features/ios/ios_callbacks.feature
+++ b/features/ios/ios_callbacks.feature
@@ -18,6 +18,8 @@ Feature: Callbacks
     And the event "context" equals "Custom Context"
     And the event "severity" equals "info"
     And the event "unhandled" is false
+    And the event "groupingDiscriminator" equals "Custom GroupingDiscriminator"
+
 
     # metadata
     And the event "metaData.test.scoop" equals "dewoop"

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -26,6 +26,25 @@ Then('the sourcemaps Content-Type header is valid multipart form-data') do
   Maze.check.match(expected, actual)
 end
 
+Then('the sourcemap is valid for the Android Build API') do
+  steps %(
+    And the sourcemap payload field "apiKey" equals "#{$api_key}"
+    And the sourcemap payload field "appId" is not null
+  )
+end
+
+Then('the sourcemap is valid for the Unity Line Mapping API') do
+  steps %(
+    And the sourcemap payload field "apiKey" equals "#{$api_key}"
+    And the sourcemap payload field "mappingFile" is not null
+  )
+end
+
+And(/^I sort the sourcemaps by path$/) do
+  list = Maze::Server.list_for('sourcemap')
+  list.sort_by_request_path!
+end
+
 When('I clear the Bugsnag cache') do
   case Maze::Helper.get_current_platform
   when 'macos', 'webgl'

--- a/scripts/code_format.sh
+++ b/scripts/code_format.sh
@@ -1,35 +1,107 @@
 #!/usr/bin/env bash
-set -e  
+set -Eeuo pipefail
 
-if [ -z "$UNITY_VERSION" ]; then
-  echo "UNITY_VERSION must be set"
+# --- Config ---
+PROJECT_DIR="Bugsnag"
+SLN_PATH="$PROJECT_DIR/Bugsnag.sln"
+UNITY_BIN="/Applications/Unity/Hub/Editor/${UNITY_VERSION}/Unity.app/Contents/MacOS/Unity"
+UNITY_LOG="${PROJECT_DIR}/Library/Logs/SyncVS-$(date +%Y%m%d-%H%M%S).log"
+
+DEFAULT_CLI_ARGS=(-quit -batchmode -nographics -logFile "$UNITY_LOG")
+SYNC_METHOD="UnityEditor.SyncVS.SyncSolution"
+
+# --- Preflight ---
+if [[ -z "${UNITY_VERSION:-}" ]]; then
+  echo "UNITY_VERSION must be set" >&2
+  exit 1
+fi
+if [[ ! -x "$UNITY_BIN" ]]; then
+  echo "Unity not found at: $UNITY_BIN" >&2
+  exit 1
+fi
+if [[ ! -d "$PROJECT_DIR" ]]; then
+  echo "Project directory not found: $PROJECT_DIR" >&2
   exit 1
 fi
 
-UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION/Unity.app/Contents/MacOS"
-DEFAULT_CLI_ARGS="-quit -batchmode -nographics"
-PROJECT_PATH="Bugsnag"
+echo "==> Generating solution via Unity (${UNITY_VERSION})"
+echo "    Log: $UNITY_LOG"
 
-# Generate .sln and project files
-$UNITY_PATH/Unity $DEFAULT_CLI_ARGS -projectPath "$PROJECT_PATH" -executeMethod "UnityEditor.SyncVS.SyncSolution"
-RESULT=$?
-if [ $RESULT -ne 0 ]; then
-  exit $RESULT
+attempt_sync() {
+  "$UNITY_BIN" "${DEFAULT_CLI_ARGS[@]}" \
+    -projectPath "$PROJECT_DIR" \
+    -executeMethod "$SYNC_METHOD"
+}
+
+wait_for_solution() {
+  # Wait up to MAX_WAIT seconds for .sln and at least one .csproj
+  local MAX_WAIT=300
+  local waited=0
+  while (( waited < MAX_WAIT )); do
+    if [[ -f "$SLN_PATH" ]] && compgen -G "$PROJECT_DIR/"'*.csproj' > /dev/null; then
+      return 0
+    fi
+    sleep 2
+    (( waited+=2 ))
+  done
+  return 1
+}
+
+# --- Sync with retry ---
+SYNC_ATTEMPTS=2
+SUCCESS=0
+for attempt in $(seq 1 "$SYNC_ATTEMPTS"); do
+  echo "---- Sync attempt $attempt/$SYNC_ATTEMPTS"
+  set +e
+  attempt_sync
+  UNITY_EXIT=$?
+  set -e
+
+  if wait_for_solution; then
+    echo "    ✔ Solution generated: $SLN_PATH"
+    SUCCESS=1
+    break
+  fi
+
+  echo "    Waiting for files failed or Unity exit was $UNITY_EXIT. Retrying..."
+done
+
+# One last **forced** SyncVS after the waits (helps on cold caches)
+if [[ $SUCCESS -eq 0 ]]; then
+  echo "---- Final SyncVS invocation after wait"
+  set +e
+  attempt_sync
+  set -e
+  if wait_for_solution; then
+    echo "    ✔ Solution generated after final sync: $SLN_PATH"
+    SUCCESS=1
+  fi
 fi
 
-# Decide which dotnet format command to run based on the argument
-FORMAT_COMMAND="dotnet format"
-if [ "$1" == "--verify" ]; then
-  FORMAT_COMMAND="dotnet format --verify-no-changes"
+# --- Validate artifacts before continuing ---
+if [[ $SUCCESS -eq 0 ]]; then
+  echo "✖ Solution file not found after retries: $SLN_PATH" >&2
+  echo "---- Unity log tail ----" >&2
+  tail -n 300 "$UNITY_LOG" || true
+  exit 2
 fi
 
-# Execute dotnet format
-$FORMAT_COMMAND "$PROJECT_PATH/Bugsnag.sln"
+# --- dotnet format (solution mode) ---
+FORMAT_ARGS=( --no-restore )
+if [[ "${1:-}" == "--verify" ]]; then
+  FORMAT_ARGS+=( --verify-no-changes )
+fi
+
+echo "==> Running dotnet format on solution"
+echo "    dotnet format ${FORMAT_ARGS[*]} \"$SLN_PATH\""
+set +e
+dotnet format "${FORMAT_ARGS[@]}" "$SLN_PATH"
 EXIT_CODE=$?
+set -e
 
-if [ "$EXIT_CODE" -ne 0 ]; then
-  echo "Error: Code formatting verification found issues."
+if [[ "$EXIT_CODE" -ne 0 ]]; then
+  echo "✖ Code formatting verification found issues (exit $EXIT_CODE)." >&2
   exit "$EXIT_CODE"
 fi
 
-echo "Done."
+echo "✔ Done."


### PR DESCRIPTION
## 8.8.0 (2025-09-16)

### Enhancements

- Added `GroupingDiscriminator` property to events and methods for setting and getting the global `GroupingDiscriminator` to `Bugsnag` [#925](https://github.com/bugsnag/bugsnag-unity/pull/925)

### Dependencies

- Update bugsnag-cocoa to [v6.33.1](https://github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.33.1) [#934](https://github.com/bugsnag/bugsnag-unity/pull/934)

- Update bugsnag-android to [v6.18.0](https://github.com/bugsnag/bugsnag-android/releases/tag/v6.18.0) [#934](https://github.com/bugsnag/bugsnag-unity/pull/934)
