### PR TITLE
Buildkite pipeline tidy-up

### DIFF
--- a/.buildkite/block.basic.yml
+++ b/.buildkite/block.basic.yml
@@ -1,12 +1,11 @@
 steps:
-  - block: 'Trigger a basic build'
-    key: 'trigger-basic-build'
+  - block: "Trigger a basic build"
+    key: "trigger-basic-build"
 
-  - label: 'Upload the basic test pipeline'
-    key: 'upload-basic-build'
+  - label: "Upload the basic test pipeline"
+    key: "upload-basic-build"
     agents:
-      queue: macos
+      queue: "macos"
     timeout_in_minutes: 2
-    depends_on: 'trigger-basic-build'
-    command: >
-      buildkite-agent pipeline upload .buildkite/pipeline.basic.yml
+    depends_on: "trigger-basic-build"
+    command: "buildkite-agent pipeline upload .buildkite/pipeline.basic.yml"

--- a/.buildkite/block.full.yml
+++ b/.buildkite/block.full.yml
@@ -1,11 +1,10 @@
 steps:
-  - block: 'Trigger a full build'
-    key: 'trigger-full-build'
+  - block: "Trigger a full build"
+    key: "trigger-full-build"
 
-  - label: 'Upload the full test pipeline'
+  - label: "Upload the full test pipeline"
     agents:
-      queue: macos
+      queue: "macos"
     timeout_in_minutes: 2
-    depends_on: 'trigger-full-build'
-    command: >
-      buildkite-agent pipeline upload .buildkite/pipeline.full.yml
+    depends_on: "trigger-full-build"
+    command: "buildkite-agent pipeline upload .buildkite/pipeline.full.yml"

--- a/.buildkite/pipeline.basic.yml
+++ b/.buildkite/pipeline.basic.yml
@@ -2,11 +2,11 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-15
+  queue: "macos-15"
 
 steps:
 
-  - label: Verify code formatting
+  - label: "Verify code formatting"
     timeout_in_minutes: 5
     env:
       UNITY_VERSION: *2021
@@ -15,39 +15,39 @@ steps:
         upload:
           - "Bugsnag/Library/Logs/*.log"
     commands:
-      - rake code:verify
+      - "rake code:verify"
 
-  - label: Run Unit Tests
+  - label: "Run Unit Tests"
     timeout_in_minutes: 5
     env:
       UNITY_VERSION: *2021
     commands:
-      - rake test:run_editor_unit_tests
+      - "rake test:run_editor_unit_tests"
     artifact_paths:
-      - testResults.xml
+      - "testResults.xml"
 
-  - label: Build released notifier artifact
+  - label: "Build released notifier artifact"
     key: "build-unitypackage"
     timeout_in_minutes: 30
     env:
       UNITY_VERSION: *2021
-      JAVA_VERSION: 17
+      JAVA_VERSION: "17"
     commands:
-      - bundle install
-      - bundle exec rake plugin:export
-      - zip -r upm-package.zip upm-package
-      - zip -r upm-edm4u-package.zip upm-edm4u-package
+      - "bundle install"
+      - "bundle exec rake plugin:export"
+      - "zip -r upm-package.zip upm-package"
+      - "zip -r upm-edm4u-package.zip upm-edm4u-package"
     artifact_paths:
-      - Bugsnag.unitypackage
-      - upm-package.zip
-      - upm-edm4u-package.zip
+      - "Bugsnag.unitypackage"
+      - "upm-package.zip"
+      - "upm-edm4u-package.zip"
     retry:
       automatic:
         - exit_status: "*"
           limit: 1
 
   - label: "Test UPM Package Import"
-    depends_on: build-unitypackage
+    depends_on: "build-unitypackage"
     timeout_in_minutes: 10
     env:
       UNITY_VERSION: *2021
@@ -55,37 +55,37 @@ steps:
     plugins:
       artifacts#v1.9.0:
         download:
-          - upm-package.zip
+          - "upm-package.zip"
         upload:
-          - upm-import.log
+          - "upm-import.log"
     commands:
       - "features/scripts/test_upm_package_import.sh"
 
-  - label: 'Run size impact reporting'
-    depends_on: build-unitypackage
+  - label: "Run size impact reporting"
+    depends_on: "build-unitypackage"
     timeout_in_minutes: 30
     env:
       UNITY_VERSION: *2021
     plugins:
       'artifacts#v1.9.0':
         download:
-          - Bugsnag.unitypackage
+          - "Bugsnag.unitypackage"
     commands:
-      features/scripts/do_size_test.sh
+      - "features/scripts/do_size_test.sh"
 
-  - label: 'Append Unity 2021 Pipeline'
-    depends_on: build-unitypackage
+  - label: "Append Unity 2021 Pipeline"
+    depends_on: "build-unitypackage"
     agents:
-      queue: macos
+      queue: "macos"
     timeout_in_minutes: 2
     commands:
-      - buildkite-agent pipeline upload .buildkite/unity.2021.yml
+      - "buildkite-agent pipeline upload .buildkite/unity.2021.yml"
 
   #
   # Conditionally trigger full pipeline
   #
   - label: "Conditionally trigger full pipeline"
     agents:
-      queue: macos
+      queue: "macos"
     timeout_in_minutes: 2
