### PR TITLE
Make test scenario exception messages more distinctive

### DIFF
--- a/features/csharp/csharp_breadcrumbs.feature
+++ b/features/csharp/csharp_breadcrumbs.feature
@@ -16,7 +16,7 @@ Feature: Csharp Breadcrumbs
     And I sort the errors by the payload field "events.0.exceptions.0.message"
     And I discard the oldest error
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error2"
+    And the exception "message" equals "EnableBreadcrumbs 2"
     And the event "breadcrumbs.0.name" equals "Debug.Log"
 
   Scenario: Setting max breadcrumbs
@@ -38,7 +38,7 @@ Feature: Csharp Breadcrumbs
     And I discard the oldest error
     And I discard the oldest error
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error3"
+    And the exception "message" equals "ManualAndAutoBreadcrumbs 3"
 
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.0.type" equals "state"
@@ -57,11 +57,11 @@ Feature: Csharp Breadcrumbs
 
     And the event "breadcrumbs.5.name" equals "Exception"
     And the event "breadcrumbs.5.type" equals "error"
-    And the event "breadcrumbs.5.metaData.message" equals "Error1"
+    And the event "breadcrumbs.5.metaData.message" equals "ManualAndAutoBreadcrumbs 1"
 
     And the event "breadcrumbs.6.name" equals "Exception"
     And the event "breadcrumbs.6.type" equals "error"
-    And the event "breadcrumbs.6.metaData.message" equals "Error2"
+    And the event "breadcrumbs.6.metaData.message" equals "ManualAndAutoBreadcrumbs 2"
 
     And the event "breadcrumbs.7.name" equals "Metadata"
     And the event "breadcrumbs.7.type" equals "manual"

--- a/features/csharp/csharp_callbacks.feature
+++ b/features/csharp/csharp_callbacks.feature
@@ -74,7 +74,7 @@ Feature: Callbacks
     And the event "session.events.handled" equals 1
     And I discard the oldest error
 
-    And the exception "message" equals "HandledInNotifyCallback"
+    And the exception "message" equals "EditUnhandled HandledInNotifyCallback"
     And the event "unhandled" is true
     And the event "severityReason.unhandledOverridden" is true
     And the event "session.events.unhandled" equals 1

--- a/features/csharp/csharp_callbacks.feature
+++ b/features/csharp/csharp_callbacks.feature
@@ -8,13 +8,13 @@ Feature: Callbacks
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
+    And the exception "message" equals "OnErrorInConfig 1"
     And all possible parameters have been edited in a callback
 
     And I discard the oldest error
 
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 2"
+    And the exception "message" equals "OnErrorInConfig 2"
     And all possible parameters have been edited in a callback
 
   Scenario: OnError callbacks added after Start
@@ -23,12 +23,12 @@ Feature: Callbacks
     And I sort the errors by the payload field "events.0.exceptions.0.message"
 
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
+    And the exception "message" equals "OnErrorAfterStart 1"
     And all possible parameters have been edited in a callback
     And I discard the oldest error
 
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 2"
+    And the exception "message" equals "OnErrorAfterStart 2"
     And all possible parameters have been edited in a callback
 
   Scenario: OnSend callbacks in config
@@ -37,19 +37,19 @@ Feature: Callbacks
     And I sort the errors by the payload field "events.0.exceptions.0.message"
 
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
+    And the exception "message" equals "OnSendInConfig 1"
     And all possible parameters have been edited in a callback
     And I discard the oldest error
 
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 2"
+    And the exception "message" equals "OnSendInConfig 2"
     And all possible parameters have been edited in a callback
 
   Scenario: Callback passed directly to Notify
     When I run the game in the "CallbackInNotify" state
     And I wait to receive 1 error
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
+    And the exception "message" equals "CallbackInNotify 1"
     And all possible parameters have been edited in a callback
 
   Scenario: Session callbacks in config
@@ -67,7 +67,7 @@ Feature: Callbacks
     And I wait to receive 4 errors
 
     # Error 1
-    And the exception "message" equals "Control"
+    And the exception "message" equals "EditUnhandled Control"
     And the event "unhandled" is false
     And the event "severityReason.unhandledOverridden" is false
     And the event "session.events.unhandled" equals 0
@@ -81,14 +81,14 @@ Feature: Callbacks
     And the event "session.events.handled" equals 1
     And I discard the oldest error
 
-    And the exception "message" equals "HandledInOnSendCallback"
+    And the exception "message" equals "EditUnhandled HandledInOnSendCallback"
     And the event "unhandled" is true
     And the event "severityReason.unhandledOverridden" is true
     And the event "session.events.unhandled" equals 2
     And the event "session.events.handled" equals 1
     And I discard the oldest error
 
