### PR TITLE
Use Maze Runner idempotent commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ UPMImportProject.sln
 upm-edm4u-package
 upm-edm4u-package.zip
 testResults.xml
+features/fixtures/maze_runner/mazerunner_BackUpThisFolder_ButDontShipItWithYourGame/

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@ gem 'danger'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-#  gem 'bugsnag-maze-runner', '~>10.0'
+  gem 'bugsnag-maze-runner', '~>10.0'
 
   # Use a specific Maze Runner branch
-  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/PLAT-15012-enhanced-idempotent'
+  #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'main'
 
   # Use a local copy of Maze Runner for development purposes
   #gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@ gem 'danger'
 
 unless Gem.win_platform?
   # Use official Maze Runner release
-  gem 'bugsnag-maze-runner', '~>10.0'
+#  gem 'bugsnag-maze-runner', '~>10.0'
 
   # Use a specific Maze Runner branch
-  # gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'
+  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/PLAT-15012-enhanced-idempotent'
 
   # Use a local copy of Maze Runner for development purposes
   #gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ x-common-environment: &common-environment
 
 services:
   maze-runner-bitbar:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-PLAT-15012-enhanced-idempotent-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v10-cli
     environment:
       <<: *common-environment
       BITBAR_USERNAME:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ x-common-environment: &common-environment
 
 services:
   maze-runner-bitbar:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v10-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-PLAT-15012-enhanced-idempotent-cli
     environment:
       <<: *common-environment
       BITBAR_USERNAME:

--- a/features/android/android_callbacks.feature
+++ b/features/android/android_callbacks.feature
@@ -8,7 +8,7 @@ Feature: Callbacks
     When I run the game in the "AndroidBackgroundJVMSmokeTest" state
     And I wait for 2 seconds
     And I clear any error dialogue
-    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "AndroidOnSendCallback" state
     And I wait to receive an error
 

--- a/features/android/android_jvm_errors.feature
+++ b/features/android/android_jvm_errors.feature
@@ -39,7 +39,7 @@ Feature: Android JVM Exceptions
     When I run the game in the "AndroidBackgroundJVMSmokeTest" state
     And I wait for 2 seconds
     And I clear any error dialogue
-    And On Mobile I relaunch the app
+#    And On Mobile I relaunch the app
     And I run the game in the "StartSDKDefault" state
     And I wait to receive an error
     And expected device metadata is included in the event
@@ -76,7 +76,7 @@ Feature: Android JVM Exceptions
     When I run the game in the "AndroidBackgroundJVMSmokeTest" state
     And I wait for 2 seconds
     And I clear any error dialogue
-    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "AndroidLastRunInfo" state
     And I wait to receive 2 errors
     And I discard the oldest error
@@ -86,7 +86,7 @@ Feature: Android JVM Exceptions
     When I run the game in the "AndroidDisableCrashes" state
     And I wait for 2 seconds
     And I clear any error dialogue
-    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I should receive no errors
        

--- a/features/android/android_jvm_errors.feature
+++ b/features/android/android_jvm_errors.feature
@@ -39,7 +39,7 @@ Feature: Android JVM Exceptions
     When I run the game in the "AndroidBackgroundJVMSmokeTest" state
     And I wait for 2 seconds
     And I clear any error dialogue
-#    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I wait to receive an error
     And expected device metadata is included in the event

--- a/features/android/android_ndk_errors.feature
+++ b/features/android/android_ndk_errors.feature
@@ -9,7 +9,7 @@ Feature: Android NDK crash
     When I run the game in the "AndroidNDKSignal" state
     And I wait for 3 seconds
     And I clear any error dialogue
-    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
         # Intentionally adding long wait times here - a core component of this
         # feature is ensuring that only a SINGLE event is sent. Unity includes

--- a/features/csharp/csharp_events.feature
+++ b/features/csharp/csharp_events.feature
@@ -139,7 +139,6 @@ Feature: csharp events
     And expected device metadata is included in the event
     And expected app metadata is included in the event
 