-    command: sh -c .buildkite/pipeline_trigger_full.sh
+    command: "sh -c .buildkite/pipeline_trigger_full.sh"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,27 +1,27 @@
 agents:
-  queue: macos
+  queue: "macos"
 
 steps:
-  - label: 'Append Unity 2020 Pipeline'
+  - label: "Append Unity 2020 Pipeline"
     depends_on: "build-unitypackage"
     timeout_in_minutes: 2
     commands:
-        - buildkite-agent pipeline upload .buildkite/unity.2020.yml
+        - "buildkite-agent pipeline upload .buildkite/unity.2020.yml"
 
-  - label: 'Append Full Unity 2021 Pipeline'
+  - label: "Append Full Unity 2021 Pipeline"
     depends_on: "build-unitypackage"
     timeout_in_minutes: 2
     commands:
-        - buildkite-agent pipeline upload .buildkite/unity.2021.full.yml
+        - "buildkite-agent pipeline upload .buildkite/unity.2021.full.yml"
 
-  - label: 'Append Unity 2022 Pipeline'
+  - label: "Append Unity 2022 Pipeline"
     depends_on: "build-unitypackage"
     timeout_in_minutes: 2
     commands:
-        - buildkite-agent pipeline upload .buildkite/unity.2022.yml
+        - "buildkite-agent pipeline upload .buildkite/unity.2022.yml"
 
-  - label: 'Append Unity 6000 Pipeline'
+  - label: "Append Unity 6000 Pipeline"
     depends_on: "build-unitypackage"
     timeout_in_minutes: 2
     commands:
-      - buildkite-agent pipeline upload .buildkite/unity.6000.yml
+      - "buildkite-agent pipeline upload .buildkite/unity.6000.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,6 @@ steps:
   #
   - label: "Conditionally trigger basic pipeline"
     agents:
-      queue: macos
+      queue: "macos"
     timeout_in_minutes: 2
-    command: sh -c .buildkite/pipeline_trigger_basic.sh
+    command: "sh -c .buildkite/pipeline_trigger_basic.sh"

--- a/.buildkite/unity.2020.yml
+++ b/.buildkite/unity.2020.yml
@@ -2,26 +2,26 @@ aliases:
   - &2020 "2020.3.48f1"
 
 agents:
-  queue: macos-15
+  queue: "macos-15"
 
 steps:
   - group: ":hammer: Build Unity 2020 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 2020"
         agents:
-          queue: macos-15
+          queue: "macos-15"
         timeout_in_minutes: 20
         key: "build-android-fixture-2020"
         env:
           UNITY_VERSION: *2020
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/maze_runner/mazerunner_2020.apk
-              - features/fixtures/build_android_apk.log
+              - "features/fixtures/maze_runner/mazerunner_2020.apk"
+              - "features/fixtures/build_android_apk.log"
         command:
               - "bundle install"
               - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_android.feature"
@@ -35,21 +35,21 @@ steps:
       #
       - label: ":ios: Build iOS test fixture for Unity 2020"
         agents:
-          queue: macos-14
+          queue: "macos-14"
         timeout_in_minutes: 10
         key: "build-ios-fixture-2020"
         env:
           XCODE_VERSION: "15.3.0"
           UNITY_VERSION: *2020
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
 
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/maze_runner/mazerunner_2020.ipa
-              - features/fixtures/unity.log
+              - "features/fixtures/maze_runner/mazerunner_2020.ipa"
+              - "features/fixtures/unity.log"
         command:
               - "bundle install"
               - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_ios.feature"
@@ -58,70 +58,70 @@ steps:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2020 MacOS test fixture
+      - label: "Build Unity 2020 MacOS test fixture"
         timeout_in_minutes: 10
         key: "macos-2020-fixture"
         env:
           UNITY_VERSION: *2020
           XCODE_VERSION: "16.3.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
 
           # Python2 needed for WebGL to build
           EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-macos-fixture.sh release
+          - "scripts/ci-build-macos-fixture.sh release"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/MacOS-release-2020.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/MacOS-release-2020.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2020 WebGL test fixture
+      - label: "Build Unity 2020 WebGL test fixture"
         timeout_in_minutes: 20
         key: "webgl-2020-fixture"
         env:
           UNITY_VERSION: *2020
           XCODE_VERSION: "16.3.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
           # Python2 needed for WebGL to build
           EMSDK_PYTHON: "/Library/Frameworks/Python.framework/Versions/2.7/bin/python"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-webgl-fixture.sh release
+          - "scripts/ci-build-webgl-fixture.sh release"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/WebGL-release-2020.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/WebGL-release-2020.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2020 Windows test fixture
+      - label: "Build Unity 2020 Windows test fixture"
         timeout_in_minutes: 30
         key: "windows-2020-fixture"
         agents:
-          queue: windows-general-wsl
+          queue: "windows-general-wsl"
         env:
           UNITY_VERSION: *2020
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - unity.log
-              - features/fixtures/maze_runner/build/Windows-release-2020.zip
+              - "unity.log"
+              - "features/fixtures/maze_runner/build/Windows-release-2020.zip"
         commands:
-          - scripts/ci-build-windows-fixture-wsl.sh release
+          - "scripts/ci-build-windows-fixture-wsl.sh release"
         retry:
           automatic:
             - exit_status: "*"