-    And the exception "message" equals "UnhandledInOnErrorCallback"
+    And the exception "message" equals "EditUnhandled UnhandledInOnErrorCallback"
     And the event "unhandled" is false
     And the event "severityReason.unhandledOverridden" is true
     And the event "session.events.unhandled" equals 2

--- a/features/csharp/csharp_config.feature
+++ b/features/csharp/csharp_config.feature
@@ -21,10 +21,10 @@ Feature: csharp events
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
+    And the exception "message" equals "MarkLaunchComplete 1"
     And the event "app.isLaunching" is true
     And I discard the oldest error
-    And the exception "message" equals "Error 2"
+    And the exception "message" equals "MarkLaunchComplete 2"
     And the event "app.isLaunching" is false
 
   @skip_cocoa @skip_windows @skip_webgl # PLAT-9061
@@ -33,10 +33,10 @@ Feature: csharp events
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
+    And the exception "message" equals "LongLaunchTime 1"
     And the event "app.isLaunching" is true
     And I discard the oldest error
-    And the exception "message" equals "Error 2"
+    And the exception "message" equals "LongLaunchTime 2"
     And the event "app.isLaunching" is false
 
   @skip_cocoa @skip_windows @skip_webgl # PLAT-9061
@@ -45,10 +45,10 @@ Feature: csharp events
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
+    And the exception "message" equals "ShortLaunchTime 1"
     And the event "app.isLaunching" is true
     And I discard the oldest error
-    And the exception "message" equals "Error 2"
+    And the exception "message" equals "ShortLaunchTime 2"
     And the event "app.isLaunching" is false
 
   Scenario: Auto notify false
@@ -74,7 +74,7 @@ Feature: csharp events
     When I run the game in the "DiscardErrorClass" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 2"
+    And the exception "message" equals "DiscardErrorClass 2"
 
   Scenario: App Type
     When I run the game in the "AppType" state

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -144,8 +144,8 @@ Feature: csharp events
     When I run the game in the "InnerException" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
-    And the event "exceptions.0.message" equals "Outer"
-    And the event "exceptions.1.message" equals "Inner"
+    And the event "exceptions.0.message" equals "InnerException Outer"
+    And the event "exceptions.1.message" equals "InnerException Inner"
     And the event "exceptions.2" is null
 
   Scenario: Reporting an uncaught exception in an async method

--- a/features/csharp/csharp_persistence.feature
+++ b/features/csharp/csharp_persistence.feature
@@ -16,9 +16,9 @@ Feature: Unity Persistence
     And I wait to receive 2 sessions
     And I sort the sessions by the payload field "app.releaseStage"
     Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
-    And the session payload field "app.releaseStage" equals "Session 1"
+    And the session payload field "app.releaseStage" equals "PersistSession 1"
     And I discard the oldest session
-    And the session payload field "app.releaseStage" equals "Session 2"
+    And the session payload field "app.releaseStage" equals "PersistSession 2"
 
   @skip_macos # Pending-PLAT-13035
   Scenario: Receive a persisted event
@@ -33,12 +33,12 @@ Feature: Unity Persistence
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
     And the error is valid for the error reporting API sent by the Unity notifier
-    And the event "context" equals "Error 1"
-    And the exception "message" equals "Error 1"
+    And the event "context" equals "PersistEvent 1"
+    And the exception "message" equals "PersistEvent 1"
     And I discard the oldest error
     And the error is valid for the error reporting API sent by the Unity notifier
-    And the event "context" equals "Error 2"
-    And the exception "message" equals "Error 2"
+    And the event "context" equals "PersistEvent 2"
+    And the exception "message" equals "PersistEvent 2"
 
   @skip_macos # Pending-PLAT-13035
   Scenario: Receive a persisted event with on send callback
@@ -52,8 +52,8 @@ Feature: Unity Persistence
     And I run the game in the "PersistEventReportCallback" state
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
-    And the event "context" equals "Error 1"
-    And the exception "message" equals "Error 1"
+    And the event "context" equals "PersistEvent 1"
+    And the exception "message" equals "PersistEvent 1"
     And the event "device.id" equals "Persist Id"
     And the event "app.binaryArch" equals "Persist BinaryArch"
     And the event "exceptions.0.errorClass" equals "Persist ErrorClass"
@@ -117,6 +117,6 @@ Feature: Unity Persistence
     And I wait for requests to persist
     And I wait to receive 1 errors
     And the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 2"
+    And the exception "message" equals "PersistEvent 2"
 
 

