### PR TITLE
Compute app.duration from Bugsnag stopwatches

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
@@ -394,7 +394,10 @@ namespace BugsnagUnity
                 durationInForeground = BugsnagWebGLBridge.GetDurationInForeground();
             }
 
-            var app = new AppWithState(Configuration)
+            // Calculate total duration since Bugsnag initialization from stopwatches
+            var totalDuration = _foregroundStopwatch.Elapsed + _backgroundStopwatch.Elapsed;
+
+            var app = new AppWithState(Configuration, totalDuration)
             {
                 InForeground = InForeground,
                 DurationInForeground = durationInForeground,

--- a/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
@@ -42,6 +42,9 @@ namespace BugsnagUnity
 
         internal INativeClient NativeClient { get; }
 
+        // Tracks total time since Bugsnag initialization. Must never be reset.
+        private Stopwatch _appDurationStopwatch;
+
         private Stopwatch _foregroundStopwatch;
 
         private Stopwatch _backgroundStopwatch;
@@ -207,6 +210,7 @@ namespace BugsnagUnity
 
         private void InitStopwatches()
         {
+            _appDurationStopwatch = Stopwatch.StartNew();
             _foregroundStopwatch = new Stopwatch();
             _backgroundStopwatch = new Stopwatch();
             // Required in case the focus event is not recieved (if Bugsnag is started after it is sent)
@@ -394,8 +398,9 @@ namespace BugsnagUnity
                 durationInForeground = BugsnagWebGLBridge.GetDurationInForeground();
             }
 
-            // Calculate total duration since Bugsnag initialization from stopwatches
-            var totalDuration = _foregroundStopwatch.Elapsed + _backgroundStopwatch.Elapsed;
+            // Total duration since Bugsnag initialization (do not derive from foreground/background stopwatches
+            // because _backgroundStopwatch is reset for session-threshold logic).
+            var totalDuration = _appDurationStopwatch.Elapsed;
 
             var app = new AppWithState(Configuration, totalDuration)
             {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Client.cs
@@ -42,9 +42,6 @@ namespace BugsnagUnity
 
         internal INativeClient NativeClient { get; }
 
-        // Tracks total time since Bugsnag initialization. Must never be reset.
-        private Stopwatch _appDurationStopwatch;
-
         private Stopwatch _foregroundStopwatch;
 
         private Stopwatch _backgroundStopwatch;
@@ -210,7 +207,6 @@ namespace BugsnagUnity
 
         private void InitStopwatches()
         {
-            _appDurationStopwatch = Stopwatch.StartNew();
             _foregroundStopwatch = new Stopwatch();
             _backgroundStopwatch = new Stopwatch();
             // Required in case the focus event is not recieved (if Bugsnag is started after it is sent)
@@ -398,9 +394,8 @@ namespace BugsnagUnity
                 durationInForeground = BugsnagWebGLBridge.GetDurationInForeground();
             }
 
-            // Total duration since Bugsnag initialization (do not derive from foreground/background stopwatches
-            // because _backgroundStopwatch is reset for session-threshold logic).
-            var totalDuration = _appDurationStopwatch.Elapsed;
+            // Total duration since app start
+            var totalDuration = UptimeClock.Elapsed;
 
             var app = new AppWithState(Configuration, totalDuration)
             {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/AppWithState.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/AppWithState.cs
@@ -54,9 +54,10 @@ namespace BugsnagUnity.Payload
 
         internal AppWithState(Dictionary<string, object> cachedData) : base(cachedData) { }
 
-        internal AppWithState(Configuration configuration) : base(configuration)
+        internal AppWithState(Configuration configuration, TimeSpan? duration = null) : base(configuration)
         {
-            Duration = TimeSpan.FromSeconds(UnityEngine.Time.realtimeSinceStartup);
+            // Use provided duration (from stopwatches) if available, otherwise fall back to realtimeSinceStartup
+            Duration = duration ?? TimeSpan.FromSeconds(UnityEngine.Time.realtimeSinceStartup);
         }
 
     }

--- a/Bugsnag/Assets/Bugsnag/Runtime/UptimeClock.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/UptimeClock.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Diagnostics;
+using UnityEngine;
+
+namespace BugsnagUnity
+{
+    internal static class UptimeClock
+    {
+        private static readonly object _lock = new object();
+        private static Stopwatch _stopwatch;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Start()
+        {
+            EnsureStarted();
+        }
+
+        internal static TimeSpan Elapsed => EnsureStarted().Elapsed;
+
+        private static Stopwatch EnsureStarted()
+        {
+            if (_stopwatch != null)
+            {
+                return _stopwatch;
+            }
+
+            lock (_lock)
+            {
+                if (_stopwatch == null)
+                {
+                    _stopwatch = Stopwatch.StartNew();
+                }
+                return _stopwatch;
+            }
+        }
+    }
+}

--- a/Bugsnag/Assets/Bugsnag/Runtime/UptimeClock.cs.meta
+++ b/Bugsnag/Assets/Bugsnag/Runtime/UptimeClock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f7b6413be834d1ba6d9f5229a8b85c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Fix WebGL foreground/background state tracking with proper indentation
 [#968](https://github.com/bugsnag/bugsnag-unity/pull/968)
 
+- Fix launch detection to use a monotonic app-uptime clock on fallback platforms
+[#969](https://github.com/bugsnag/bugsnag-unity/pull/969)
+
 ## 8.9.0 (2026-02-05)
 
 ### Enhancements

--- a/features/csharp/csharp_config.feature
+++ b/features/csharp/csharp_config.feature
@@ -58,11 +58,11 @@ Feature: csharp events
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "DelayedBugsnagStart 1"
     And the event "app.isLaunching" is true
-    And the event "app.duration" is less than 4000
+    And the event "app.duration" is less than 6000
     And I discard the oldest error
     And the exception "message" equals "DelayedBugsnagStart 2"
     And the event "app.isLaunching" is false
-    And the event "app.duration" is greater than 4000
+    And the event "app.duration" is greater than 6000
 
   Scenario: Auto notify false
     When I run the game in the "AutoNotifyFalse" state

--- a/features/csharp/csharp_config.feature
+++ b/features/csharp/csharp_config.feature
@@ -51,14 +51,14 @@ Feature: csharp events
     And the exception "message" equals "ShortLaunchTime 2"
     And the event "app.isLaunching" is false
 
-  Scenario: Duration uses stopwatch time not Unity realtime
+  Scenario: Duration uses app uptime clock
     When I run the game in the "DelayedBugsnagStart" state
     And I wait to receive 2 errors
     And I sort the errors by the payload field "events.0.exceptions.0.message"
     Then the error is valid for the error reporting API sent by the Unity notifier
     And the exception "message" equals "DelayedBugsnagStart 1"
     And the event "app.isLaunching" is true
-    And the event "app.duration" is less than 2000
+    And the event "app.duration" is less than 4000
     And I discard the oldest error
     And the exception "message" equals "DelayedBugsnagStart 2"
     And the event "app.isLaunching" is false

--- a/features/csharp/csharp_config.feature
+++ b/features/csharp/csharp_config.feature
@@ -51,6 +51,19 @@ Feature: csharp events
     And the exception "message" equals "ShortLaunchTime 2"
     And the event "app.isLaunching" is false
 
+  Scenario: Duration uses stopwatch time not Unity realtime
+    When I run the game in the "DelayedBugsnagStart" state
+    And I wait to receive 2 errors
+    And I sort the errors by the payload field "events.0.exceptions.0.message"
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "DelayedBugsnagStart 1"
+    And the event "app.isLaunching" is true
+    And the event "app.duration" is less than 2000
+    And I discard the oldest error
+    And the exception "message" equals "DelayedBugsnagStart 2"
+    And the event "app.isLaunching" is false
+    And the event "app.duration" is greater than 4000
+
   Scenario: Auto notify false
     When I run the game in the "AutoNotifyFalse" state
     And I should receive no errors

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -147,6 +147,7 @@ GameObject:
   - component: {fileID: 355371106}
   - component: {fileID: 355371107}
   - component: {fileID: 355371108}
+  - component: {fileID: 355371109}
   m_Layer: 0
   m_Name: Config
   m_TagString: Untagged
@@ -403,6 +404,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 98657fae1a3494aeeb952c009b146b6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2
+    () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &355371109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 355371092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4771497587e244e838eb27933cf1e297, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DelayedBugsnagStart.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DelayedBugsnagStart.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnity;
+using UnityEngine;
+
+public class DelayedBugsnagStart : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        Configuration.LaunchDurationMillis = 4000;
+    }
+
+    public override void Run()
+    {
+        Invoke("DoNotify1", 1);
+        Invoke("DoNotify2", 5);
+    }
+
+    private void DoNotify1()
+    {
+        Bugsnag.Notify(new System.Exception("DelayedBugsnagStart 1"));
+    }
+
+    private void DoNotify2()
+    {
+        Bugsnag.Notify(new System.Exception("DelayedBugsnagStart 2"));
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DelayedBugsnagStart.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DelayedBugsnagStart.cs
@@ -6,13 +6,13 @@ public class DelayedBugsnagStart : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.LaunchDurationMillis = 4000;
+        Configuration.LaunchDurationMillis = 6000;
     }
 
     public override void Run()
     {
         Invoke("DoNotify1", 1);
-        Invoke("DoNotify2", 5);
+        Invoke("DoNotify2", 8);
     }
 
     private void DoNotify1()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DelayedBugsnagStart.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DelayedBugsnagStart.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using BugsnagUnity;
 using UnityEngine;
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DelayedBugsnagStart.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/DelayedBugsnagStart.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4771497587e244e838eb27933cf1e297
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -5,7 +5,16 @@ def execute_command(action, scenario_name = '')
     action: action,
     scenarioName: scenario_name
   }
-  Maze::Server.commands.add command
+
+  # Unity fixtures poll `/idem-command` (idempotent command queue).
+  # Older fixtures may poll `/command`, so enqueue to both when available.
+  if Maze::Server.respond_to?(:idem_commands)
+    Maze::Server.idem_commands.add command
+  end
+
+  if Maze::Server.respond_to?(:commands)
+    Maze::Server.commands.add command
+  end
 end
 
 Then('the sourcemaps Content-Type header is valid multipart form-data') do
@@ -360,6 +369,13 @@ end
 Then("the exception {string} equals one of:") do |keypath, possible_values|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.exceptions.0.#{keypath}")
   Maze.check.include(possible_values.raw.flatten, value)
+end
+
+Then('the event {string} is less than {int}') do |field, expected_value|
+  value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field}")
+
+  Maze.check.not_nil(value, "Expected '#{field}' to be present")
+  Maze.check.true(value.to_f < expected_value, "Expected '#{field}' to be < #{expected_value} but was #{value}")
 end
 
 def start_app

--- a/features/steps/unity_steps.rb
+++ b/features/steps/unity_steps.rb
@@ -6,14 +6,22 @@ def execute_command(action, scenario_name = '')
     scenarioName: scenario_name
   }
 