--- a/.buildkite/unity.2021.full.yml
+++ b/.buildkite/unity.2021.full.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-15
+  queue: "macos-15"
 
 steps:
   - group: ":hammer: Build Unity 2021 full test fixtures"
@@ -12,17 +12,17 @@ steps:
         key: "build-android-dev-fixture-2021"
         env:
           UNITY_VERSION: *2021
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/maze_runner/mazerunner_dev_2021.apk
-              - features/fixtures/build_android_apk.log
+              - "features/fixtures/maze_runner/mazerunner_dev_2021.apk"
+              - "features/fixtures/build_android_apk.log"
         commands:
-          - bundle install
-          - rake test:android:build_dev
+          - "bundle install"
+          - "rake test:android:build_dev"
         retry:
           automatic:
             - exit_status: "*"
@@ -33,17 +33,17 @@ steps:
         key: "build-android-edm4u-fixture-2021"
         env:
           UNITY_VERSION: *2021
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - upm-edm4u-package.zip
+              - "upm-edm4u-package.zip"
             upload:
-              - features/fixtures/EDM_Fixture/edm4u_2021.apk
-              - build-edm4u.log
+              - "features/fixtures/EDM_Fixture/edm4u_2021.apk"
+              - "build-edm4u.log"
         commands:
-          - bundle install
-          - rake test:android:build_edm4u
+          - "bundle install"
+          - "rake test:android:build_edm4u"
         retry:
           automatic:
             - exit_status: "*"
@@ -54,18 +54,18 @@ steps:
         key: "generate-dev-fixture-project-2021"
         env:
           UNITY_VERSION: *2021
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.5.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/unity.log
-              - project_dev_2021.tgz
+              - "features/fixtures/unity.log"
+              - "project_dev_2021.tgz"
         commands:
-          - bundle install
-          - rake test:ios:generate_xcode_dev
-          - tar -zvcf project_dev_2021.tgz features/fixtures/maze_runner/mazerunner_dev_xcode
+          - "bundle install"
+          - "rake test:ios:generate_xcode_dev"
+          - "tar -zvcf project_dev_2021.tgz features/fixtures/maze_runner/mazerunner_dev_xcode"
         retry:
           automatic:
             - exit_status: "*"
@@ -78,149 +78,149 @@ steps:
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.5.0:
             download:
-              - Bugsnag.unitypackage
-              - project_dev_2021.tgz
+              - "Bugsnag.unitypackage"
+              - "project_dev_2021.tgz"
             upload:
-              - features/fixtures/maze_runner/mazerunner_dev_2021.ipa
-              - features/fixtures/unity.log
+              - "features/fixtures/maze_runner/mazerunner_dev_2021.ipa"
+              - "features/fixtures/unity.log"
         commands:
-          - bundle install
-          - tar -zxf project_dev_2021.tgz features/fixtures/maze_runner
-          - rake test:ios:build_xcode_dev
+          - "bundle install"
+          - "tar -zxf project_dev_2021.tgz features/fixtures/maze_runner"
+          - "rake test:ios:build_xcode_dev"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2021 MacOS test fixture
+      - label: "Build Unity 2021 MacOS test fixture"
         timeout_in_minutes: 10
         key: "macos-2021-fixture"
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-macos-fixture.sh release
+          - "scripts/ci-build-macos-fixture.sh release"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/MacOS-release-2021.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/MacOS-release-2021.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2021 MacOS DEV test fixture
+      - label: "Build Unity 2021 MacOS DEV test fixture"
         timeout_in_minutes: 30
         key: "macos-2021-dev-fixture"
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-macos-fixture.sh dev
+          - "scripts/ci-build-macos-fixture.sh dev"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/MacOS-dev-2021.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/MacOS-dev-2021.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2021 WebGL test fixture
+      - label: "Build Unity 2021 WebGL test fixture"
         timeout_in_minutes: 20
         key: "webgl-2021-fixture"
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-webgl-fixture.sh release
+          - "scripts/ci-build-webgl-fixture.sh release"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/WebGL-release-2021.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/WebGL-release-2021.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2021 DEV WebGL test fixture
+      - label: "Build Unity 2021 DEV WebGL test fixture"
         timeout_in_minutes: 20
         key: "webgl-2021-dev-fixture"
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-webgl-fixture.sh dev
+          - "scripts/ci-build-webgl-fixture.sh dev"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/WebGL-dev-2021.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/WebGL-dev-2021.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2021 Windows test fixture
+      - label: "Build Unity 2021 Windows test fixture"
         timeout_in_minutes: 30
         key: "windows-2021-fixture"
         agents:
           queue: windows-general-wsl
         env:
           UNITY_VERSION: *2021
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         commands:
-          - scripts/ci-build-windows-fixture-wsl.sh release
+          - "scripts/ci-build-windows-fixture-wsl.sh release"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - unity.log
-              - unity_import.log
-              - features/fixtures/maze_runner/build/Windows-release-2021.zip
+              - "unity.log"
+              - "unity_import.log"
+              - "features/fixtures/maze_runner/build/Windows-release-2021.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2021 Windows DEV test fixture
+      - label: "Build Unity 2021 Windows DEV test fixture"
         timeout_in_minutes: 30
         key: "windows-2021-dev-fixture"
         agents:
           queue: windows-general-wsl
         env:
           UNITY_VERSION: *2021
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         commands:
-          - scripts/ci-build-windows-fixture-wsl.sh dev
+          - "scripts/ci-build-windows-fixture-wsl.sh dev"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - unity.log
-              - unity_import.log
-              - features/fixtures/maze_runner/build/Windows-dev-2021.zip
+              - "unity.log"
+              - "unity_import.log"
+              - "features/fixtures/maze_runner/build/Windows-dev-2021.zip"
         retry:
           automatic:
             - exit_status: "*"