--- a/features/csharp/csharp_sessions.feature
+++ b/features/csharp/csharp_sessions.feature
@@ -104,10 +104,10 @@ Feature: Session Tracking
     And I wait to receive 3 errors
     Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
     And the current error request events match one of:
-      | message           | handled | unhandled |
-      | Handled Error 1   | 1       | 0         |
-      | Handled Error 2   | 2       | 0         |
-      | Unhandled Error 1 | 2       | 1         |
+      | message                               | handled | unhandled |
+      | MultipleEventCounts Handled Error 1   | 1       | 0         |
+      | MultipleEventCounts Handled Error 2   | 2       | 0         |
+      | MultipleEventCounts Unhandled Error 1 | 2       | 1         |
 
   Scenario: No Auto session when not in enabled release stage
     When I run the game in the "SessionNotInReleaseStage" state
@@ -130,15 +130,15 @@ Feature: Session Tracking
     And I sort the errors by the payload field "events.0.exceptions.0.message"
     Then the session is valid for the session reporting API version "1.0" for the "Unity Bugsnag Notifier" notifier
     And the error is valid for the error reporting API sent by the Unity notifier
-    And the exception "message" equals "Error 1"
+    And the exception "message" equals "ResumedSession 1"
     And the error payload field "session.id" is stored as the value "session_id"
     And the error payload field "session.startedAt" is stored as the value "session_startedAt"
     And the error payload field "events.0.session.events.handled" equals 1
     And I discard the oldest error
-    And the exception "message" equals "Error 2"
+    And the exception "message" equals "ResumedSession 2"
     And the event "session" is null
     And I discard the oldest error
