### PR TITLE
Releases/v8.8.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,10 @@ steps:
     timeout_in_minutes: 5
     env:
       UNITY_VERSION: *2021
+    plugins:
+      artifacts#v1.9.0:
+        upload:
+          - "Bugsnag/Library/Logs/*.log"
     commands:
       - rake code:verify
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/AssemblyInfo.cs
@@ -1,2 +1,2 @@
 using System.Reflection;
-[assembly: AssemblyVersion("8.8.0.0")]
+[assembly: AssemblyVersion("8.8.1.0")]

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeClient.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeClient.cs
@@ -182,10 +182,11 @@ namespace BugsnagUnity
                 return new StackTraceLine[0];
             }
 
-            var StackTraceLength = nativeAddresses.Length;
-            StackTraceLine[] Trace = new StackTraceLine[StackTraceLength];
+            // Use the minimum of both lengths to avoid out-of-bounds access
+            var length = nativeAddresses.Length < lines.Length ? nativeAddresses.Length : lines.Length;
+            StackTraceLine[] Trace = new StackTraceLine[length];
 
-            for (int i = 0; i < StackTraceLength; i++)
+            for (int i = 0; i < length; i++)
             {
                 StackTraceLine Frame = new StackTraceLine();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 8.8.1 (2025-09-23)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix an issue where building native stack traces could trigger an out of bounds exception [#941](https://github.com/bugsnag/bugsnag-unity/pull/941)
+
 ## 8.8.0 (2025-09-16)
 
 ### Enhancements
@@ -13,6 +19,8 @@
 - Update bugsnag-android to [v6.18.0](https://github.com/bugsnag/bugsnag-android/releases/tag/v6.18.0) [#934](https://github.com/bugsnag/bugsnag-unity/pull/934)
 
 ## 8.7.1 (2025-09-08)
+
+### Bug Fixes
 
 - Fix an issue where additional IL2CPP arguments were added without proper whitespace checks [#928](https://github.com/bugsnag/bugsnag-unity/pull/928)
 


### PR DESCRIPTION
## 8.8.1 (2025-09-23)

### Bug Fixes

- Fix an issue where building native stack traces could trigger an out of bounds exception [#941](https://github.com/bugsnag/bugsnag-unity/pull/941)
