### PR TITLE
Implement C#-side sanitization for large ulong values (> long.MaxValue)

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
@@ -48,50 +48,47 @@ namespace BugsnagUnity.Payload
                 return sanitized;
             }
 
-            // Handle non-generic IDictionary with string keys
+            // Handle non-generic IDictionary (convert keys to strings for JSON compatibility)
             if (value is System.Collections.IDictionary nonGenericDict)
             {
                 var sanitized = new Dictionary<string, object>();
                 foreach (System.Collections.DictionaryEntry entry in nonGenericDict)
                 {
-                    if (entry.Key is string keyString)
-                    {
-                        sanitized[keyString] = SanitizeValue(entry.Value);
-                    }
+                    var keyString = entry.Key is string str
+                        ? str
+                        : entry.Key?.ToString() ?? "null";
+                    sanitized[keyString] = SanitizeValue(entry.Value);
                 }
                 return sanitized;
             }
 
             // Handle generic IDictionary<string, T> variants
             var valueType = value.GetType();
-            if (valueType.IsGenericType)
+            foreach (var iface in valueType.GetInterfaces())
             {
-                foreach (var iface in valueType.GetInterfaces())
+                if (iface.IsGenericType &&
+                    iface.GetGenericTypeDefinition() == typeof(IDictionary<,>))
                 {
-                    if (iface.IsGenericType &&
-                        iface.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+                    var genericArgs = iface.GetGenericArguments();
+                    if (genericArgs[0] == typeof(string))
                     {
-                        var genericArgs = iface.GetGenericArguments();
-                        if (genericArgs[0] == typeof(string))
+                        var sanitized = new Dictionary<string, object>();
+                        foreach (var item in (System.Collections.IEnumerable)value)
                         {
-                            var sanitized = new Dictionary<string, object>();
-                            foreach (var item in (System.Collections.IEnumerable)value)
+                            var itemType = item.GetType();
+                            var keyProp = itemType.GetProperty("Key");
+                            var valueProp = itemType.GetProperty("Value");
+                            if (keyProp != null && valueProp != null)
                             {
-                                var itemType = item.GetType();
-                                var keyProp = itemType.GetProperty("Key");
-                                var valueProp = itemType.GetProperty("Value");
-                                if (keyProp != null && valueProp != null)
+                                var key = keyProp.GetValue(item) as string;
+                                if (key != null)
                                 {
-                                    var key = keyProp.GetValue(item) as string;
-                                    if (key != null)
-                                    {
-                                        var dictValue = valueProp.GetValue(item);
-                                        sanitized[key] = SanitizeValue(dictValue);
-                                    }
+                                    var dictValue = valueProp.GetValue(item);
+                                    sanitized[key] = SanitizeValue(dictValue);
                                 }
                             }
-                            return sanitized;
                         }
+                        return sanitized;
                     }
                 }
             }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using BugsnagUnity;
 using UnityEngine;
@@ -33,7 +34,7 @@ namespace BugsnagUnity.Payload
             // Convert large ulongs to strings (> Int64.MaxValue causes JSON errors)
             if (value is ulong ulongValue && ulongValue > long.MaxValue)
             {
-                return ulongValue.ToString();
+                return ulongValue.ToString(CultureInfo.InvariantCulture);
             }
 
             // Recursively sanitize dictionaries
@@ -117,6 +118,17 @@ namespace BugsnagUnity.Payload
                 return sanitized;
             }
 
+            // Preserve JsonArray type for Delivery string truncation
+            if (value is JsonArray jsonArray)
+            {
+                var sanitized = new JsonArray();
+                for (int i = 0; i < jsonArray.Count; i++)
+                {
+                    sanitized.Add(SanitizeValue(jsonArray[i]));
+                }
+                return sanitized;
+            }
+
             // Generic arrays/lists (preserving as object[] for mixed types)
             if (value is System.Collections.IList list)
             {
@@ -134,7 +146,7 @@ namespace BugsnagUnity.Payload
 
         public void AddMetadata(string section, string key, object value)
         {
-            AddMetadata(section, new Dictionary<string, object> { { key, SanitizeValue(value) } });
+            AddMetadata(section, new Dictionary<string, object> { { key, value } });
         }
 
         public void AddMetadata(string section, IDictionary<string, object> metadataSection)

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
@@ -18,10 +18,76 @@ namespace BugsnagUnity.Payload
             _nativeClient = nativeClient;
         }
 