+  enqueued = false
+
   # Unity fixtures poll `/idem-command` (idempotent command queue).
   # Older fixtures may poll `/command`, so enqueue to both when available.
   if Maze::Server.respond_to?(:idem_commands)
     Maze::Server.idem_commands.add command
+    enqueued = true
   end
 
   if Maze::Server.respond_to?(:commands)
     Maze::Server.commands.add command
+    enqueued = true
+  end
+
+  unless enqueued
+    raise 'No Maze::Server command queue available (expected Maze::Server.commands and/or Maze::Server.idem_commands)'
   end
 end
 


### PR DESCRIPTION
###Goal
Fix "app.duration"/"app.isLaunching" so launch state is based on time since app launched, not "Time.realtimeSinceStartup"(Editor play-session clock).

###Design
A dedicated Stopwatch is the smallest/cleanest way to fix this.

###Changeset
1. Implemented a dedicated UptimeClock.
2. Injected  totalDuration = UptimeClock.Elapsed in AppWithState.
3. Maze Runner: add "DelayedBugsnagStart" scenario + assertions for "isLaunching" flip and duration bounds.
4. Fix Unity Maze Runner command delivery: enqueue to [/idem-command] queue (compat with [/command]), add missing [event … is less than …] step, and register scenario in fixture scene.

###Testing
1. Ran Maze Runner on macOS fixture:
Scenario “Duration uses stopwatch time not Unity realtime” passes end-to-end.
2. Also verified broader C# suite run succeeds locally.