-  @skip_unity_2018
   Scenario: Reporting an inner exception
     When I run the game in the "InnerException" state
     And I wait to receive an error

--- a/features/csharp/csharp_persistence.feature
+++ b/features/csharp/csharp_persistence.feature
@@ -10,8 +10,8 @@ Feature: Unity Persistence
     And I wait to receive 1 session
     And I wait for requests to persist
     And I discard the oldest session
-    And I close the Unity app
-    And On Mobile I relaunch the app
+    And I stop the Unity app
+    And I start the Unity app
     And I run the game in the "PersistSessionReport" state
     And I wait to receive 2 sessions
     And I sort the sessions by the payload field "app.releaseStage"
@@ -27,8 +27,8 @@ Feature: Unity Persistence
     And I wait to receive an error
     And I wait for requests to persist
     And I discard the oldest error
-    And I close the Unity app
-    And On Mobile I relaunch the app
+    And I stop the Unity app
+    And I start the Unity app
     And I run the game in the "PersistEventReport" state
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
@@ -47,8 +47,8 @@ Feature: Unity Persistence
     And I wait to receive an error
     And I wait for requests to persist
     And I discard the oldest error
-    And I close the Unity app
-    And On Mobile I relaunch the app
+    And I stop the Unity app
+    And I start the Unity app
     And I run the game in the "PersistEventReportCallback" state
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
@@ -71,8 +71,8 @@ Feature: Unity Persistence
     And I discard the oldest error
     And I discard the oldest error
     And I discard the oldest error
-    And I close the Unity app
-    And On Mobile I relaunch the app
+    And I stop the Unity app
+    And I start the Unity app
     And I run the game in the "ReportMaxPersistedEvents" state
     And I wait to receive an error
     And the exception "message" equals "true"
@@ -87,8 +87,8 @@ Feature: Unity Persistence
     And I discard the oldest session
     And I discard the oldest session
     And I discard the oldest session
-    And I close the Unity app
-    And On Mobile I relaunch the app
+    And I stop the Unity app
+    And I start the Unity app
     And I run the game in the "ReportMaxPersistedSessions" state
     And I wait to receive an error
     And the exception "message" equals "true"
@@ -100,8 +100,8 @@ Feature: Unity Persistence
     And the exception "message" equals "PersistDeviceId"
     And the error payload field "events.0.device.id" is stored as the value "device_id"
     And I discard the oldest error
-    And I close the Unity app
-    And On Mobile I relaunch the app
+    And I stop the Unity app
+    And I start the Unity app
     And I run the game in the "PersistDeviceId" state
     And I wait to receive an error
     And the exception "message" equals "PersistDeviceId"
@@ -111,8 +111,8 @@ Feature: Unity Persistence
   Scenario: Handle Corrupt Json
     And I run the game in the "CorruptedCacheFile" state
     And I wait for requests to persist
-    And I close the Unity app
-    And On Mobile I relaunch the app
+    And I stop the Unity app
+    And I start the Unity app
     And I run the game in the "PersistEventReport" state
     And I wait for requests to persist
     And I wait to receive 1 errors

--- a/features/edm4u/edm4u.feature
+++ b/features/edm4u/edm4u.feature
@@ -1,7 +1,6 @@
 Feature: Android EDM4U smoke test
 
   Scenario: Android EDM4U smoke test
-    When On Mobile I relaunch the app
     And I wait to receive at least 1 error
     And the exception "message" equals "EDM4U"
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Logger.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Logger.cs
@@ -1,28 +1,21 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
 public class Logger : MonoBehaviour
 {
-
     const string LOG_PREFIX = "BUGSNAG_MAZERUNNER_LOG : ";
 
     const string LOG_FILE_NAME = "mazerunner-unity.log";
 
-    private static string _currentLog;
-
     public static void I(string msg)
     {
         Debug.Log(LOG_PREFIX + msg);
-        _currentLog += msg + "\n";
-        WriteLogFile();
-    }
 
-    private static void WriteLogFile()
-    {
         var path = Path.Combine(Application.persistentDataPath, LOG_FILE_NAME);
-        File.WriteAllText(path, _currentLog);
+        var log = string.Format("[{0:yyyy-MM-dd HH:mm:ss.fff}] {1}\n", DateTime.Now, msg);
+        File.AppendAllText(path, log);
     }
-   
 }

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 public class Command
 {
     public string action;
+    public string uuid;
     public string scenarioName;
 }
 
