### PR TITLE
check for out of bounds in native trace builder on android

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeClient.cs
@@ -182,10 +182,11 @@ namespace BugsnagUnity
                 return new StackTraceLine[0];
             }
 
-            var StackTraceLength = nativeAddresses.Length;
-            StackTraceLine[] Trace = new StackTraceLine[StackTraceLength];
+            // Use the minimum of both lengths to avoid out-of-bounds access
+            var length = nativeAddresses.Length < lines.Length ? nativeAddresses.Length : lines.Length;
+            StackTraceLine[] Trace = new StackTraceLine[length];
 
-            for (int i = 0; i < StackTraceLength; i++)
+            for (int i = 0; i < length; i++)
             {
                 StackTraceLine Frame = new StackTraceLine();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where building native stack traces could trigger an out of bounds exception [#941](https://github.com/bugsnag/bugsnag-unity/pull/941)
+
 ## 8.8.0 (2025-09-16)
 
 ### Enhancements
@@ -13,6 +19,8 @@
 - Update bugsnag-android to [v6.18.0](https://github.com/bugsnag/bugsnag-android/releases/tag/v6.18.0) [#934](https://github.com/bugsnag/bugsnag-unity/pull/934)
 
 ## 8.7.1 (2025-09-08)
+
+### Bug Fixes
 
 - Fix an issue where additional IL2CPP arguments were added without proper whitespace checks [#928](https://github.com/bugsnag/bugsnag-unity/pull/928)
 


### PR DESCRIPTION
This pull request updates the logic in the `ToStackFrames` method to improve safety when constructing stack traces from native addresses and lines. The main change ensures that the method does not attempt to access elements beyond the bounds of either array, preventing potential runtime errors.

Stack trace construction safety:

* The stack trace array length is now set to the minimum of `nativeAddresses.Length` and `lines.Length`, and the loop iterates up to this minimum length to avoid out-of-bounds access.