@@ -232,7 +232,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: "build-android-dev-fixture-2021"
         agents:
-          queue: opensource
+          queue: "opensource"
         env:
           UNITY_VERSION: *2021
         plugins:
@@ -240,11 +240,12 @@ steps:
             download:
               - "features/fixtures/maze_runner/mazerunner_dev_2021.apk"
             upload:
-              - "maze_output/**/*"
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
               - "maze_output/metrics.csv"
           docker-compose#v4.7.0:
-            pull: maze-runner-bitbar
-            run: maze-runner-bitbar
+            pull: "maze-runner-bitbar"
+            run: "maze-runner-bitbar"
             service-ports: true
             command:
               - "features/csharp"
@@ -261,7 +262,7 @@ steps:
             branch: "^master|next$$"
         concurrency: 25
         concurrency_group: "bitbar"
-        concurrency_method: eager
+        concurrency_method: "eager"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed
@@ -271,7 +272,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: "build-android-edm4u-fixture-2021"
         agents:
-          queue: opensource
+          queue: "opensource"
         env:
           UNITY_VERSION: *2021
         plugins:
@@ -279,11 +280,12 @@ steps:
             download:
               - "features/fixtures/EDM_Fixture/edm4u_2021.apk"
             upload:
-              - "maze_output/**/*"
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
               - "maze_output/metrics.csv"
           docker-compose#v4.7.0:
-            pull: maze-runner-bitbar
-            run: maze-runner-bitbar
+            pull: "maze-runner-bitbar"
+            run: "maze-runner-bitbar"
             service-ports: true
             command:
               - "features/edm4u"
@@ -299,7 +301,7 @@ steps:
             branch: "^master|next$$"
         concurrency: 25
         concurrency_group: "bitbar"
-        concurrency_method: eager
+        concurrency_method: "eager"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed
@@ -309,17 +311,18 @@ steps:
         timeout_in_minutes: 60
         depends_on: "build-ios-dev-fixture-2021"
         agents:
-          queue: opensource
+          queue: "opensource"
         plugins:
           artifacts#v1.5.0:
             download:
               - "features/fixtures/maze_runner/mazerunner_dev_2021.ipa"
             upload:
-              - "maze_output/**/*"
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
               - "maze_output/metrics.csv"
           docker-compose#v4.7.0:
-            pull: maze-runner-bitbar
-            run: maze-runner-bitbar
+            pull: "maze-runner-bitbar"
+            run: "maze-runner-bitbar"
             service-ports: true
             command:
               - "features/csharp"
@@ -337,126 +340,132 @@ steps:
             branch: "^master|next$$"
         concurrency: 25
         concurrency_group: "bitbar"
-        concurrency_method: eager
+        concurrency_method: "eager"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed
               limit: 2
 
-      - label: Run MacOS e2e tests for Unity 2021
+      - label: "Run MacOS e2e tests for Unity 2021"
         agents:
-          queue: macos-15-isolated
+          queue: "macos-15-isolated"
         timeout_in_minutes: 30
-        depends_on: 'macos-2021-fixture'
+        depends_on: "macos-2021-fixture"
         env:
           UNITY_VERSION: *2021
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/MacOS-release-2021.zip
+              - "features/fixtures/maze_runner/build/MacOS-release-2021.zip"
             upload:
-              - maze_output/**/*
-              - Mazerunner.log
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
+              - "Mazerunner.log"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
             branch: "^master|next$$"
         commands:
-          - scripts/ci-run-macos-tests.sh release
+          - "scripts/ci-run-macos-tests.sh release"
 
-      - label: Run MacOS e2e DEV tests for Unity 2021
+      - label: "Run MacOS e2e DEV tests for Unity 2021"
         agents:
-          queue: macos-15-isolated
+          queue: "macos-15-isolated"
         timeout_in_minutes: 60
-        depends_on: 'macos-2021-dev-fixture'
+        depends_on: "macos-2021-dev-fixture"
         env:
           UNITY_VERSION: *2021
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/MacOS-dev-2021.zip
+              - "features/fixtures/maze_runner/build/MacOS-dev-2021.zip"
             upload:
-              - maze_output/**/*
-              - Mazerunner.log
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
+              - "Mazerunner.log"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
             branch: "^master|next$$"
         commands:
-          - scripts/ci-run-macos-tests.sh dev
+          - "scripts/ci-run-macos-tests.sh dev"
 
-      - label: Run WebGL e2e tests for Unity 2021
+      - label: "Run WebGL e2e tests for Unity 2021"
         agents:
-          queue: macos-15-isolated
+          queue: "macos-15-isolated"
         timeout_in_minutes: 20
-        depends_on: 'webgl-2021-fixture'
+        depends_on: "webgl-2021-fixture"
         env:
           UNITY_VERSION: *2021
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/WebGL-release-2021.zip
+              - "features/fixtures/maze_runner/build/WebGL-release-2021.zip"
             upload:
-              - maze_output/**/*
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
             branch: "^master|next$$"
         # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
         commands:
-          - scripts/ci-run-webgl-tests.sh release
+          - "scripts/ci-run-webgl-tests.sh release"
 
-      - label: Run WebGL e2e DEV tests for Unity 2021
+      - label: "Run WebGL e2e DEV tests for Unity 2021"
         agents:
-          queue: macos-15-isolated
+          queue: "macos-15-isolated"
         timeout_in_minutes: 20
-        depends_on: 'webgl-2021-dev-fixture'
+        depends_on: "webgl-2021-dev-fixture"
         env:
           UNITY_VERSION: *2021
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/WebGL-dev-2021.zip
+              - "features/fixtures/maze_runner/build/WebGL-dev-2021.zip"
             upload:
-              - maze_output/**/*
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
             branch: "^master|next$$"
         # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
         commands:
-          - scripts/ci-run-webgl-tests.sh dev
+          - "scripts/ci-run-webgl-tests.sh dev"
 
-      - label: Run Windows e2e tests for Unity 2021
+      - label: "Run Windows e2e tests for Unity 2021"
         timeout_in_minutes: 30
         depends_on: "windows-2021-fixture"
         agents:
-          queue: windows-general-isolated
+          queue: "windows-general-isolated"
         env:
           UNITY_VERSION: *2021
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/Windows-release-2021.zip
+              - "features/fixtures/maze_runner/build/Windows-release-2021.zip"
             upload:
-              - maze_output/**/*
-              - maze_output/metrics.csv
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
+              - "maze_output/metrics.csv"
         commands:
-          - scripts/ci-run-windows-tests-wsl.sh release
+          - "scripts/ci-run-windows-tests-wsl.sh release"
 
-      - label: Run Windows e2e DEV tests for Unity 2021
+      - label: "Run Windows e2e DEV tests for Unity 2021"
         timeout_in_minutes: 30
         depends_on: "windows-2021-dev-fixture"
         agents:
-          queue: windows-general-isolated
+          queue: "windows-general-isolated"
         env:
           UNITY_VERSION: *2021
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/Windows-dev-2021.zip
+              - "features/fixtures/maze_runner/build/Windows-dev-2021.zip"
             upload:
-              - maze_output/**/*
-              - maze_output/metrics.csv
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
+              - "maze_output/metrics.csv"
         commands:
-          - scripts/ci-run-windows-tests-wsl.sh dev
+          - "scripts/ci-run-windows-tests-wsl.sh dev"

--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -2,7 +2,7 @@ aliases:
   - &2021 "2021.3.45f1"
 
 agents:
-  queue: macos-15
+  queue: "macos-15"
 
 steps:
   - group: ":hammer: Build Unity 2021 test fixtures"
@@ -12,14 +12,14 @@ steps:
         key: "build-android-fixture-2021"
         env:
           UNITY_VERSION: *2021
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/maze_runner/mazerunner_2021.apk
-              - features/fixtures/build_android_apk.log
+              - "features/fixtures/maze_runner/mazerunner_2021.apk"
+              - "features/fixtures/build_android_apk.log"
         command:
               - "bundle install"
               - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_android.feature"
@@ -34,15 +34,15 @@ steps:
         env:
           UNITY_VERSION: *2021
           XCODE_VERSION: "16.2.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.5.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/maze_runner/mazerunner_2021.ipa
-              - features/fixtures/maze_runner/build.xcresult
-              - features/fixtures/unity.log
+              - "features/fixtures/maze_runner/mazerunner_2021.ipa"
+              - "features/fixtures/maze_runner/build.xcresult"
+              - "features/fixtures/unity.log"
         command:
               - "bundle install"
               - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_ios.feature"
@@ -57,7 +57,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: "build-android-fixture-2021"
         agents:
-          queue: opensource
+          queue: "opensource"
         env:
           UNITY_VERSION: *2021
         plugins:
@@ -65,11 +65,12 @@ steps:
             download:
               - "features/fixtures/maze_runner/mazerunner_2021.apk"
             upload:
-              - "maze_output/**/*"
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
               - "maze_output/metrics.csv"
           docker-compose#v4.7.0:
-            pull: maze-runner-bitbar
-            run: maze-runner-bitbar
+            pull: "maze-runner-bitbar"
+            run: "maze-runner-bitbar"
             service-ports: true
             command:
               - "features/csharp"
@@ -87,7 +88,7 @@ steps:
             branch: "^master|next$$"
         concurrency: 25
         concurrency_group: "bitbar"
-        concurrency_method: eager
+        concurrency_method: "eager"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed
@@ -97,18 +98,19 @@ steps:
         timeout_in_minutes: 60
         depends_on: "build-ios-fixture-2021"
         agents:
-          queue: opensource
+          queue: "opensource"
         plugins:
           artifacts#v1.5.0:
             download:
               - "features/fixtures/maze_runner/mazerunner_2021.ipa"
             upload:
-              - "maze_output/**/*"
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
               - "maze_output/metrics.csv"
 
           docker-compose#v4.7.0:
-            pull: maze-runner-bitbar
-            run: maze-runner-bitbar
+            pull: "maze-runner-bitbar"
+            run: "maze-runner-bitbar"
             service-ports: true
             command:
               - "features/csharp"
@@ -126,7 +128,7 @@ steps:
             branch: "^master|next$$"
         concurrency: 25
         concurrency_group: "bitbar"
-        concurrency_method: eager
+        concurrency_method: "eager"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -2,26 +2,26 @@ aliases:
   - &2022 "2022.3.62f1"
 
 agents:
-  queue: macos-15
+  queue: "macos-15"
 
 steps:
   - group: ":hammer: Build Unity 2022 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 2022"
         agents:
-          queue: macos-15
+          queue: "macos-15"
         timeout_in_minutes: 30
         key: "build-android-fixture-2022"
         env:
           UNITY_VERSION: *2022
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/maze_runner/mazerunner_2022.apk
-              - features/fixtures/build_android_apk.log
+              - "features/fixtures/maze_runner/mazerunner_2022.apk"
+              - "features/fixtures/build_android_apk.log"
         command:
               - "bundle install"
               - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_android.feature"
@@ -36,14 +36,14 @@ steps:
         env:
           UNITY_VERSION: *2022
           XCODE_VERSION: "16.3.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/maze_runner/mazerunner_2022.ipa
-              - features/fixtures/unity.log
+              - "features/fixtures/maze_runner/mazerunner_2022.ipa"
+              - "features/fixtures/unity.log"
         command:
               - "bundle install"
               - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_ios.feature"
@@ -52,66 +52,66 @@ steps:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2022 MacOS fixture
+      - label: "Build Unity 2022 MacOS fixture"
         timeout_in_minutes: 10
         key: "macos-2022-fixture"
         env:
           UNITY_VERSION: *2022
           XCODE_VERSION: "16.3.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-macos-fixture.sh release
+          - "scripts/ci-build-macos-fixture.sh release"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/MacOS-release-2022.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/MacOS-release-2022.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2022 WebGL test fixture
+      - label: "Build Unity 2022 WebGL test fixture"
         timeout_in_minutes: 10
         key: "webgl-2022-fixture"
         env:
           UNITY_VERSION: *2022
           XCODE_VERSION: "16.3.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-webgl-fixture.sh release
+          - "scripts/ci-build-webgl-fixture.sh release"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/WebGL-release-2022.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/WebGL-release-2022.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 2022 Windows test fixture
+      - label: "Build Unity 2022 Windows test fixture"
         timeout_in_minutes: 30
         key: "windows-2022-fixture"
         agents:
-          queue: windows-general-wsl
+          queue: "windows-general-wsl"
         env:
           UNITY_VERSION: *2022
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         commands:
-          - scripts/ci-build-windows-fixture-wsl.sh release
+          - "scripts/ci-build-windows-fixture-wsl.sh release"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - unity.log
-              - unity_import.log
-              - features/fixtures/maze_runner/build/Windows-release-2022.zip
+              - "unity.log"
+              - "unity_import.log"
+              - "features/fixtures/maze_runner/build/Windows-release-2022.zip"
         retry:
           automatic:
             - exit_status: "*"
@@ -123,7 +123,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: "build-android-fixture-2022"
         agents:
-          queue: opensource
+          queue: "opensource"
         env:
           UNITY_VERSION: *2022
         plugins:
@@ -131,11 +131,12 @@ steps:
             download:
               - "features/fixtures/maze_runner/mazerunner_2022.apk"
             upload:
-              - "maze_output/**/*"
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
               - "maze_output/metrics.csv"
           docker-compose#v4.7.0:
-            pull: maze-runner-bitbar
-            run: maze-runner-bitbar
+            pull: "maze-runner-bitbar"
+            run: "maze-runner-bitbar"
             service-ports: true
             command:
               - "features/csharp"
@@ -153,7 +154,7 @@ steps:
             branch: "^master|next$$"
         concurrency: 25
         concurrency_group: "bitbar"
-        concurrency_method: eager
+        concurrency_method: "eager"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed
@@ -163,17 +164,18 @@ steps:
         timeout_in_minutes: 60
         depends_on: "build-ios-fixture-2022"
         agents:
-          queue: opensource
+          queue: "opensource"
         plugins:
           artifacts#v1.9.0:
             download:
               - "features/fixtures/maze_runner/mazerunner_2022.ipa"
             upload:
-              - "maze_output/**/*"
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
               - "maze_output/metrics.csv"
           docker-compose#v4.7.0:
-            pull: maze-runner-bitbar
-            run: maze-runner-bitbar
+            pull: "maze-runner-bitbar"
+            run: "maze-runner-bitbar"
             service-ports: true
             command:
               - "features/csharp"
@@ -191,67 +193,70 @@ steps:
             branch: "^master|next$$"
         concurrency: 25
         concurrency_group: "bitbar"
-        concurrency_method: eager
+        concurrency_method: "eager"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed
               limit: 2
 
-      - label: Run MacOS e2e tests for Unity 2022
+      - label: "Run MacOS e2e tests for Unity 2022"
         timeout_in_minutes: 60
-        depends_on: 'macos-2022-fixture'
+        depends_on: "macos-2022-fixture"
         agents:
