### PR TITLE
Add warning breadcrumb serialization failures

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Breadcrumb.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Breadcrumb.cs
@@ -79,7 +79,38 @@ namespace BugsnagUnity.Payload
             }
             set
             {
-                Add(METADATA_KEY, value);
+                // Sanitize metadata to avoid JSON serializer reflection errors.
+                if (value == null)
+                {
+                    Add(METADATA_KEY, null);
+                    return;
+                }
+
+                var sanitized = new Dictionary<string, object>();
+                var warnings = new List<string>();
+
+                foreach (var kvp in value)
+                {
+                    var val = kvp.Value;
+                    if (SanitizationHelpers.IsTriviallySerializable(val) || val == null)
+                    {
+                        sanitized[kvp.Key] = val;
+                    }
+                    else
+                    {
+                        // Convert unexpected types to string to ensure safe serialization
+                        sanitized[kvp.Key] = val?.ToString();
+                        var typeName = val.GetType().FullName;
+                        warnings.Add($"Could not serialize breadcrumb metadata key '{kvp.Key}' (type: {typeName})");
+                    }
+                }
+
+                if (warnings.Count > 0)
+                {
+                    sanitized["__bugsnag_unserializable_values"] = warnings;
+                }
+
+                Add(METADATA_KEY, sanitized);
             }
         }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/Metadata.cs
@@ -154,11 +154,30 @@ namespace BugsnagUnity.Payload
                 return;
             }
 
-            // Sanitize all values before storing
+            // Sanitize all values before storing. Collect warnings for values
+            // that still cannot be safely serialized and convert them to strings.
             var sanitizedSection = new Dictionary<string, object>();