@@ -32,9 +33,11 @@ public class Main : MonoBehaviour
 #endif
 
     private string _fixtureConfigFileName = "/fixture_config.json";
+    private string _commandUuidFileName = "/command_uuid.txt";
 
     private const string API_KEY = "a35a2a72bd230ac0aa0f52715bbdc6aa";
     public static string MazeHost;
+    private static string LastCommandUuid;
 
     private const int MAX_CONFIG_GET_TRIES = 15;
 
@@ -44,12 +47,37 @@ public class Main : MonoBehaviour
     {
         Log("Maze Runner app started");
 
+        GetLastCommandUuid();
+
         yield return GetFixtureConfig();
 
 #if UNITY_STANDALONE_OSX
         PreventCrashPopups();
 #endif
         InvokeRepeating("DoRunNextMazeCommand", 0, 1);
+    }
+
+    private void GetLastCommandUuid()
+    {
+        var uuidFilePath = Application.persistentDataPath + _commandUuidFileName;
+        if (File.Exists(uuidFilePath))
+        {
+            LastCommandUuid = File.ReadAllText(uuidFilePath);
+        }
+        else
+        {
+            LastCommandUuid = "";
+        }
+        Log("Last command UUID is: " + LastCommandUuid);
+    }
+
+    private void SetLastCommandUuid(String uuid) 
+    {
+        Log("Setting last command UUID: " + uuid);
+        var uuidFilePath = Application.persistentDataPath + _commandUuidFileName;
+        File.WriteAllText(uuidFilePath, uuid);
+        LastCommandUuid = uuid;
+        Log("Command UUID is now: " + LastCommandUuid);
     }
 
     private IEnumerator GetFixtureConfig()
@@ -89,7 +117,7 @@ public class Main : MonoBehaviour
                 MazeHost = "http://bs-local.com:9339";
             }
         }
-        Log("Mazerunner host set to: " + MazeHost);
+        Log("Maze Runner host set to: " + MazeHost);
     }
 
     private void DoRunNextMazeCommand()
@@ -99,25 +127,17 @@ public class Main : MonoBehaviour
 
     IEnumerator RunNextMazeCommand()
     {
-        var url = MazeHost + "/command";
+        var url = MazeHost + "/idem-command?after=" + LastCommandUuid;
         Log("Requesting maze command from: " + url);
         using (UnityWebRequest request = UnityWebRequest.Get(url))
         {
             yield return request.SendWebRequest();
-#if UNITY_2020_1_OR_NEWER
             var result = request != null && request.result == UnityWebRequest.Result.Success;
-#else
-            var result = request != null &&
-                !request.isHttpError &&
-                !request.isNetworkError;
-#endif
 
-            Log("result is " + result);
             if (result)
             {
                 var response = request.downloadHandler?.text;
-                Log("Raw response: " + response);
-                if (response == null || response == "null" || response == "No commands to provide")
+                if (response == null || response == "null")
                 {
                     Log("No Maze Runner command to process at present");
                 }
@@ -126,24 +146,34 @@ public class Main : MonoBehaviour
                     var command = JsonUtility.FromJson<Command>(response);
                     if (command != null)
                     {
-                        Log("Received Maze Runner command:");
-                        Log("Action: " + command.action);
-                        Log("Scenario: " + command.scenarioName);
+                        Log("Received Maze Runner command:\n" + response);
 
-                        if ("clear_cache".Equals(command.action))
+                        switch(command.action) 
                         {
-                            ClearUnityCache();
-                        }
-                        else if ("run_scenario".Equals(command.action))
-                        {
-                            ScenarioRunner.RunScenario(command.scenarioName, API_KEY, MazeHost);
-                        }
-                        else if ("close_application".Equals(command.action))
-                        {
-                            CloseFixture();
+                            case "noop":
+                                break;
+                            case "reset_uuid":
+                                SetLastCommandUuid("");
+                                break;
+                            case "clear_cache":
+                                ClearUnityCache();
+                                SetLastCommandUuid(command.uuid);
+                                break;
+                            case "run_scenario":
+                                SetLastCommandUuid(command.uuid);
+                                ScenarioRunner.RunScenario(command.scenarioName, API_KEY, MazeHost);
+                                break;
+                            case "close_application":
+                                SetLastCommandUuid(command.uuid);
+                                CloseFixture();
+                                break;
                         }
                     }
                 }
+            }
+            else 
+            {
+                Log("Request error: " + request.error);
             }
         }
     }