-    And the exception "message" equals "Error 3"
+    And the exception "message" equals "ResumedSession 3"
     And the error is valid for the error reporting API sent by the Unity notifier
     And the error payload field "session.id" equals the stored value "session_id"
     And the error payload field "session.startedAt" equals the stored value "session_startedAt"

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/EnableBreadcrumbs.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/EnableBreadcrumbs.cs
@@ -14,7 +14,7 @@ public class EnableBreadcrumbs : Scenario
     public override void Run()
     {
         Debug.Log("Debug.Log");
-        Bugsnag.Notify(new Exception("Error1"));
-        throw new Exception("Error2");
+        Bugsnag.Notify(new Exception("EnableBreadcrumbs 1"));
+        throw new Exception("EnableBreadcrumbs 2");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/ManualAndAutoBreadcrumbs.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/ManualAndAutoBreadcrumbs.cs
@@ -13,12 +13,12 @@ public class ManualAndAutoBreadcrumbs : Scenario
         Debug.Log("Debug.Log");
         Debug.LogWarning("Debug.LogWarning");
         Debug.LogError("Debug.LogError");
-        Debug.LogException(new Exception("Error1"));
-        Bugsnag.Notify(new Exception("Error2"));
+        Debug.LogException(new Exception("ManualAndAutoBreadcrumbs 1"));
+        Bugsnag.Notify(new Exception("ManualAndAutoBreadcrumbs 2"));
         Bugsnag.LeaveBreadcrumb("Metadata", new Dictionary<string, object>() {
             {"test" , "value" },
             {"nullTest" , null }
         });
-        throw new Exception("Error3");
+        throw new Exception("ManualAndAutoBreadcrumbs 3");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/CallbackInNotify.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/CallbackInNotify.cs
@@ -4,6 +4,6 @@ public class CallbackInNotify : Scenario
 {
     public override void Run()
     {
-        Bugsnag.Notify(new System.Exception("Error 1"),SimpleEventCallback);
+        Bugsnag.Notify(new System.Exception("CallbackInNotify 1"),SimpleEventCallback);
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/EditUnhandled.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/EditUnhandled.cs
@@ -22,22 +22,22 @@ public class EditUnhandled : Scenario
 
     private IEnumerator DoTest()
     {
-        Bugsnag.Notify(new Exception("Control"));
+        Bugsnag.Notify(new Exception("EditUnhandled Control"));
         yield return new WaitForSeconds(1);
-        Bugsnag.Notify(new Exception("HandledInNotifyCallback"), (report) =>
+        Bugsnag.Notify(new Exception("EditUnhandled HandledInNotifyCallback"), (report) =>
         {
             report.Unhandled = true;
             return true;
         });
         yield return new WaitForSeconds(1);
-        Bugsnag.Notify(new Exception("HandledInOnSendCallback"));
+        Bugsnag.Notify(new Exception("EditUnhandled HandledInOnSendCallback"));
         yield return new WaitForSeconds(1);
-        throw new Exception("UnhandledInOnErrorCallback");
+        throw new Exception("EditUnhandled UnhandledInOnErrorCallback");
     }
 
     private bool OnErrorCallback(IEvent @event)
     {
-        if (@event.Errors[0].ErrorMessage == "UnhandledInOnErrorCallback")
+        if (@event.Errors[0].ErrorMessage == "EditUnhandled UnhandledInOnErrorCallback")
         {
             @event.Unhandled = false;
             return true;
@@ -46,7 +46,7 @@ public class EditUnhandled : Scenario
     }
     private bool OnSendCallback(IEvent @event)
     {
-        if (@event.Errors[0].ErrorMessage == "HandledInOnSendCallback")
+        if (@event.Errors[0].ErrorMessage == "EditUnhandled HandledInOnSendCallback")
         {
             @event.Unhandled = true;
             return true;

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnErrorAfterStart.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnErrorAfterStart.cs
@@ -6,8 +6,8 @@ public class OnErrorAfterStart : Scenario
     public override void Run()
     {
         Bugsnag.AddOnError(SimpleEventCallback);
-        Bugsnag.Notify(new Exception("Error 1"));
-        throw new Exception("Error 2");
+        Bugsnag.Notify(new Exception("OnErrorAfterStart 1"));
+        throw new Exception("OnErrorAfterStart 2");
     }
 
    

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnErrorInConfig.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnErrorInConfig.cs
@@ -11,7 +11,7 @@ public class OnErrorInConfig : Scenario
 
     public override void Run()
     {
-        Bugsnag.Notify(new Exception("Error 1"));
-        throw new Exception("Error 2");
+        Bugsnag.Notify(new Exception("OnErrorInConfig 1"));
+        throw new Exception("OnErrorInConfig 2");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnSendInConfig.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Callbacks/OnSendInConfig.cs
@@ -11,7 +11,7 @@ public class OnSendInConfig : Scenario
 
     public override void Run()
     {
-        Bugsnag.Notify(new Exception("Error 1"));
-        throw new Exception("Error 2");
+        Bugsnag.Notify(new Exception("OnSendInConfig 1"));
+        throw new Exception("OnSendInConfig 2");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/AutoNotifyFalse.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/AutoNotifyFalse.cs
@@ -8,6 +8,6 @@
 
     public override void Run()
     {
-        throw new System.Exception("Error 1");
+        throw new System.Exception("AutoNotifyFalse 1");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DiscardErrorClass.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DiscardErrorClass.cs
@@ -12,7 +12,7 @@ public class DiscardErrorClass : Scenario
 
     public override void Run()
     {
-        Bugsnag.Notify(new System.IndexOutOfRangeException("Error 1"));
-        Bugsnag.Notify(new System.Exception("Error 2"));
+        Bugsnag.Notify(new System.IndexOutOfRangeException("DiscardErrorClass 1"));
+        Bugsnag.Notify(new System.Exception("DiscardErrorClass 2"));
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/LongLaunchTime.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/LongLaunchTime.cs
@@ -16,11 +16,11 @@ public class LongLaunchTime : Scenario
 
     private void DoNotify1()
     {
-        Bugsnag.Notify(new System.Exception("Error 1"));
+        Bugsnag.Notify(new System.Exception("LongLaunchTime 1"));
     }
 
     private void DoNotify2()
     {
-        Bugsnag.Notify(new System.Exception("Error 2"));
+        Bugsnag.Notify(new System.Exception("LongLaunchTime 2"));
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/MarkLaunchComplete.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/MarkLaunchComplete.cs
@@ -15,8 +15,8 @@ public class MarkLaunchComplete : Scenario
 
     private void DoException()
     {
-        Bugsnag.Notify(new System.Exception("Error 1"));
+        Bugsnag.Notify(new System.Exception("MarkLaunchComplete 1"));
         Bugsnag.MarkLaunchCompleted();
-        Bugsnag.Notify(new System.Exception("Error 2"));
+        Bugsnag.Notify(new System.Exception("MarkLaunchComplete 2"));
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/ShortLaunchTime.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/ShortLaunchTime.cs
@@ -19,11 +19,11 @@ public class ShortLaunchTime : Scenario
 
     private void DoNotify1()
     {
-        Bugsnag.Notify(new System.Exception("Error 1"));
+        Bugsnag.Notify(new System.Exception("ShortLaunchTime 1"));
     }
 
     private void DoNotify2()
     {
-        Bugsnag.Notify(new System.Exception("Error 2"));
+        Bugsnag.Notify(new System.Exception("ShortLaunchTime 2"));
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/InnerException.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Events/InnerException.cs
@@ -4,6 +4,6 @@ public class InnerException : Scenario
 {
     public override void Run()
     {
-        throw new Exception("Outer", new Exception("Inner"));
+        throw new Exception("InnerException Outer", new Exception("InnerException Inner"));
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/MaxPersistEvents.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/MaxPersistEvents.cs
@@ -20,7 +20,7 @@ public class MaxPersistEvents : Scenario
     {
         for (int i = 0; i < 4; i++)
         {
-            Bugsnag.Notify(new Exception("Error " + i));
+            Bugsnag.Notify(new Exception("MaxPersistEvents " + i));
             yield return new WaitForSeconds(2f);
         }
     }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEvent.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEvent.cs
@@ -5,11 +5,11 @@ public class PersistEvent : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.Context = "Error 1";
+        Configuration.Context = "PersistEvent 1";
     }
 
     public override void Run()
     {
-        throw new System.Exception("Error 1");
+        throw new System.Exception("PersistEvent 1");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReport.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReport.cs
@@ -5,11 +5,11 @@ public class PersistEventReport : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.Context = "Error 2";
+        Configuration.Context = "PersistEvent 2";
     }
 
     public override void Run()
     {
-        throw new System.Exception("Error 2");
+        throw new System.Exception("PersistEvent 2");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReportCallback.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistEventReportCallback.cs
@@ -6,7 +6,7 @@ public class PersistEventReportCallback : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.Context = "Error 2";
+        Configuration.Context = "PersistEvent 2";
         Configuration.AddOnSendError((@event) => {
 
             @event.App.BinaryArch = "Persist BinaryArch";
@@ -30,6 +30,6 @@ public class PersistEventReportCallback : Scenario
 
     public override void Run()
     {
-        throw new System.Exception("Error 2");
+        throw new System.Exception("PersistEvent 2");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistSession.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistSession.cs
@@ -6,7 +6,7 @@ public class PersistSession : Scenario
         base.PrepareConfig(apiKey, host);
         Configuration.AddOnSession((session) =>
         {
-            session.App.ReleaseStage = "Session 1";
+            session.App.ReleaseStage = "PersistSession 1";
             return true;
         });
     }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistSessionReport.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Persistence/PersistSessionReport.cs
@@ -6,7 +6,7 @@ public class PersistSessionReport : Scenario
         base.PrepareConfig(apiKey, host);
         Configuration.AddOnSession((session) =>
         {
-            session.App.ReleaseStage = "Session 2";
+            session.App.ReleaseStage = "PersistSession 2";
             return true;
         });
     }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/MultipleEventCounts.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/MultipleEventCounts.cs
@@ -14,8 +14,8 @@ public class MultipleEventCounts : Scenario
     public override void Run()
     {
         Bugsnag.StartSession();
-        Bugsnag.Notify(new System.Exception("Handled Error 1"));
-        Bugsnag.Notify(new System.Exception("Handled Error 2"));
-        throw new System.Exception("Unhandled Error 1");
+        Bugsnag.Notify(new System.Exception("MultipleEventCounts Handled Error 1"));
+        Bugsnag.Notify(new System.Exception("MultipleEventCounts Handled Error 2"));
+        throw new System.Exception("MultipleEventCounts Unhandled Error 1");
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/NewSession.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/NewSession.cs
@@ -13,8 +13,8 @@ public class NewSession : Scenario
     public override void Run()
     {
         Bugsnag.StartSession();
-        Bugsnag.Notify(new System.Exception("Error 1"));
+        Bugsnag.Notify(new System.Exception("NewSession 1"));
         Bugsnag.StartSession();
-        Bugsnag.Notify(new System.Exception("Error 2"));
+        Bugsnag.Notify(new System.Exception("NewSession 2"));
     }
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/ResumedSession.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Sessions/ResumedSession.cs
@@ -14,11 +14,11 @@ public class ResumedSession : Scenario
     public override void Run()
     {
         Bugsnag.StartSession();
-        Bugsnag.Notify(new System.Exception( "Error 1"));
+        Bugsnag.Notify(new System.Exception("ResumedSession 1"));
         Bugsnag.PauseSession();
-        Bugsnag.Notify(new System.Exception("Error 2"));
+        Bugsnag.Notify(new System.Exception("ResumedSession 2"));
         Bugsnag.ResumeSession();
-        Bugsnag.Notify(new System.Exception("Error 3"));
+        Bugsnag.Notify(new System.Exception("ResumedSession 3"));
     }
 
 }


### PR DESCRIPTION
## Goal

Make test scenario exception messages more distinctive, so that requests bleeding across scenarios are much easier to identify.

## Testing

Covered by a basic CI run (only CSharp scenarios have been changed, the rest were already distinctive).