### PR TITLE
Fix Android context being overwritten by Activity

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Bugsnag.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using BugsnagUnity.Payload;
+using UnityEngine;
 using UnityEngine.Networking;
 
 namespace BugsnagUnity
@@ -29,6 +30,12 @@ namespace BugsnagUnity
                     configClone.Endpoints.Configure(configClone.ApiKey);
                     var nativeClient = new NativeClient(configClone);
                     InternalClient = new Client(nativeClient);
+
+                    // On Android, set context once to force MANUAL mode (prevents Activity auto-context).
+                    if (Application.platform == RuntimePlatform.Android)
+                    {
+                        InternalClient.SetContext(configClone.Context);
+                    }
                 }
                 else
                 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug Fixes
+
+- Fix Android context being overwritten by Activity
+[#977](https://github.com/bugsnag/bugsnag-unity/pull/977)
+
 ## 8.9.1 (2026-04-01)
 
 ### Bug Fixes

--- a/features/android/android_config.feature
+++ b/features/android/android_config.feature
@@ -20,3 +20,14 @@ Feature: Android Config
     And the exception "message" equals "AndroidVersionCodeInConfig"
     And the event "app.versionCode" equals 555
 
+  Scenario: Disable Automatic Context Capture
+    When I run the game in the "AndroidDisableAutomaticContext" state
+    And I wait to receive an error
+    And the exception "message" equals "AndroidDisableAutomaticContext"
+    And the event "context" is null
+
+  Scenario: Enable Automatic Context Capture
+    When I run the game in the "AndroidEnableAutomaticContext" state
+    And I wait to receive an error
+    And the exception "message" equals "AndroidEnableAutomaticContext"
+    And the event "context" equals "UnityPipelineContext"

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -1516,6 +1516,8 @@ GameObject:
   - component: {fileID: 1388241504}
   - component: {fileID: 1388241506}
   - component: {fileID: 1388241505}
+  - component: {fileID: 1388241507}
+  - component: {fileID: 1388241508}
   m_Layer: 0
   m_Name: Android
   m_TagString: Untagged
@@ -1676,6 +1678,30 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ad7cb7beeace84b0698b1d2cc73b3537, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1388241507
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1388241496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a8e7c6d5b4f3e2a1d0c9b8a7f6e5d4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1388241508
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1388241496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b7a6c5d4e3f2a1b0c9d8e7f6a5b4c3d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   CustomStacktrace: 'Main.CUSTOM1 () (at Assets/Scripts/Main.cs:123)

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidDisableAutomaticContext.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidDisableAutomaticContext.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public class AndroidDisableAutomaticContext : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        // Explicitly set null context so the Android notifier is placed into MANUAL
+        // context mode and cannot overwrite context from Activity lifecycle events.
+        Configuration.Context = null;
+    }
+
+    public override void Run()
+    {
+        // Trigger an error to verify context remains empty (not set to Activity name)
+        DoSimpleNotify("AndroidDisableAutomaticContext");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidDisableAutomaticContext.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidDisableAutomaticContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a8e7c6d5b4f3e2a1d0c9b8a7f6e5d4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidEnableAutomaticContext.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidEnableAutomaticContext.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+public class AndroidEnableAutomaticContext : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        base.PrepareConfig(apiKey, host);
+        // Simulate a Unity-managed context value (pipeline-controlled).
+        Configuration.Context = "UnityPipelineContext";
+    }
+
+    public override void Run()
+    {
+        // Trigger an error to verify the context matches the Unity-managed value.
+        DoSimpleNotify("AndroidEnableAutomaticContext");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidEnableAutomaticContext.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Android/AndroidEnableAutomaticContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b7a6c5d4e3f2a1b0c9d8e7f6a5b4c3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Goal

Prevent the Android native notifier from intermittently setting [event.context] to the Unity Activity name (e.g. GameActivity).
Ensure Unity (pipeline) remains the single source of truth for context on Android, including when context is intentionally null.

## Design

On Android, force the underlying notifier into MANUAL context mode immediately after [Bugsnag.Start()] by explicitly calling [SetContext(configClone.Context)] once the client is created.
This avoids timing/race issues where the Android SDK can briefly apply automatic Activity-based context before Unity/pipeline sets context.
No Android native SDK changes required.

## Changeset

Add a one-time Android-only post-start call in:
[Bugsnag.cs]

## Testing

Update Maze Runner scenarios + expectations to reflect Unity-owned context:
[AndroidDisableAutomaticContext.cs]
[AndroidEnableAutomaticContext.cs]
[android_config.feature]