### PR TITLE
Handle mixed stack traces on Android

### DIFF
--- a/Bugsnag/Assets/Tests/StackFrameParsingTests.cs
+++ b/Bugsnag/Assets/Tests/StackFrameParsingTests.cs
@@ -145,5 +145,27 @@ namespace BugsnagUnityTests
                 Assert.AreEqual(expectedLine, bugsnagFrame.LineNumber, "Line number did not match for method {0}", expectedMethod);
             }
         }
+
+        [Test]
+        public void MixedAndroidStackTrace()
+        {
+            var stackTraceMessage = "java.lang.ClassNotFoundException: java.lang.String\n" +
+                "  at java.lang.Class.forName(Class.java:453)\n" +
+                "  at UnityEngine.AndroidJavaClass._AndroidJavaClass (System.String className) (at <00000000000000000000000000000000>:0)\n";
+
+            var lines = new PayloadStackTrace(stackTraceMessage, StackTraceFormat.AndroidJava).StackTraceLines;
+
+            Assert.AreEqual(2, lines.Length);
+
+            var javaFrame = lines[0];
+            Assert.AreEqual("java.lang.Class.forName()", javaFrame.Method);
+            Assert.AreEqual("Class.java", javaFrame.File);
+            Assert.AreEqual(453, javaFrame.LineNumber);
+
+            var standardFrame = lines[1];
+            Assert.AreEqual("UnityEngine.AndroidJavaClass._AndroidJavaClass(System.String className)", standardFrame.Method);
+            Assert.AreEqual("<00000000000000000000000000000000>", standardFrame.File);
+            Assert.AreEqual(0, standardFrame.LineNumber);
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Correctly handle mixed C#/Java stack traces on Android [#962](https://github.com/bugsnag/bugsnag-unity/pull/962)
+
 ## 8.8.2 (2025-12-08)
 
 ### Bug Fixes


### PR DESCRIPTION
## Goal
Correctly handle mixed stack traces on Android that include both Java/Kotlin frames, and C# frames in the same trace. These typically switch from the Java/Kotlin frames to C# at `UnityEngine.AndroidJNISafe.CheckException`.

## Design
Some stack traces the originate in Android code also include some C# frames when the exception is thrown through `UnityEngine.AndroidJNISafe.CheckException`.

These C# frames are matched incorrectly as Android frames due to the Android regex structure, resulting in stack trace corruption like:

```
          "file": "System.IntPtr methodID, System.Object[] args",
          "lineNumber": 0,
          "columnNumber": 0,
          "method": "at UnityEngine.AndroidJavaObject._CallStatic()",
          "inProject": true,
```

This PR introduces a "strict" version of the C# regex that does *not* match Android frames, and only matches complete C# frames (while the Android regex will match either). The Android stack frame parser now attempts this strict C# parse on every frame before falling back to its Android match, instead of always assuming that every Android frame is actually a Java/Android formatted stack frame.

## Testing
Added a new unit test with a mixed trace.