### PR TITLE
Clear the Bugsnag cache runs before each scenario

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
@@ -42,14 +42,6 @@ namespace BugsnagUnity
             return InternalClient != null;
         }
 
-        public static void ResetForTesting()
-        {
-            lock (_clientLock)
-            {
-                InternalClient = null;
-            }
-        }
-
         private static Client InternalClient { get; set; }
 
         private static IClient Client => InternalClient;

--- a/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
@@ -185,5 +185,20 @@ namespace BugsnagUnity
 
         public static void ClearFeatureFlags() => Client.ClearFeatureFlags();
 
+#if UNITY_ASSERTIONS
+        /// <summary>
+        /// Resets the Bugsnag client for testing purposes.
+        /// This allows Start() to be called again with a new configuration.
+        /// Only available in test/development builds.
+        /// </summary>
+        public static void ResetForTesting()
+        {
+            lock (_clientLock)
+            {
+                InternalClient = null;
+            }
+        }
+#endif
+
     }
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
@@ -42,7 +42,7 @@ namespace BugsnagUnity
             return InternalClient != null;
         }
 
-        internal static void ResetForTesting()
+        public static void ResetForTesting()
         {
             lock (_clientLock)
             {

--- a/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
@@ -42,6 +42,14 @@ namespace BugsnagUnity
             return InternalClient != null;
         }
 
+        internal static void ResetForTesting()
+        {
+            lock (_clientLock)
+            {
+                InternalClient = null;
+            }
+        }
+
         private static Client InternalClient { get; set; }
 
         private static IClient Client => InternalClient;

--- a/Bugsnag/Assets/Resources/Bugsnag/BugsnagSettingsObject.asset
+++ b/Bugsnag/Assets/Resources/Bugsnag/BugsnagSettingsObject.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   AutoUploadSymbols: 1
   BugsnagCLIExecutablePath: 
   UploadEndpoint: 
-  StartAutomaticallyAtLaunch: 1
+  StartAutomaticallyAtLaunch: 0
   AutoDetectErrors: 1
   AutoTrackSessions: 1
   ApiKey: 227df1042bc7772c321dbde3b31a03c2

--- a/features/fixtures/maze_runner/Assets/Editor/Builder.cs
+++ b/features/fixtures/maze_runner/Assets/Editor/Builder.cs
@@ -9,8 +9,11 @@ public class Builder : MonoBehaviour
     static void BuildStandalone(string folder, BuildTarget target, bool dev)
     {
         BuildPlayerOptions opts = new BuildPlayerOptions();
-        PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone, "UNITY_ASSERTIONS");
-        PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.WebGL, "UNITY_ASSERTIONS");
+        PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone, "UNITY_ASSERTIONS;BUGSNAG_UNITY_WEB_REQUEST");
+        PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.WebGL, "UNITY_ASSERTIONS;BUGSNAG_UNITY_WEB_REQUEST");
+        var settingsObject = BugsnagSettingsObject.LoadBuildTimeSettingsObject();
+        settingsObject.StartAutomaticallyAtLaunch = false;
+        UnityEditor.EditorUtility.SetDirty(settingsObject);
         var scenes = EditorBuildSettings.scenes.Where(s => s.enabled).Select(s => s.path).ToArray();
         opts.scenes = scenes;
         opts.locationPathName = folder;

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -212,6 +212,16 @@ public class Main : MonoBehaviour
         {
             Directory.Delete(Application.persistentDataPath + "/Bugsnag", true);
         }
+
+        try
+        {
+            BugsnagUnity.Bugsnag.ResetForTesting();
+        }
+        catch
+        {
+            Log("Resetting got failed");
+            // Best-effort: fixture cache clearing should not fail if Bugsnag isn't available.
+        }
         if (Application.platform == RuntimePlatform.IPhonePlayer)
         {
             ClearIOSData();

--- a/features/fixtures/maze_runner/Assets/Scripts/Main.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Main.cs
@@ -212,16 +212,6 @@ public class Main : MonoBehaviour
         {
             Directory.Delete(Application.persistentDataPath + "/Bugsnag", true);
         }
-
-        try
-        {
-            BugsnagUnity.Bugsnag.ResetForTesting();
-        }
-        catch
-        {
-            Log("Resetting got failed");
-            // Best-effort: fixture cache clearing should not fail if Bugsnag isn't available.
-        }
         if (Application.platform == RuntimePlatform.IPhonePlayer)
         {
             ClearIOSData();

--- a/features/fixtures/maze_runner/Assets/Scripts/ScenarioRunner.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/ScenarioRunner.cs
@@ -27,6 +27,9 @@ public class ScenarioRunner : MonoBehaviour
 
     public void RunScenario(string scenarioName, string apiKey, string host)
     {
+#if UNITY_ASSERTIONS
+        Bugsnag.ResetForTesting();
+#endif
 
         var scenario = GetScenario(scenarioName);
         scenario.PrepareConfig(apiKey, host);

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/DisableBreadcrumbs.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/DisableBreadcrumbs.cs
@@ -7,6 +7,7 @@ public class DisableBreadcrumbs : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
+        Configuration.EnabledBreadcrumbTypes = new [] { BreadcrumbType.Log };
         Configuration.EnabledBreadcrumbTypes = new BreadcrumbType[0];
     }
 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/EnableBreadcrumbs.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Breadcrumbs/EnableBreadcrumbs.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using BugsnagUnity;
+using BugsnagUnity.Payload;
 using System;
 
 public class EnableBreadcrumbs : Scenario
@@ -8,7 +9,7 @@ public class EnableBreadcrumbs : Scenario
     public override void PrepareConfig(string apiKey, string host)
     {
         base.PrepareConfig(apiKey, host);
-        Configuration.EnabledBreadcrumbTypes = new BugsnagUnity.Payload.BreadcrumbType[] {BugsnagUnity.Payload.BreadcrumbType.Log };
+        Configuration.EnabledBreadcrumbTypes = new [] { BreadcrumbType.Log };
     }
 
     public override void Run()


### PR DESCRIPTION
- Previously it only deleted disk cache [Application.persistentDataPath/Bugsnag], but that does not reset the in-memory Bugsnag singleton.
- Now, we clear the local cache before each scenario run [Bugsnag.ResetForTesting()] which clears the in-memory [InternalClient]. That forces the next scenario’s [Bugsnag.Start(config)] to create a fresh client with no leaked callbacks/breadcrumbs.