@@ -159,6 +189,12 @@ public class Main : MonoBehaviour
 #if UNITY_SWITCH
         return;
 #endif
+
+        Log("Start ClearUnityCache");
+#if DEBUG
+        ListAllPersistentDataFiles();
+#endif
+
         if (Directory.Exists(Application.persistentDataPath + "/Bugsnag"))
         {
             Directory.Delete(Application.persistentDataPath + "/Bugsnag", true);
@@ -167,11 +203,22 @@ public class Main : MonoBehaviour
         {
             ClearIOSData();
         }
-        if (Application.platform != RuntimePlatform.Android &&
-            Application.platform != RuntimePlatform.IPhonePlayer)
+#if DEBUG
+        ListAllPersistentDataFiles();
+#endif
+        Log("End ClearUnityCache");
+    }
+
+    private void ListAllPersistentDataFiles()
+    {
+        string rootPath = Application.persistentDataPath;
+        string listing = "Contents of " + rootPath + ":\n";
+        string[] files = Directory.GetFiles(rootPath, "*", SearchOption.AllDirectories);
+        foreach (var file in files)
         {
-            Invoke("CloseFixture", 0.25f);
+            listing += "  " + file + "\n";
         }
+        Log(listing);
     }
 
     public static void ClearIOSData()
@@ -191,8 +238,5 @@ public class Main : MonoBehaviour
         {
             // can fail on windows
         }
-
     }
-
-
 }

--- a/features/ios/ios_callbacks.feature
+++ b/features/ios/ios_callbacks.feature
@@ -10,7 +10,7 @@ Feature: Callbacks
     When I run the game in the "IosNativeException" state
     And I wait for 2 seconds
     And I clear any error dialogue
-    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "IosNativeOnSendCallback" state
     And I wait to receive an error
 

--- a/features/ios/ios_native_errors.feature
+++ b/features/ios/ios_native_errors.feature
@@ -6,7 +6,7 @@ Feature: iOS Native Errors
   Scenario: Disable Crashes
     When I run the game in the "IosDisableCrashes" state
     And I wait for 2 seconds
-    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I should receive no errors
 
@@ -14,19 +14,18 @@ Feature: iOS Native Errors
     When I run the game in the "IosNativeException" state
     And I wait for 2 seconds
     And I clear any error dialogue
-    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "IosLastRunInfo" state
     And I wait for 3 seconds
     And I wait to receive 2 errors
     And I discard the oldest error
     And the exception "message" equals "Last Run Info Correct"
 
-  @skip_unity_2018
   Scenario: iOS native exception Smoke Test
     When I run the game in the "IosNativeException" state
     And I wait for 2 seconds
     And I clear any error dialogue
-    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I wait to receive an error
     And expected device metadata is included in the event
@@ -60,12 +59,11 @@ Feature: iOS Native Errors
     And the error payload field "events.0.usage.config" is not null
     And the error payload field "events.0.usage.callbacks.onSession" equals 1
 
-  @skip_unity_2018
   Scenario: iOS signal Smoke Test
     When I run the game in the "IosSignal" state
     And I wait for 2 seconds
     And I clear any error dialogue