-          queue: macos-15-isolated
+          queue: "macos-15-isolated"
         env:
           UNITY_VERSION: *2022
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/MacOS-release-2022.zip
+              - "features/fixtures/maze_runner/build/MacOS-release-2022.zip"
             upload:
-              - maze_output/**/*
-              - '*-mazerunner.log'
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
+              - "'*-mazerunner.log'"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
             branch: "^master|next$$"
         commands:
-          - scripts/ci-run-macos-tests.sh release
+          - "scripts/ci-run-macos-tests.sh release"
 
-      - label: Run WebGL e2e tests for Unity 2022
+      - label: "Run WebGL e2e tests for Unity 2022"
         timeout_in_minutes: 30
-        depends_on: 'webgl-2022-fixture'
+        depends_on: "webgl-2022-fixture"
         agents:
-          queue: macos-15-isolated
+          queue: "macos-15-isolated"
         env:
           UNITY_VERSION: *2022
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/WebGL-release-2022.zip
+              - "features/fixtures/maze_runner/build/WebGL-release-2022.zip"
             upload:
-              - maze_output/**/*
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
             branch: "^master|next$$"
         # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
         commands:
-          - scripts/ci-run-webgl-tests.sh release
+          - "scripts/ci-run-webgl-tests.sh release"
 
-      - label: Run Windows e2e tests for Unity 2022
+      - label: "Run Windows e2e tests for Unity 2022"
         timeout_in_minutes: 30
         depends_on: "windows-2022-fixture"
         agents:
-          queue: windows-general-isolated
+          queue: "windows-general-isolated"
         env:
           UNITY_VERSION: *2022
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/Windows-release-2022.zip
+              - "features/fixtures/maze_runner/build/Windows-release-2022.zip"
             upload:
-              - maze_output/**/*
-              - maze_output/metrics.csv
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
+              - "maze_output/metrics.csv"
         commands:
-          - scripts/ci-run-windows-tests-wsl.sh release
+          - "scripts/ci-run-windows-tests-wsl.sh release"

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -2,26 +2,26 @@ aliases:
   - &6000 "6000.2.2f1"
 
 agents:
-  queue: macos-15
+  queue: "macos-15"
 
 steps:
   - group: ":hammer: Build Unity 6000 test fixtures"
     steps:
       - label: ":android: Build Android test fixture for Unity 6000"
         agents:
-          queue: macos-15
+          queue: "macos-15"
         timeout_in_minutes: 20
         key: "build-android-fixture-6000"
         env:
           UNITY_VERSION: *6000
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/maze_runner/mazerunner_6000.apk
-              - features/fixtures/build_android_apk.log
+              - "features/fixtures/maze_runner/mazerunner_6000.apk"
+              - "features/fixtures/build_android_apk.log"
         command:
               - "bundle install"
               - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_android.feature"
@@ -36,14 +36,14 @@ steps:
         env:
           UNITY_VERSION: *6000
           XCODE_VERSION: "16.3.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - features/fixtures/maze_runner/mazerunner_6000.ipa
-              - features/fixtures/unity.log
+              - "features/fixtures/maze_runner/mazerunner_6000.ipa"
+              - "features/fixtures/unity.log"
         command:
               - "bundle install"
               - "bundle exec maze-runner --os=macos --port=$((MAZE_RUNNER_PORT)) features/build/build_ios.feature"
@@ -52,69 +52,69 @@ steps:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 6000 MacOS test fixture
+      - label: "Build Unity 6000 MacOS test fixture"
         agents:
-          queue: macos-15
+          queue: "macos-15"
         timeout_in_minutes: 10
         key: "macos-6000-fixture"
         env:
           UNITY_VERSION: *6000
           XCODE_VERSION: "16.3.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-macos-fixture.sh release
+          - "scripts/ci-build-macos-fixture.sh release"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/MacOS-release-6000.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/MacOS-release-6000.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 6000 WebGL test fixture
+      - label: "Build Unity 6000 WebGL test fixture"
         timeout_in_minutes: 10
         key: "webgl-6000-fixture"
         env:
           UNITY_VERSION: *6000
           XCODE_VERSION: "16.3.0"
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
         commands:
-          - scripts/ci-build-webgl-fixture.sh release
+          - "scripts/ci-build-webgl-fixture.sh release"
         artifact_paths:
-          - unity.log
-          - features/fixtures/maze_runner/build/WebGL-release-6000.zip
+          - "unity.log"
+          - "features/fixtures/maze_runner/build/WebGL-release-6000.zip"
         retry:
           automatic:
             - exit_status: "*"
               limit: 1
 
-      - label: Build Unity 6000 Windows test fixture
-        skip: Pending PLAT-12072
+      - label: "Build Unity 6000 Windows test fixture"
+        skip: "Pending PLAT-12072"
         timeout_in_minutes: 30
         key: "windows-6000-fixture"
         agents:
-          queue: windows-general-wsl
+          queue: "windows-general-wsl"
         env:
           UNITY_VERSION: *6000
-          JAVA_VERSION: 17
+          JAVA_VERSION: "17"
         commands:
-          - scripts/ci-build-windows-fixture-wsl.sh release
+          - "scripts/ci-build-windows-fixture-wsl.sh release"
         plugins:
           artifacts#v1.9.0:
             download:
-              - Bugsnag.unitypackage
+              - "Bugsnag.unitypackage"
             upload:
-              - unity.log
-              - unity_import.log
-              - features/fixtures/maze_runner/build/Windows-release-6000.zip
+              - "unity.log"
+              - "unity_import.log"
+              - "features/fixtures/maze_runner/build/Windows-release-6000.zip"
         retry:
           automatic:
             - exit_status: "*"
@@ -126,7 +126,7 @@ steps:
         timeout_in_minutes: 60
         depends_on: "build-android-fixture-6000"
         agents:
-          queue: opensource
+          queue: "opensource"
         env:
           UNITY_VERSION: *6000
         plugins:
@@ -134,11 +134,12 @@ steps:
             download:
               - "features/fixtures/maze_runner/mazerunner_6000.apk"
             upload:
-              - "maze_output/**/*"
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
               - "maze_output/metrics.csv"
           docker-compose#v4.7.0:
-            pull: maze-runner-bitbar
-            run: maze-runner-bitbar
+            pull: "maze-runner-bitbar"
+            run: "maze-runner-bitbar"
             service-ports: true
             command:
               - "features/csharp"
@@ -156,7 +157,7 @@ steps:
             branch: "^master|next$$"
         concurrency: 25
         concurrency_group: "bitbar"
-        concurrency_method: eager
+        concurrency_method: "eager"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed
@@ -166,17 +167,18 @@ steps:
         timeout_in_minutes: 60
         depends_on: "build-ios-fixture-6000"
         agents:
-          queue: opensource
+          queue: "opensource"
         plugins:
           artifacts#v1.9.0:
             download:
               - "features/fixtures/maze_runner/mazerunner_6000.ipa"
             upload:
-              - "maze_output/**/*"
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
               - "maze_output/metrics.csv"
           docker-compose#v4.7.0:
-            pull: maze-runner-bitbar
-            run: maze-runner-bitbar
+            pull: "maze-runner-bitbar"
+            run: "maze-runner-bitbar"
             service-ports: true
             command:
               - "features/csharp"
@@ -194,68 +196,71 @@ steps:
             branch: "^master|next$$"
         concurrency: 25
         concurrency_group: "bitbar"
-        concurrency_method: eager
+        concurrency_method: "eager"
         retry:
           automatic:
             - exit_status: 103  # Appium session failed
               limit: 2
 
-      - label: Run MacOS e2e tests for Unity 6000
+      - label: "Run MacOS e2e tests for Unity 6000"
         timeout_in_minutes: 60
-        depends_on: 'macos-6000-fixture'
+        depends_on: "macos-6000-fixture"
         agents:
-          queue: macos-15-isolated
+          queue: "macos-15-isolated"
         env:
           UNITY_VERSION: *6000
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/MacOS-release-6000.zip
+              - "features/fixtures/maze_runner/build/MacOS-release-6000.zip"
             upload:
-              - maze_output/**/*
-              - '*-mazerunner.log'
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
+              - "'*-mazerunner.log'"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
             branch: "^master|next$$"
         commands:
-          - scripts/ci-run-macos-tests.sh release
+          - "scripts/ci-run-macos-tests.sh release"
 
-      - label: Run WebGL e2e tests for Unity 6000
+      - label: "Run WebGL e2e tests for Unity 6000"
         timeout_in_minutes: 30
-        depends_on: 'webgl-6000-fixture'
+        depends_on: "webgl-6000-fixture"
         agents:
-          queue: macos-15-isolated
+          queue: "macos-15-isolated"
         env:
           UNITY_VERSION: *6000
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/WebGL-release-6000.zip
+              - "features/fixtures/maze_runner/build/WebGL-release-6000.zip"
             upload:
-              - maze_output/**/*
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"
             format: "junit"
             branch: "^master|next$$"
         # TODO: WebGL persistence tests are currently skipped pending PLAT-8151
         commands:
-          - scripts/ci-run-webgl-tests.sh release
+          - "scripts/ci-run-webgl-tests.sh release"
 
-      - label: Run Windows e2e tests for Unity 6000
-        skip: Pending PLAT-12072
+      - label: "Run Windows e2e tests for Unity 6000"
+        skip: "Pending PLAT-12072"
         timeout_in_minutes: 30
         depends_on: "windows-6000-fixture"
         agents:
-          queue: windows-general-isolated
+          queue: "windows-general-isolated"
         env:
           UNITY_VERSION: *6000
         plugins:
           artifacts#v1.9.0:
             download:
-              - features/fixtures/maze_runner/build/Windows-release-6000.zip
+              - "features/fixtures/maze_runner/build/Windows-release-6000.zip"
             upload:
-              - maze_output/**/*
-              - maze_output/metrics.csv
+              - "maze_output/failed/*"
+              - "maze_output/maze_output.zip"
+              - "maze_output/metrics.csv"
         commands:
-          - scripts/ci-run-windows-tests-wsl.sh release
+          - "scripts/ci-run-windows-tests-wsl.sh release"


### PR DESCRIPTION
## Goal

The functional change here is to change this artifact upload pattern:
```
              - "maze_output/*/*"
```
into...
```
              - "maze_output/failed/*"
              - "maze_output/maze_output.zip"
```

This makes it easier for us to find the log files for failed scenarios (which we tend to care about most), whilst still allowing us to access the logs for all scenarios if we wish.

## Testing

Covered by a full CI run.