+            var warnings = new List<string>();
             foreach (var kvp in metadataSection)
             {
-                sanitizedSection[kvp.Key] = SanitizeValue(kvp.Value);
+                var original = kvp.Value;
+                var sanitized = SanitizeValue(original);
+
+                if (!SanitizationHelpers.IsTriviallySerializable(sanitized) && sanitized != null)
+                {
+                    // convert to string to avoid serializer reflection
+                    var typeName = sanitized.GetType().FullName;
+                    warnings.Add($"Could not serialize value for key '{kvp.Key}' (type: {typeName})");
+                    sanitizedSection[kvp.Key] = sanitized.ToString();
+                }
+                else
+                {
+                    sanitizedSection[kvp.Key] = sanitized;
+                }
+            }
+            if (warnings.Count > 0)
+            {
+                sanitizedSection["__bugsnag_unserializable_values"] = warnings;
             }
 
             if (SectionExists(section))

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/SanitizationHelpers.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/SanitizationHelpers.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace BugsnagUnity.Payload
+{
+    internal static class SanitizationHelpers
+    {
+        internal static bool IsTriviallySerializable(object value)
+        {
+            switch (value)
+            {
+                case null:
+                case string _:
+                case bool _:
+                case byte _:
+                case sbyte _:
+                case short _:
+                case ushort _:
+                case int _:
+                case uint _:
+                case long _:
+                case ulong _:
+                case float _:
+                case double _:
+                case decimal _:
+                case DateTime _:
+                case DateTimeOffset _:
+                case Guid _:
+                case Enum _:
+                case IDictionary _:
+                case IEnumerable _:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/SanitizationHelpers.cs.meta
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/SanitizationHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2be43aa71b20040c990b5145788c1980
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Bugsnag/Assets/Tests/SerializationSanitizationTests.cs
+++ b/Bugsnag/Assets/Tests/SerializationSanitizationTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using BugsnagUnity.Payload;
+
+namespace BugsnagUnityTests
+{
+    [TestFixture]
+    public class SerializationSanitizationTests
+    {
+        [Test]
+        public void Metadata_AddMetadata_ShouldAddWarningForUnserializableValues()
+        {
+            var metadata = new Metadata();
+            var bad = new Action(() => { });
+            var section = "testSection";
+            var input = new Dictionary<string, object> { { "bad", (object)bad } };
+
+            metadata.AddMetadata(section, input);
+
+            var stored = metadata.GetMetadata(section);
+            Assert.IsNotNull(stored, "Section should exist");
+            Assert.IsTrue(stored.ContainsKey("__bugsnag_unserializable_values"), "Warnings key should be present");
+            var warnings = stored["__bugsnag_unserializable_values"] as List<string>;
+            Assert.IsNotNull(warnings, "Warnings should be a list of strings");
+            Assert.IsTrue(warnings.Count >= 1, "There should be at least one warning");
+            StringAssert.Contains("bad", warnings[0]);
+        }
+
+        [Test]
+        public void Breadcrumb_MetadataSetter_ShouldAddWarningForUnserializableValues()
+        {
+            var bad = new Action(() => { });
+            var metadata = new Dictionary<string, object> { { "bad", (object)bad } };
+
+            var crumb = new Breadcrumb("m", metadata, BreadcrumbType.Manual);
+
+            var stored = crumb.Metadata;
+            Assert.IsNotNull(stored, "Breadcrumb metadata should exist");
+            Assert.IsTrue(stored.ContainsKey("__bugsnag_unserializable_values"), "Breadcrumb warnings key should be present");
+            var warnings = stored["__bugsnag_unserializable_values"] as List<string>;
+            Assert.IsNotNull(warnings, "Breadcrumb warnings should be a list of strings");
+            Assert.IsTrue(warnings.Count >= 1, "There should be at least one breadcrumb warning");
+            StringAssert.Contains("bad", warnings[0]);
+        }
+    }
+}

--- a/Bugsnag/Assets/Tests/SerializationSanitizationTests.cs.meta
+++ b/Bugsnag/Assets/Tests/SerializationSanitizationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ffd39b70bebaf4dd6a027ecea6570f9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require "rbconfig"
 require 'fileutils'
 require 'tmpdir'
 require "json"
+require 'date'
 
 HOST_OS = RbConfig::CONFIG['host_os']
 def is_mac?; HOST_OS =~ /darwin/i; end
@@ -285,6 +286,47 @@ def build_upm_edm4u_package
   unless system command
     raise 'build upm edm4u package failed'
   end
+end
+
+desc 'Bump project version files. Usage: rake bump VERSION="1.2.3"'
+task :bump do
+  version = ENV['VERSION']
+  unless version && version.match(/^\d+\.\d+\.\d+$/)
+    raise 'Usage: rake bump VERSION="1.2.3" (version must be in X.Y.Z format)'
+  end
+
+  puts "Bumping version to #{version}"
+
+  # Update AssemblyInfo.cs
+  assembly_info_path = File.join("Bugsnag", "Assets", "Bugsnag", "Runtime", "AssemblyInfo.cs")
+  if File.exist?(assembly_info_path)
+    assembly_content = File.read(assembly_info_path)
+    new_assembly = assembly_content.gsub(/AssemblyVersion\("\d+\.\d+\.\d+(?:\.\d+)?"\)/, "AssemblyVersion(\"#{version}.0\")")
+    File.write(assembly_info_path, new_assembly)
+    puts "Updated #{assembly_info_path}"
+  else
+    puts "Warning: #{assembly_info_path} not found"
+  end
+
+    # Update CHANGELOG.md: replace the leading '## TBD' section with a release header only
+    changelog_path = File.join("CHANGELOG.md")
+    if File.exist?(changelog_path)
+      changelog = File.read(changelog_path)
+      date_str = Date.today.strftime('%Y-%m-%d')
+      version_header = "## #{version} (#{date_str})"
+
+      if changelog =~ /^##\s+TBD/m
+        updated = changelog.sub(/^##\s+TBD/m, version_header)
+        File.write(changelog_path, updated)
+        puts "Updated #{changelog_path} with release #{version}"
+      else
+        puts "No '## TBD' section found in #{changelog_path}; please update version manually"
+      end
+    else
+      puts "Warning: #{changelog_path} not found"
+    end
+
+    puts "Done."
 end
 
 namespace :plugin do

--- a/Rakefile
+++ b/Rakefile
@@ -291,7 +291,7 @@ end
 desc 'Bump project version files. Usage: rake bump VERSION="1.2.3"'
 task :bump do
   version = ENV['VERSION']
-  unless version && version.match(/^\d+\.\d+\.\d+$/)
+  unless version && version.match(/\A\d+\.\d+\.\d+\z/)
     raise 'Usage: rake bump VERSION="1.2.3" (version must be in X.Y.Z format)'
   end
 
@@ -301,32 +301,43 @@ task :bump do
   assembly_info_path = File.join("Bugsnag", "Assets", "Bugsnag", "Runtime", "AssemblyInfo.cs")
   if File.exist?(assembly_info_path)
     assembly_content = File.read(assembly_info_path)
-    new_assembly = assembly_content.gsub(/AssemblyVersion\("\d+\.\d+\.\d+(?:\.\d+)?"\)/, "AssemblyVersion(\"#{version}.0\")")
-    File.write(assembly_info_path, new_assembly)
-    puts "Updated #{assembly_info_path}"
+    pattern = /AssemblyVersion\("\d+\.\d+\.\d+(?:\.\d+)?"\)/
+    target = "AssemblyVersion(\"#{version}.0\")"
+
+    if assembly_content =~ pattern
+      if assembly_content.include?(target)
+        puts "AssemblyVersion already set to #{version} in #{assembly_info_path}; skipping"
+      else
+        new_assembly = assembly_content.sub(pattern, target)
+        File.write(assembly_info_path, new_assembly)
+        puts "Updated #{assembly_info_path}"
+      end
+    else
+      raise "AssemblyVersion(...) not found or not in expected format in #{assembly_info_path}; version #{version} was not applied"
+    end
   else
     puts "Warning: #{assembly_info_path} not found"
   end
 
-    # Update CHANGELOG.md: replace the leading '## TBD' section with a release header only
-    changelog_path = File.join("CHANGELOG.md")
-    if File.exist?(changelog_path)
-      changelog = File.read(changelog_path)
-      date_str = Date.today.strftime('%Y-%m-%d')
-      version_header = "## #{version} (#{date_str})"
+  # Update CHANGELOG.md: replace the leading '## TBD' section with a release header only
+  changelog_path = File.join("CHANGELOG.md")
+  if File.exist?(changelog_path)
+    changelog = File.read(changelog_path)
+    date_str = Date.today.strftime('%Y-%m-%d')
+    version_header = "## #{version} (#{date_str})"
 
-      if changelog =~ /^##\s+TBD/m
-        updated = changelog.sub(/^##\s+TBD/m, version_header)
-        File.write(changelog_path, updated)
-        puts "Updated #{changelog_path} with release #{version}"
-      else
-        puts "No '## TBD' section found in #{changelog_path}; please update version manually"
-      end
+    if changelog =~ /^##\s+TBD/
+      updated = changelog.sub(/^##\s+TBD/, version_header)
+      File.write(changelog_path, updated)
+      puts "Updated #{changelog_path} with release #{version}"
     else
-      puts "Warning: #{changelog_path} not found"
+      puts "No '## TBD' section found in #{changelog_path}; please update version manually"
     end
+  else
+    puts "Warning: #{changelog_path} not found"
+  end
 
-    puts "Done."
+  puts "Done."
 end
 
 namespace :plugin do

--- a/features/csharp/csharp_metadata.feature
+++ b/features/csharp/csharp_metadata.feature
@@ -75,6 +75,13 @@ Feature: Metadata
     And the event "metaData.edgeCases.maxLong" is not null
     And the event "metaData.edgeCases.overMaxLong" equals "9223372036854775808"
 
+  Scenario: Unserializable metadata gets warning
+    When I run the game in the "UnserializableMetadata" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "UnserializableMetadata"
+    And the event "metaData.unserializable.__bugsnag_unserializable_values.0" is not null
+
   # these platform specific tests are smoke tests, if os name is wrong then it's a sign that the native information has not been properly retrieved from the native layer and the unity placeholder data is being used
   @ios_only
   Scenario: iOS specific metadata

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/UnserializableMetadata.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/UnserializableMetadata.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using BugsnagUnity;
+
+public class UnserializableMetadata : Scenario
+{
+    public override void Run()
+    {
+        // Add a delegate (which is not JSON-serializable) into metadata
+        Action noop = () => { };
+        Bugsnag.AddMetadata("unserializable", "testKey", noop);
+
+        DoSimpleNotify("UnserializableMetadata");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/UnserializableMetadata.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Metadata/UnserializableMetadata.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec004b909dc894a8c85972cd80eb4cc8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Goal

Check runtime JSON serialization failures by ensuring metadata and breadcrumb values are safe to serialize and surface warnings when conversion occurs.

## Design

- Keep fast-path sanitization for common types and only perform minimal conversion for rare/unknown types. Convert remaining non-trivially-serializable values to strings and add a __bugsnag_unserializable_values list to the same metadata section so the issue is visible in the event payload.
- Avoid invoking the reflective JSON serializer on unexpected runtime objects (which caused exceptions), while preserving performance in the hot path by using cheap type checks [SanitizationHelpers.IsTriviallySerializable] and reusing existing [SanitizeValue] logic.

## Changeset

-Behavioral changes:
Metadata now records warnings and converts residual non-serializable values to strings before storing.
Breadcrumb metadata is sanitized the same way as event metadata so untrusted values cannot trigger serializer errors.
Files touched (examples):
[Metadata.cs] — added final safe-conversion + warnings using [SanitizationHelpers].
[Breadcrumb.cs] — sanitize [Metadata] setter; add __bugsnag_unserializable_values when needed.
[SanitizationHelpers.cs] — centralized fast-path checks.
[UnserializableMetadata.cs] — new scenario inserting an unserializable value.
[csharp_metadata.feature] — added scenario asserting presence of the warning key.

## Testing

- Automated: Added a MazeRunner feature scenario (UnserializableMetadata) to exercise end-to-end behavior and assert metaData. "bugsnag_unserializable_values" is present in the sent event.
- Manual / local validation performed: Built unit test case [SerializationSanitizationTests.cs]