-    And On Mobile I relaunch the app
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I wait to receive an error
     And expected device metadata is included in the event

--- a/features/macos/macos_native_crashes.feature
+++ b/features/macos/macos_native_crashes.feature
@@ -6,7 +6,7 @@ Feature: MacOS native crashes
   @macos_only
   Scenario: Reporting a MacOS native crash
     When I run the game in the "MacOSNativeCrash" state
-    And I wait for 2 seconds
+    And I wait for the macOS Unity app to stop
     And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I wait to receive an error
@@ -27,12 +27,11 @@ Feature: MacOS native crashes
     And the event "user.email" equals "2"
     And the event "user.name" equals "3"
 
-#NOTE to be improved in PLAT-9129
-
+  #NOTE to be improved in PLAT-9129
   @macos_only
   Scenario: Reporting a MacOS native crash with an onsend callback
     When I run the game in the "MacOSNativeCrash" state
-    And I wait for 2 seconds
+    And I wait for the macOS Unity app to stop
     And I start the Unity app
     And I run the game in the "MacOSNativeCrashCallback" state
     And I wait to receive an error
@@ -98,7 +97,7 @@ Feature: MacOS native crashes
   @macos_only
   Scenario: Set User After Init Native Error
     When I run the game in the "MacOSSetUserAfterInitNativeCrash" state
-    And I wait for 2 seconds
+    And I wait for the macOS Unity app to stop
     And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I wait to receive an error
@@ -113,7 +112,7 @@ Feature: MacOS native crashes
   @macos_only
   Scenario: Native crash outside of release stage
     When I run the game in the "MacOSNativeCrashOutsideReleaseStages" state
-    And I wait for 2 seconds
+    And I wait for the macOS Unity app to stop
     And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     Then I should receive no errors
@@ -121,7 +120,7 @@ Feature: MacOS native crashes
   @macos_only
   Scenario: Reporting a native crash when AutoDetectErrors = false
     When I run the game in the "MacOSNativeCrashAutoDetectErrorsFalse" state
-    And I wait for 2 seconds
+    And I wait for the macOS Unity app to stop
     And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     Then I should receive no errors
@@ -129,7 +128,7 @@ Feature: MacOS native crashes
   @macos_only
   Scenario: Reporting a native crash when EnabledErrorTypes.Crashes = false
     When I run the game in the "MacOSNativeCrashEnabledErrorTypes" state
-    And I wait for 2 seconds
+    And I wait for the macOS Unity app to stop
     And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     Then I should receive no errors

--- a/features/macos/macos_native_crashes.feature
+++ b/features/macos/macos_native_crashes.feature
@@ -1,9 +1,13 @@
 Feature: MacOS native crashes
 
+  Background:
+    Given I clear the Bugsnag cache
+
   @macos_only
   Scenario: Reporting a MacOS native crash
     When I run the game in the "MacOSNativeCrash" state
     And I wait for 2 seconds
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the native Unity notifier
@@ -29,6 +33,7 @@ Feature: MacOS native crashes
   Scenario: Reporting a MacOS native crash with an onsend callback
     When I run the game in the "MacOSNativeCrash" state
     And I wait for 2 seconds
+    And I start the Unity app
     And I run the game in the "MacOSNativeCrashCallback" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the native Unity notifier
@@ -94,6 +99,7 @@ Feature: MacOS native crashes
   Scenario: Set User After Init Native Error
     When I run the game in the "MacOSSetUserAfterInitNativeCrash" state
     And I wait for 2 seconds
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the native Unity notifier
@@ -108,6 +114,7 @@ Feature: MacOS native crashes
   Scenario: Native crash outside of release stage
     When I run the game in the "MacOSNativeCrashOutsideReleaseStages" state
     And I wait for 2 seconds
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     Then I should receive no errors
 
@@ -115,13 +122,15 @@ Feature: MacOS native crashes
   Scenario: Reporting a native crash when AutoDetectErrors = false
     When I run the game in the "MacOSNativeCrashAutoDetectErrorsFalse" state
     And I wait for 2 seconds
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     Then I should receive no errors
 
