### PR TITLE
Added thread.state field

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeThread.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeThread.cs
@@ -15,6 +15,18 @@ namespace BugsnagUnity
 
         public string Name { get => GetNativeString("getName"); set => SetNativeString("setName",value); }
 
+        public string State 
+        { 
+            get => NativePointer.Call<AndroidJavaObject>("getState").Call<string>("getDescriptor"); 
+            set 
+            {
+                // Convert string descriptor to Thread.State enum and call setState
+                var threadStateClass = new AndroidJavaClass("com.bugsnag.android.Thread$State");
+                var stateEnum = threadStateClass.CallStatic<AndroidJavaObject>("byDescriptor", value);
+                NativePointer.Call("setState", stateEnum);
+            }
+        }
+
         public List<IStackframe> Stacktrace => GetStacktrace();
 
         public string Type => NativePointer.Call<AndroidJavaObject>("getType").Call<string>("toString");

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeThread.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeThread.cs
@@ -7,6 +7,19 @@ namespace BugsnagUnity
 {
     internal class NativeThread : NativePayloadClassWrapper, IThread
     {
+        private static AndroidJavaClass _threadStateClass;
+        private static AndroidJavaClass ThreadStateClass
+        {
+            get
+            {
+                if (_threadStateClass == null)
+                {
+                    _threadStateClass = new AndroidJavaClass("com.bugsnag.android.Thread$State");
+                }
+                return _threadStateClass;
+            }
+        }
+
         public NativeThread(AndroidJavaObject androidJavaObject) : base(androidJavaObject){}
 
         public string Id { get => GetNativeString("getId"); set => SetNativeString("setId",value); }
@@ -15,15 +28,22 @@ namespace BugsnagUnity
 
         public string Name { get => GetNativeString("getName"); set => SetNativeString("setName",value); }
 
-        public string State 
-        { 
-            get => NativePointer.Call<AndroidJavaObject>("getState").Call<string>("getDescriptor"); 
-            set 
+        public string State
+        {
+            get
+            {
+                using (var stateEnum = NativePointer.Call<AndroidJavaObject>("getState"))
+                {
+                    return stateEnum.Call<string>("getDescriptor");
+                }
+            }
+            set
             {
                 // Convert string descriptor to Thread.State enum and call setState
-                var threadStateClass = new AndroidJavaClass("com.bugsnag.android.Thread$State");
-                var stateEnum = threadStateClass.CallStatic<AndroidJavaObject>("byDescriptor", value);
-                NativePointer.Call("setState", stateEnum);
+                using (var stateEnum = ThreadStateClass.CallStatic<AndroidJavaObject>("byDescriptor", value))
+                {
+                    NativePointer.Call("setState", stateEnum);
+                }
             }
         }
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeThread.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeThread.cs
@@ -14,6 +14,7 @@ namespace BugsnagUnity
         private const string ID_KEY = "id";
         private const string ERROR_REPORTING_THREAD_KEY = "errorReportingThread";
         private const string NAME_KEY = "name";
+        private const string STATE_KEY = "state";
 
         public NativeThread(IntPtr nativePointer) : base(nativePointer)
         {
@@ -28,6 +29,8 @@ namespace BugsnagUnity
         public bool? ErrorReportingThread => GetNativeBool(ERROR_REPORTING_THREAD_KEY);
 
         public string Name { get => GetNativeString(NAME_KEY); set => SetNativeString(NAME_KEY, value); }
+
+        public string State { get => GetNativeString(STATE_KEY); set => SetNativeString(STATE_KEY, value); }
 
         private List<IStackframe> _stacktrace = new List<IStackframe>();
 

--- a/Bugsnag/Assets/Bugsnag/Runtime/Payload/IThread.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Payload/IThread.cs
@@ -8,6 +8,7 @@ namespace BugsnagUnity.Payload
         string Id { get; set; }
         bool? ErrorReportingThread { get; }
         string Name { get; set; }
+        string State { get; set; }
         List<IStackframe> Stacktrace { get; }
         string Type { get; }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## TBD
 
+### Enhancements
+Added `State` property to `IThread` interface to expose thread state information from native error reports
+[#981](https://github.com/bugsnag/bugsnag-unity/pull/981)
+
 ### Bug Fixes
 
-- Fix breadcrumb sanitization: emit bugsnag_unserializable_values as string[], preserve warnings.
+- Fix breadcrumb sanitization: emit bugsnag_unserializable_values as string[], preserve warnings
 [#975](https://github.com/bugsnag/bugsnag-unity/pull/975)
 
 - Fix Android context being overwritten by Activity

--- a/features/android/android_ndk_errors.feature
+++ b/features/android/android_ndk_errors.feature
@@ -36,6 +36,12 @@ Feature: Android NDK crash
     And the event "exceptions.0.stacktrace.0.method" is not null
     And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" starts with "0x"
 
+        # Thread validation - verify state is present for native threads
+    And the error payload field "events.0.threads" is a non-empty array
+    And the error payload field "events.0.threads.0.state" is not null
+    And the error payload field "events.0.threads.0.name" is not null
+    And the event "threads.0.id" matches "^[0-9]+$"
+
         #breadcrumbs
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.1.name" equals "test"

--- a/features/ios/ios_native_errors.feature
+++ b/features/ios/ios_native_errors.feature
@@ -48,6 +48,12 @@ Feature: iOS Native Errors
     And the event "metaData.app.companyName" equals "bugsnag"
     And the event "metaData.app.name" matches ".azerunner"
 
+    # Thread validation - verify state is present for native threads
+    And the error payload field "events.0.threads" is a non-empty array
+    And the error payload field "events.0.threads.0.state" is not null
+    And the error payload field "events.0.threads.0.name" is not null
+    And the event "threads.0.id" is not null
+
     # Exception details
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "St13runtime_error"

--- a/features/macos/macos_native_crashes.feature
+++ b/features/macos/macos_native_crashes.feature
@@ -23,6 +23,12 @@ Feature: MacOS native crashes
     And feature flags are included in the event
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.1.name" equals "test"
+
+    # Thread validation - verify state is present for native threads
+    And the error payload field "events.0.threads" is a non-empty array
+    And the error payload field "events.0.threads.0.state" is not null
+    And the error payload field "events.0.threads.0.name" is not null
+    And the event "threads.0.id" is not null
     And the event "user.id" equals "1"
     And the event "user.email" equals "2"
     And the event "user.name" equals "3"


### PR DESCRIPTION
## Goal

Expose the `thread.state` field from native crash reports in the Unity API for completeness.

## Design

- Added `string State { get; set; }` property to the `IThread` interface for consistency across all thread implementations
- **Android**: Implemented via JNI bridge to `com.bugsnag.android.Thread.State` enum
  - Getter: Calls `getState().getDescriptor()` to retrieve the string representation
  - Setter: Uses `Thread.State.byDescriptor(value)` to convert string back to enum before calling native `setState()`
- **Cocoa**: Implemented via P/Invoke bridge using key-value pattern
  - Added `STATE_KEY` constant and implemented using existing `GetNativeString`/`SetNativeString` helpers
- No changes to managed (C#-only) thread implementations as state is only relevant for native threads

## Changeset

**Core API:**
- `Bugsnag/Assets/Bugsnag/Runtime/Payload/IThread.cs`: Added `State` property
- `Bugsnag/Assets/Bugsnag/Runtime/Native/Android/NativeThread.cs`: Implemented State with enum conversion
- `Bugsnag/Assets/Bugsnag/Runtime/Native/Cocoa/NativeThread.cs`: Implemented State with native bridge

**Test Coverage:**
- `features/android/android_ndk_errors.feature`: Added validation for thread state field
- `features/ios/ios_native_errors.feature`: Added validation for thread state field
- `features/macos/macos_native_crashes.feature`: Added validation for thread state field

## Testing

- macOS native crash tests pass locally
- Android NDK tests pass locally
- iOS native error tests pass locally

All tests validate that:
- `events.0.threads` array is non-empty
- `events.0.threads.0.state` is not null
- `events.0.threads.0.name` is not null
- `events.0.threads.0.id` exists (and matches pattern for Android)