+        /// <summary>
+        /// Sanitizes metadata values to prevent JSON serialization errors.
+        /// Converts large unsigned 64-bit integers (> Int64.MaxValue) to strings,
+        /// as they cannot be represented in standard JSON numeric format.
+        /// </summary>
+        private static object SanitizeValue(object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            // Convert large ulongs to strings (> Int64.MaxValue causes JSON errors)
+            if (value is ulong ulongValue && ulongValue > long.MaxValue)
+            {
+                return ulongValue.ToString();
+            }
+
+            // Recursively sanitize dictionaries
+            if (value is IDictionary<string, object> dict)
+            {
+                var sanitized = new Dictionary<string, object>();
+                foreach (var kvp in dict)
+                {
+                    sanitized[kvp.Key] = SanitizeValue(kvp.Value);
+                }
+                return sanitized;
+            }
+
+            // Recursively sanitize arrays/lists - preserve type for string truncation
+            if (value is string[] stringArray)
+            {
+                var sanitized = new string[stringArray.Length];
+                for (int i = 0; i < stringArray.Length; i++)
+                {
+                    var sanitizedValue = SanitizeValue(stringArray[i]);
+                    sanitized[i] = sanitizedValue as string ?? sanitizedValue?.ToString();
+                }
+                return sanitized;
+            }
+
+            if (value is System.Collections.Generic.List<string> stringList)
+            {
+                var sanitized = new System.Collections.Generic.List<string>(stringList.Count);
+                for (int i = 0; i < stringList.Count; i++)
+                {
+                    var sanitizedValue = SanitizeValue(stringList[i]);
+                    sanitized.Add(sanitizedValue as string ?? sanitizedValue?.ToString());
+                }
+                return sanitized;
+            }
+
+            // Generic arrays/lists (preserving as object[] for mixed types)
+            if (value is System.Collections.IList list)
+            {
+                var sanitized = new object[list.Count];
+                for (int i = 0; i < list.Count; i++)
+                {
+                    sanitized[i] = SanitizeValue(list[i]);
+                }
+                return sanitized;
+            }
+
+            return value;
+        }
+
 
         public void AddMetadata(string section, string key, object value)
         {
-            AddMetadata(section, new Dictionary<string, object> { { key, value } });
+            AddMetadata(section, new Dictionary<string, object> { { key, SanitizeValue(value) } });
         }
 
         public void AddMetadata(string section, IDictionary<string, object> metadataSection)
@@ -31,13 +97,21 @@ namespace BugsnagUnity.Payload
                 ClearMetadata(section);
                 return;
             }
+
+            // Sanitize all values before storing
+            var sanitizedSection = new Dictionary<string, object>();
+            foreach (var kvp in metadataSection)
+            {
+                sanitizedSection[kvp.Key] = SanitizeValue(kvp.Value);
+            }
+
             if (SectionExists(section))
             {
                 var existingSection = (IDictionary<string, object>)Get(section);
 
-                foreach (var key in metadataSection.Keys.ToList())
+                foreach (var key in sanitizedSection.Keys.ToList())
                 {
-                    var value = metadataSection[key];
+                    var value = sanitizedSection[key];
                     if (value == null)
                     {
                         ClearMetadata(section, key);
@@ -50,11 +124,11 @@ namespace BugsnagUnity.Payload
             }
             else
             {
-                Add(section, metadataSection);
+                Add(section, sanitizedSection);
             }
             if (_nativeClient != null)
             {
-                _nativeClient.AddNativeMetadata(section, metadataSection);
+                _nativeClient.AddNativeMetadata(section, sanitizedSection);
             }
         }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
@@ -47,6 +47,53 @@ namespace BugsnagUnity.Payload
                 return sanitized;
             }
 