-   @macos_only
+  @macos_only
   Scenario: Reporting a native crash when EnabledErrorTypes.Crashes = false
     When I run the game in the "MacOSNativeCrashEnabledErrorTypes" state
     And I wait for 2 seconds
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     Then I should receive no errors
 

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -62,7 +62,7 @@ end
 When('I run the game in the {string} state') do |state|
   platform = Maze::Helper.get_current_platform
   case platform
-  when 'macos','android', 'ios', 'switch'
+  when 'macos','android', 'ios', 'switch', 'windows'
     execute_command('run_scenario', state)
   when 'browser'
     # WebGL in a browser
@@ -102,17 +102,7 @@ Then('the error is valid for the error reporting API sent by the native Unity no
 end
 
 Then('the error is valid for the error reporting API sent by the Unity notifier') do
-
-  os = if Maze.config.farm == :bs
-    # Mobile - could be ios or android
-    Maze.config.capabilities['os']
-  else
-    # Could be windows or macos
-    Maze.config.os
-  end
-
   notifier_name = 'Unity Bugsnag Notifier'
-
   check_error_reporting_api notifier_name
 end
 

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -374,13 +374,16 @@ def start_app
     manager.activate
   when 'switch'
     switch_run_on_target
+  when 'browser'
+    # WebGL - do nothing
   else
     raise "Platform #{platform} has not been considered"
   end
 end
 
 def stop_app
-  case Maze::Helper.get_current_platform
+  platform = Maze::Helper.get_current_platform
+  case platform
   when 'macos'
     `killall Mazerunner`
   when 'windows'
@@ -392,6 +395,8 @@ def stop_app
   when 'switch'
     # Terminate the app
     Maze::Runner.run_command('ControlTarget.exe terminate')
+  when 'browser'
+    # WebGL - do nothing
   else
     raise "Platform #{platform} has not been considered"
   end

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -391,7 +391,8 @@ def stop_app
     `killall Mazerunner`
   when 'windows'
     # This assumes Maze Runner is being run under WSL
-    `/mnt/c/Windows/system32/taskkill.exe /F /IM Mazerunner.exe`
+    process_name = File.basename(Maze.config.app)
+    `/mnt/c/Windows/system32/taskkill.exe /F /IM #{process_name}`
   when 'android', 'ios'
     manager = Maze::Api::Appium::AppManager.new
     manager.terminate

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -303,6 +303,19 @@ Then("expected app metadata is included in the event") do
   }
 end
 
+When("I wait for the macOS Unity app to stop") do
+  # The macOS app can vary wildly in how long it takes to stop, so use pgrep to detect when it has fully exited
+  # Also wait for a second before polling as pgrep may return false positives if checked too quickly
+  sleep 1
+  wait = Maze::Wait.new(timeout: 30, interval: 1)
+  stopped = wait.until do
+    `pgrep Mazerunner`
+    running = $?.exitstatus
+    running == 1
+  end
+  Maze.check.true(stopped, "The app did not stop within the timeout period")
+end
+
 When("I clear any error dialogue") do
   click_if_present 'android:id/button1'
   click_if_present 'android:id/aerr_close'

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -1,23 +1,11 @@
 require 'cgi'
 
-When('On Mobile I relaunch the app') do
-  next unless Maze.config.device
-  manager = Maze::Api::Appium::AppManager.new
-  manager.launch
-  sleep 3
-end
-
 def execute_command(action, scenario_name = '')
   command = {
     action: action,
     scenarioName: scenario_name
   }
   Maze::Server.commands.add command
-
-  # Ensure fixture has read the command
-  count = 300
-  sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
-  raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
 end
 
 Then('the sourcemaps Content-Type header is valid multipart form-data') do
@@ -47,80 +35,41 @@ end
 
 When('I clear the Bugsnag cache') do
   case Maze::Helper.get_current_platform
