### PR TITLE
CI Test case improvements : native callback values

### DIFF
--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -199,7 +199,6 @@ public class Scenario : MonoBehaviour
         @event.Errors[0].ErrorMessage = "Custom ErrorMessage";
 
         @event.App.Duration = TimeSpan.FromMilliseconds(1000);
-        @event.Device.Time = new DateTimeOffset(1985, 08, 21, 01, 01, 01, TimeSpan.Zero);
 
         var testDict = new Dictionary<string, object>();
         testDict.Add("scoop", "dewoop");

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenario.cs
@@ -190,7 +190,20 @@ public class Scenario : MonoBehaviour
         EditAllAppData(@event);
         EditAllDeviceData(@event);
 
+        @event.Context = "Custom Context";
+        @event.Severity = Severity.Info;
+        @event.GroupingHash = "Custom GroupingHash";
+        @event.GroupingDiscriminator = "Custom GroupingDiscriminator";
+
         @event.Errors[0].ErrorClass = "ErrorClass";
+        @event.Errors[0].ErrorMessage = "Custom ErrorMessage";
+
+        @event.App.Duration = TimeSpan.FromMilliseconds(1000);
+        @event.Device.Time = new DateTimeOffset(1985, 08, 21, 01, 01, 01, TimeSpan.Zero);
+
+        var testDict = new Dictionary<string, object>();
+        testDict.Add("scoop", "dewoop");
+        @event.Device.RuntimeVersions = testDict;
 
         @event.Errors[0].Stacktrace[0].Method = "Method";
 

--- a/features/ios/ios_callbacks.feature
+++ b/features/ios/ios_callbacks.feature
@@ -1,7 +1,5 @@
 Feature: Callbacks
 
-#NOTE to be improved in PLAT-9129
-
   Background:
     Given I clear the Bugsnag cache
 
@@ -19,6 +17,7 @@ Feature: Callbacks
     And the event "severity" equals "info"
     And the event "unhandled" is false
     And the event "groupingDiscriminator" equals "Custom GroupingDiscriminator"
+    And the event "groupingHash" equals "Custom GroupingHash"
 
 
     # metadata
@@ -55,8 +54,6 @@ Feature: Callbacks
     And the event "device.modelNumber" equals "Custom ModelNumber"
     And the event "device.totalMemory" equals 999
 
-
-
     # Breadcrumbs
     And the event "breadcrumbs.0.name" equals "Custom Message"
     And the event "breadcrumbs.0.type" equals "user"
@@ -75,3 +72,6 @@ Feature: Callbacks
     # errors
     And the event "exceptions.0.errorClass" equals "Custom ErrorClass"
     And the event "exceptions.0.message" equals "Custom ErrorMessage"
+
+    # stacktrace
+    And the event "exceptions.0.stacktrace.0.method" equals "Custom Method"

--- a/features/macos/macos_native_crashes.feature
+++ b/features/macos/macos_native_crashes.feature
@@ -27,7 +27,6 @@ Feature: MacOS native crashes
     And the event "user.email" equals "2"
     And the event "user.name" equals "3"
 
-  #NOTE to be improved in PLAT-9129
   @macos_only
   Scenario: Reporting a MacOS native crash with an onsend callback
     When I run the game in the "MacOSNativeCrash" state
@@ -40,6 +39,12 @@ Feature: MacOS native crashes
     And the event "unhandled" is true
     And the error payload field "notifier.name" equals "Unity Bugsnag Notifier"
     
+    # Event properties
+    And the event "context" equals "Custom Context"
+    And the event "severity" equals "info"
+    And the event "groupingHash" equals "Custom GroupingHash"
+    And the event "groupingDiscriminator" equals "Custom GroupingDiscriminator"
+    
      # Device metadata
     And the event "device.osName" equals "OsName"
     And the event "device.osVersion" equals "OsVersion"
@@ -51,6 +56,7 @@ Feature: MacOS native crashes
     And the event "device.freeMemory" equals 456
     And the event "device.jailbroken" is true
     And the event "device.locale" equals "Locale"
+    And the event "device.runtimeVersions.scoop" equals "dewoop"
 
     # App metadata
     And the event "app.id" equals "Id"
@@ -60,12 +66,13 @@ Feature: MacOS native crashes
     And the event "app.bundleVersion" equals "BundleVersion"
     And the event "app.binaryArch" equals "BinaryArch"
     And the event "app.codeBundleId" equals "CodeBundleId"
-    And the event "app.dsymUUIDs" is not null
+    And the event "app.duration" equals 1000
     And the event "app.inForeground" is false
     And the event "app.isLaunching" is false
 
     # Exception data
     And the event "exceptions.0.errorClass" equals "ErrorClass"
+    And the event "exceptions.0.message" equals "Custom ErrorMessage"
     And the event "exceptions.0.stacktrace.0.method" equals "Method"
     #And the event "exceptions.0.stacktrace.0.frameAddress" equals "FrameAddress"
     And the event "exceptions.0.stacktrace.0.isLR" is true
@@ -81,11 +88,11 @@ Feature: MacOS native crashes
     And the event "breadcrumbs.0.name" equals "Custom Message"
     And the event "breadcrumbs.0.metaData.test" equals "test"
 
-    # Feature flags
+    # Feature flags - NOTE: These work for native crashes but may not persist if added in managed OnSendError callbacks
     And the event "featureFlags.2.featureFlag" equals "fromCallback"
     And the event "featureFlags.2.variant" equals "a"
 
-    # Metadata
+    # Metadata - NOTE: These work for native crashes but may not persist if added in managed OnSendError callbacks
     And the event "metaData.test1.test" equals "test"
     And the event "metaData.test2" is null
 


### PR DESCRIPTION
## Goal

Improve tests so that Maze Runner fixtures and callback assertions match actual platform behavior across Android, iOS, and macOS.

## Design

- Keep behavior-driven tests truthful to platform constraints by adjusting feature assertions to only check values that actually persist into final payloads.

## Changeset

Code:
- Removed invalid assignments in [IosNativeOnSendCallback.cs] that attempted to set read-only fields (e.g., app.apiKey, app.dsymUuid).
- Updated [Scenario.cs](CocoaNativeEventCallback) to set only supported event/app/device fields (context, severity, groupingHash, groupingDiscriminator, app.duration, device.runtimeVersions) consistent with observed persistence.

Tests / Features:
Updated [ios_callbacks.feature] and [macos_native_crashes.feature] to remove non-persistent assertions (e.g., device.time, certain stackframe fields) and add assertions that are actually persisted.
Left Android callback assertions aligned with Android behavior in [android_callbacks.feature]

## Testing

Manual:
Cleaned build artifacts and re-ran iOS archive — IPA exported successfully.
Built macOS fixture after removing conflicting package — app produced at build/MacOS/Mazerunner_dev.app.
Verified Unity compilation succeeds locally after removing invalid iOS assignments and package conflict.
Ran feature-level inspection and updated assertions to reflect observed behavior on Android, iOS and macOS.

Automated:
Feature files updated in the repo; Maze Runner/Cucumber scenarios align with verified behavior and are ready for CI runs.