+            // Handle non-generic IDictionary with string keys
+            if (value is System.Collections.IDictionary nonGenericDict)
+            {
+                var sanitized = new Dictionary<string, object>();
+                foreach (System.Collections.DictionaryEntry entry in nonGenericDict)
+                {
+                    if (entry.Key is string keyString)
+                    {
+                        sanitized[keyString] = SanitizeValue(entry.Value);
+                    }
+                }
+                return sanitized;
+            }
+
+            // Handle generic IDictionary<string, T> variants
+            var valueType = value.GetType();
+            if (valueType.IsGenericType)
+            {
+                foreach (var iface in valueType.GetInterfaces())
+                {
+                    if (iface.IsGenericType &&
+                        iface.GetGenericTypeDefinition() == typeof(IDictionary<,>))
+                    {
+                        var genericArgs = iface.GetGenericArguments();
+                        if (genericArgs[0] == typeof(string))
+                        {
+                            var sanitized = new Dictionary<string, object>();
+                            foreach (var item in (System.Collections.IEnumerable)value)
+                            {
+                                var itemType = item.GetType();
+                                var keyProp = itemType.GetProperty("Key");
+                                var valueProp = itemType.GetProperty("Value");
+                                if (keyProp != null && valueProp != null)
+                                {
+                                    var key = keyProp.GetValue(item) as string;
+                                    if (key != null)
+                                    {
+                                        var dictValue = valueProp.GetValue(item);
+                                        sanitized[key] = SanitizeValue(dictValue);
+                                    }
+                                }
+                            }
+                            return sanitized;
+                        }
+                    }
+                }
+            }
             // Recursively sanitize arrays/lists - preserve type for string truncation
             if (value is string[] stringArray)
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Fix launch detection to use a monotonic app-uptime clock on fallback platforms
 [#969](https://github.com/bugsnag/bugsnag-unity/pull/969)
 
+- (Cocoa) Fix JSON serialization errors when metadata contains large ulong values
+[#970](https://github.com/bugsnag/bugsnag-unity/pull/970)
+
 ## 8.9.0 (2026-02-05)
 
 ### Enhancements

--- a/features/csharp/csharp_metadata.feature
+++ b/features/csharp/csharp_metadata.feature
@@ -42,6 +42,18 @@ Feature: Metadata
     And the event "metaData.dictionary.foo" equals "bar"
     And the event "metaData.number.testKey" equals 123
 
+  @cocoa_only
+  Scenario: Large long values in metadata on Cocoa platforms
+    When I run the game in the "LargeLongMetadata" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "LargeLongMetadata"
+    And the event "metaData.numeric.normalInt" equals 42
+    And the event "metaData.numeric.normalDouble" equals 123.456
+    And the event "metaData.numeric.validLong" is not null
+    And the event "metaData.numeric.negativeLong" is not null
+    And the event "metaData.numeric.largeLong" is not null
+
   # these platform specific tests are smoke tests, if os name is wrong then it's a sign that the native information has not been properly retrieved from the native layer and the unity placeholder data is being used
   @ios_only
   Scenario: iOS specific metadata

--- a/features/csharp/csharp_metadata.feature
+++ b/features/csharp/csharp_metadata.feature
@@ -54,6 +54,27 @@ Feature: Metadata
     And the event "metaData.numeric.negativeLong" is not null
     And the event "metaData.numeric.largeLong" equals "12345678901234567890"
 
+  Scenario: Complex metadata sanitization with various dictionary types
+    When I run the game in the "ComplexMetadataSanitization" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "ComplexMetadataSanitization"
+    And the event "metaData.generic.dict.small" equals 100
+    And the event "metaData.generic.dict.large" equals "18446744073709551615"
+    And the event "metaData.nonGeneric.hashtable.stringKey" equals "12345678901234567890"
+    And the event "metaData.nonGeneric.hashtable.normalKey" equals "valueWithStringKey"
+    And the event "metaData.nonGeneric.hashtable.nested.deep" equals "18446744073709551000"
+    And the event "metaData.custom.dict.custom1" equals "18446744073709551615"
+    And the event "metaData.custom.dict.custom2" equals "normalValue"
+    And the event "metaData.nested.level1.level2.level3.level4" equals "18446744073709551615"
+    And the event "metaData.nested.level1.level2.level3.array.1" equals "12345678901234567890"
+    And the event "metaData.arrays.mixedArray.0" equals "12345678901234567890"
+    And the event "metaData.arrays.mixedArray.1.inArray" equals "18446744073709551615"
+    And the event "metaData.edgeCases.nullValue" is null
+    And the event "metaData.edgeCases.zeroUlong" equals 0
+    And the event "metaData.edgeCases.maxLong" is not null
+    And the event "metaData.edgeCases.overMaxLong" equals "9223372036854775808"
+
   # these platform specific tests are smoke tests, if os name is wrong then it's a sign that the native information has not been properly retrieved from the native layer and the unity placeholder data is being used
   @ios_only
   Scenario: iOS specific metadata

--- a/features/csharp/csharp_metadata.feature
+++ b/features/csharp/csharp_metadata.feature
@@ -52,7 +52,7 @@ Feature: Metadata
     And the event "metaData.numeric.normalDouble" equals 123.456
     And the event "metaData.numeric.validLong" is not null
     And the event "metaData.numeric.negativeLong" is not null
-    And the event "metaData.numeric.largeLong" is not null
+    And the event "metaData.numeric.largeLong" equals "12345678901234567890"
 
   # these platform specific tests are smoke tests, if os name is wrong then it's a sign that the native information has not been properly retrieved from the native layer and the unity placeholder data is being used
   @ios_only

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -664,6 +664,7 @@ GameObject:
   - component: {fileID: 547010192}
   - component: {fileID: 547010191}
   - component: {fileID: 547010190}
+  - component: {fileID: 547010193}
   m_Layer: 0
   m_Name: Metadata
   m_TagString: Untagged
@@ -728,6 +729,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0ebd005ad77d4465dba6cc32040aec06, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2
+    () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &547010193
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 547010188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1d76787639cb40b5ad6fffbe709f9bdd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -665,6 +665,7 @@ GameObject:
   - component: {fileID: 547010191}
   - component: {fileID: 547010190}
   - component: {fileID: 547010193}
+  - component: {fileID: 547010195}
   m_Layer: 0
   m_Name: Metadata
   m_TagString: Untagged
@@ -745,6 +746,22 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1d76787639cb40b5ad6fffbe709f9bdd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)
+
+    Main.CUSTOM2
+    () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &547010195
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 547010188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f98909861ed52f7ce8bbbc8920b1dee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/ComplexMetadataSanitization.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/ComplexMetadataSanitization.cs
@@ -1,0 +1,114 @@
+using System.Collections;
+using System.Collections.Generic;
+using BugsnagUnity;
+
+public class ComplexMetadataSanitization : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+    }
+
+    public override void Run()
+    {
+        // Test 1: Generic Dictionary<string, ulong>
+        var genericDict = new Dictionary<string, ulong>
+        {
+            { "small", 100UL },
+            { "large", 18446744073709551615UL }  // Max UInt64
+        };
+        Bugsnag.AddMetadata("generic", "dict", genericDict);
+
+        // Test 2: Non-generic Hashtable
+        var hashtable = new Hashtable
+        {
+            { "stringKey", 12345678901234567890UL },
+            { "normalKey", "valueWithStringKey" },
+            { "nested", new Dictionary<string, object> 
+                { 
+                    { "deep", 18446744073709551000UL } 
+                } 
+            }
+        };
+        Bugsnag.AddMetadata("nonGeneric", "hashtable", hashtable);
+
+        // Test 3: Custom non-generic dictionary implementation
+        var customDict = new CustomStringDictionary
+        {
+            { "custom1", 18446744073709551615UL },
+            { "custom2", "normalValue" }
+        };
+        Bugsnag.AddMetadata("custom", "dict", customDict);
+
+        // Test 4: Deeply nested structure (4 levels)
+        Bugsnag.AddMetadata("nested", new Dictionary<string, object>
+        {
+            { "level1", new Dictionary<string, object>
+                {
+                    { "level2", new Dictionary<string, object>
+                        {
+                            { "level3", new Dictionary<string, object>
+                                {
+                                    { "level4", 18446744073709551615UL },
+                                    { "array", new object[] { 1, 12345678901234567890UL, "test" } }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // Test 5: Mixed arrays with dictionaries
+        Bugsnag.AddMetadata("arrays", new Dictionary<string, object>
+        {
+            { "mixedArray", new object[]
+                {
+                    12345678901234567890UL,
+                    new Dictionary<string, object> { { "inArray", 18446744073709551615UL } },
+                    new string[] { "str1", "str2" }
+                }
+            }
+        });
+
+        // Test 6: Dictionary with null values and edge cases
+        Bugsnag.AddMetadata("edgeCases", new Dictionary<string, object>
+        {
+            { "nullValue", null },
+            { "zeroUlong", 0UL },
+            { "maxLong", 9223372036854775807L },  // Just under the limit (valid long)
+            { "overMaxLong", 9223372036854775808UL }  // Just over the limit (requires sanitization)
+        });
+
+        DoSimpleNotify("ComplexMetadataSanitization");
+    }
+
+    // Custom non-generic dictionary that implements IDictionary<string, object>
+    private class CustomStringDictionary : IDictionary<string, object>
+    {
+        private Dictionary<string, object> _inner = new Dictionary<string, object>();
+
+        public object this[string key] 
+        { 
+            get => _inner[key]; 
+            set => _inner[key] = value; 
+        }
+
+        public ICollection<string> Keys => _inner.Keys;
+        public ICollection<object> Values => _inner.Values;
+        public int Count => _inner.Count;
+        public bool IsReadOnly => false;
+
+        public void Add(string key, object value) => _inner.Add(key, value);
+        public void Add(KeyValuePair<string, object> item) => _inner.Add(item.Key, item.Value);
+        public void Clear() => _inner.Clear();
+        public bool Contains(KeyValuePair<string, object> item) => _inner.ContainsKey(item.Key);
+        public bool ContainsKey(string key) => _inner.ContainsKey(key);
+        public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex) { }
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => _inner.GetEnumerator();
+        public bool Remove(string key) => _inner.Remove(key);
+        public bool Remove(KeyValuePair<string, object> item) => _inner.Remove(item.Key);
+        public bool TryGetValue(string key, out object value) => _inner.TryGetValue(key, out value);
+        IEnumerator IEnumerable.GetEnumerator() => _inner.GetEnumerator();
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/ComplexMetadataSanitization.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/ComplexMetadataSanitization.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f98909861ed52f7ce8bbbc8920b1dee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/LargeLongMetadata.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/LargeLongMetadata.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using BugsnagUnity;
+
+public class LargeLongMetadata : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+    }
+
+    public override void Run()
+    {
+        // Add various long values to metadata including values that overflow Int64
+        Bugsnag.AddMetadata("numeric", new Dictionary<string, object>(){
+            {"validLong", 9223372036854775807L }, // Int64.MaxValue
+            {"negativeLong", -9223372036854775808L }, // Int64.MinValue
+            {"largeLong", 12345678901234567890UL }, // Exceeds Int64.MaxValue (UInt64)
+            {"normalInt", 42 },
+            {"normalDouble", 123.456 }
+        });
+
+        Bugsnag.LeaveBreadcrumb("Test large long values");
+        
+        DoSimpleNotify("LargeLongMetadata");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/LargeLongMetadata.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/LargeLongMetadata.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d76787639cb40b5ad6fffbe709f9bdd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
###Goal
Fix JSON serialization errors on Cocoa platforms when metadata contains ulong values exceeding [long.MaxValue](9223372036854775807). These large values cannot be represented in standard JSON numeric format and caused SerializationException crashes during native JSON serialization. Additionally, ensure metadata sanitization preserves array types to maintain compatibility with string truncation logic.

###Design
C#-side sanitization at insertion time instead of native recursive sanitization at serialization time:
Lightweight approach: Convert problematic ulong values to strings once when metadata is added via [AddMetadata()], not repeatedly during every JSON serialization
Type preservation: Specifically handle string[] and [List<string>] to maintain their types (rather than converting to generic object[]), ensuring the existing string truncation logic in [Delivery.cs] can still recognize and process them
Recursive handling: Sanitize nested dictionaries and arrays to catch large ulongs at any depth
Minimal overhead: One-time cost at insertion vs. repeated native-side recursive walks

###Changeset
1. [Metadata.cs]
Added [SanitizeValue()] method to convert [ulong > long.MaxValue] to strings
Handles string[] and [List<string>] specifically to preserve types
Recursively processes dictionaries, non-generic IDictionary and generic arrays
Applied in both [AddMetadata()] overloads
2. [LargeLongMetadata.cs]:
Added test scenario with values: [long.MaxValue], long.MinValue, and 12345678901234567890UL (exceeds [long.MaxValue])
3. [MainScene.unity]Added [LargeLongMetadata] component to Metadata GameObject for scenario discovery

### Testing
New scenario: [LargeLongMetadata](@cocoa_only) , [ComplexMetadataSanitization.cs] : Scenario
verifies that complex & large ulong values in metadata don't cause crashes and are properly serialized
Regression test: [MaxStringValueLength] confirms that string array type preservation works correctly and string truncation still functions as expected