-  when 'macos', 'webgl'
-    # Call executable directly rather than use open, which flakes on CI
-    log = File.join(Dir.pwd, 'mazerunner.log')
-    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args -logfile #{log} > /dev/null"
-    Maze::Runner.run_command(command, blocking: false)
-    execute_command('clear_cache')
-
-  when 'windows'
-    win_log = File.join(Dir.pwd, 'mazerunner.log')
-    command = "#{Maze.config.app} --args -logfile #{win_log}"
-    Maze::Runner.run_command(command, blocking: false)
-    execute_command('clear_cache')
-
-  when 'android', 'ios'
+  when 'macos', 'windows', 'android', 'ios', 'switch'
     execute_command('clear_cache')
   when 'browser'
     url = "http://localhost:#{Maze.config.port}/docs/index.html"
     $logger.debug "Navigating to URL: #{url}"
     step("I navigate to the URL \"#{url}\"")
     execute_command('clear_cache')
-
-  when 'switch'
-    switch_run_on_target
-    execute_command('clear_cache')
-
   else
     raise "Platform #{platform} has not been considered"
   end
-
-  sleep 2
-
 end
 
 When('I wait for requests to persist') do
   sleep 1
 end
 
-When('I close the Unity app') do
-  execute_command('close_application')
+When('I stop the Unity app') do
+  stop_app
+end
+
+When('I start the Unity app') do
+  start_app
 end
 
 When('I run the game in the {string} state') do |state|
   platform = Maze::Helper.get_current_platform
   case platform
-  when 'macos'
-    # Call executable directly rather than use open, which flakes on CI
-    log = File.join(Dir.pwd, "#{state}-mazerunner.log")
-    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args -logfile #{log} > /dev/null"
-    Maze::Runner.run_command(command, blocking: false)
-
+  when 'macos','android', 'ios', 'switch'
     execute_command('run_scenario', state)
-
-  when 'windows'
-    win_log = File.join(Dir.pwd, "#{state}-mazerunner.log")
-    command = "#{Maze.config.app} --args -logfile #{win_log}"
-    Maze::Runner.run_command(command, blocking: false)
-
-    execute_command('run_scenario', state)
-
-  when 'android', 'ios'
-    execute_command('run_scenario', state)
-
   when 'browser'
     # WebGL in a browser
     url = "http://localhost:#{Maze.config.port}/docs/index.html"
     $logger.debug "Navigating to URL: #{url}"
     step("I navigate to the URL \"#{url}\"")
     execute_command('run_scenario', state)
-
-  when 'switch'
-
-    switch_run_on_target
-    execute_command('run_scenario', state)
-
   else
     raise "Platform #{platform} has not been considered"
   end
@@ -408,4 +357,42 @@ end
 Then("the exception {string} equals one of:") do |keypath, possible_values|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.exceptions.0.#{keypath}")
   Maze.check.include(possible_values.raw.flatten, value)
+end
+
+def start_app
+  platform = Maze::Helper.get_current_platform
+  case platform
+  when 'macos'
+    # Open the fixture - call executable directly rather than use open, which flakes on CI
+    command = "#{Maze.config.app}/Contents/MacOS/Mazerunner --args > /dev/null"
+    Maze::Runner.run_command(command, blocking: false)
+  when 'windows'
+    command = "#{Maze.config.app}"
+    Maze::Runner.run_command(command, blocking: false)
+  when 'android', 'ios'
+    manager = Maze::Api::Appium::AppManager.new
+    manager.activate
+  when 'switch'
+    switch_run_on_target
+  else
+    raise "Platform #{platform} has not been considered"
+  end
+end
+
+def stop_app
+  case Maze::Helper.get_current_platform
+  when 'macos'
+    `killall Mazerunner`
+  when 'windows'
+    # This assumes Maze Runner is being run under WSL
+    `/mnt/c/Windows/system32/taskkill.exe /F /IM Mazerunner.exe`
+  when 'android', 'ios'
+    manager = Maze::Api::Appium::AppManager.new
+    manager.terminate
+  when 'switch'
+    # Terminate the app
+    Maze::Runner.run_command('ControlTarget.exe terminate')
+  else
+    raise "Platform #{platform} has not been considered"
+  end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,14 +1,5 @@
 require 'fileutils'
 
-Before('@skip_unity_2018') do |_scenario|
-  if ENV['UNITY_VERSION']
-    unity_version = ENV['UNITY_VERSION'][0..3].to_i
-    if unity_version == 2018
-      skip_this_scenario('Skipping scenario on Unity 2018')
-    end
-  end
-end
-
 Before('@skip_unity_2020') do |_scenario|
   if ENV['UNITY_VERSION']
     unity_version = ENV['UNITY_VERSION'][0..3].to_i
@@ -135,7 +126,8 @@ BeforeAll do
 end
 
 Maze.hooks.before do
-  if Maze.config.os == 'macos'
+  platform = Maze::Helper.get_current_platform
+  if platform == 'macos'
     support_dir = File.expand_path '~/Library/Application Support/com.bugsnag.Bugsnag'
     $logger.info "Clearing #{support_dir}"
     FileUtils.rm_rf(support_dir)
@@ -147,6 +139,8 @@ Maze.hooks.before do
     $logger.info 'Killing defaults service'
     Maze::Runner.run_command("killall -u #{ENV['USER']} cfprefsd")
   end
+
+  start_app unless platform in ['android', 'ios'] # Maze Runner will handle mobile platforms
 end
 
 Before do |scenario|
@@ -160,15 +154,8 @@ end
 After do |scenario|
   next if scenario.status == :skipped
 
-  case Maze::Helper.get_current_platform
-  when 'macos'
-    `killall Mazerunner`
-  when 'webgl','windows'
-    execute_command('close_application')
-  when 'switch'
-    # Terminate the app
-    Maze::Runner.run_command('ControlTarget.exe terminate')
-  end
+  platform = Maze::Helper.get_current_platform
+  stop_app unless platform in ['android', 'ios'] # Maze Runner will handle mobile platforms
 end
 
 device_logs = []

--- a/features/switch/switch.feature
+++ b/features/switch/switch.feature
@@ -6,7 +6,8 @@ Feature: Switch Specific Tests
     And I wait to receive an error
     And I wait for requests to persist
     And I discard the oldest error
-    And I close the Unity app
+    And I stop the Unity app
+    And I start the Unity app
     And I run the game in the "SwitchCacheNone" state
     And I wait to receive an error
     Then the error is valid for the error reporting API sent by the Unity notifier
@@ -21,7 +22,8 @@ Feature: Switch Specific Tests
     And I wait for requests to persist
     And I discard the oldest error
     And I discard the oldest error
-    And I close the Unity app
+    And I stop the Unity app
+    And I start the Unity app
     And I run the game in the "StartSDKDefault" state
     And I wait to receive 1 errors
     And the exception "message" equals "LARGE PAYLOAD 2"


### PR DESCRIPTION
## Goal

Convert the e2e tests to use idempotent Maze Runner commands, together with various other stability improvements.

## Design

The idempotent command pattern works by passing the UUID of the last successfully processed command when making a command for the next.  This means the fixture needs to write the the UUID to disk once received so that it can be read after restarting the app.

In the course of making the change I realised that there were some inherent race conditions relating to how we sent commands to run scenarios and how were were starting and stopping the app.  We were often ending up with two instances of the app running (on macOS/Windows), causing various forms of test flakes.

## Changeset

- Test fixture now uses the `/idem-command` endpoint, passing the last known UUID.
- Mechanism added to persist the UUID of the last command processed, as well as reset it when instructed to by Maze Runner.
- Fixture app is now opened `Before` every scenario and closed `After` each.  If a scenario needs the app to stop/start then this is now handled by explicit Cucumber steps.
- Approach to starting and stopping the app on macOS/Windows, adding a mechanism to wait for the macOS app to actually stop. 

## Testing

Covered by a full CI run.  It's not completely flake free, but should be much better than it has been.