### PR TITLE
CI example app for Unity version 2021,2022,6000 for android and ios p…

### DIFF
--- a/.buildkite/unity.2021.yml
+++ b/.buildkite/unity.2021.yml
@@ -51,6 +51,51 @@ steps:
             - exit_status: "*"
               limit: 1
 
+  - group: ":package: Build Unity 2021 example app"
+    steps:
+      - label: ":android: Build Android example app for Unity 2021"
+        # NOTE: This is a smoke test build - Bugsnag Android AARs are removed to avoid D8 crashes.
+        # The build verifies package import and C# compilation work correctly.
+        timeout_in_minutes: 20
+        key: "build-android-example-2021"
+        env:
+          UNITY_VERSION: *2021
+          JAVA_VERSION: "17"
+        plugins:
+          artifacts#v1.9.0:
+            download:
+              - "Bugsnag.unitypackage"
+            upload:
+              - "example/example_2021.apk"
+              - "example/build_android_example.log"
+        commands:
+          - "features/scripts/build_example_android.sh"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
+      - label: ":ios: Build iOS example app for Unity 2021"
+        timeout_in_minutes: 15
+        key: "build-ios-example-2021"
+        env:
+          UNITY_VERSION: *2021
+          XCODE_VERSION: "16.2.0"
+          JAVA_VERSION: "17"
+        plugins:
+          artifacts#v1.9.0:
+            download:
+              - "Bugsnag.unitypackage"
+            upload:
+              - "example/example_2021.ipa"
+              - "example/build_ios_example.log"
+        commands:
+          - "features/scripts/build_example_ios.sh"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
   - group: ":test_tube: E2E tests Unity 2021"
     steps:
       - label: ":bitbar: :android: Run Android e2e tests for Unity 2021"

--- a/.buildkite/unity.2022.yml
+++ b/.buildkite/unity.2022.yml
@@ -52,6 +52,53 @@ steps:
             - exit_status: "*"
               limit: 1
 
+  - group: ":package: Build Unity 2022 example app"
+    steps:
+      - label: ":android: Build Android example app for Unity 2022"
+        # NOTE: This is a smoke test build - Bugsnag Android AARs are removed to avoid D8 crashes.
+        # The build verifies package import and C# compilation work correctly.
+        timeout_in_minutes: 20
+        key: "build-android-example-2022"
+        env:
+          UNITY_VERSION: *2022
+          JAVA_VERSION: "17"
+        plugins:
+          artifacts#v1.9.0:
+            download:
+              - "Bugsnag.unitypackage"
+            upload:
+              - "example/example_2022.apk"
+              - "example/build_android_example.log"
+        commands:
+          - "features/scripts/build_example_android.sh"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
+      - label: ":ios: Build iOS example app for Unity 2022"
+        timeout_in_minutes: 15
+        key: "build-ios-example-2022"
+        env:
+          UNITY_VERSION: *2022
+          XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: "17"
+        plugins:
+          artifacts#v1.9.0:
+            download:
+              - "Bugsnag.unitypackage"
+            upload:
+              - "example/example_2022.ipa"
+              - "example/build_ios_example.log"
+        commands:
+          - "features/scripts/build_example_ios.sh"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
+  - group: ":hammer: Build Unity 2022 platform test fixtures"
+    steps:
       - label: "Build Unity 2022 MacOS fixture"
         timeout_in_minutes: 10
         key: "macos-2022-fixture"

--- a/.buildkite/unity.6000.yml
+++ b/.buildkite/unity.6000.yml
@@ -52,6 +52,53 @@ steps:
             - exit_status: "*"
               limit: 1
 
+  - group: ":package: Build Unity 6000 example app"
+    steps:
+      - label: ":android: Build Android example app for Unity 6000"
+        # NOTE: This is a smoke test build - Bugsnag Android AARs are removed to avoid D8 crashes.
+        # The build verifies package import and C# compilation work correctly.
+        timeout_in_minutes: 20
+        key: "build-android-example-6000"
+        env:
+          UNITY_VERSION: *6000
+          JAVA_VERSION: "17"
+        plugins:
+          artifacts#v1.9.0:
+            download:
+              - "Bugsnag.unitypackage"
+            upload:
+              - "example/example_6000.apk"
+              - "example/build_android_example.log"
+        commands:
+          - "features/scripts/build_example_android.sh"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
+      - label: ":ios: Build iOS example app for Unity 6000"
+        timeout_in_minutes: 15
+        key: "build-ios-example-6000"
+        env:
+          UNITY_VERSION: *6000
+          XCODE_VERSION: "16.3.0"
+          JAVA_VERSION: "17"
+        plugins:
+          artifacts#v1.9.0:
+            download:
+              - "Bugsnag.unitypackage"
+            upload:
+              - "example/example_6000.ipa"
+              - "example/build_ios_example.log"
+        commands:
+          - "features/scripts/build_example_ios.sh"
+        retry:
+          automatic:
+            - exit_status: "*"
+              limit: 1
+
+  - group: ":hammer: Build Unity 6000 platform test fixtures"
+    steps:
       - label: "Build Unity 6000 MacOS test fixture"
         agents:
           queue: "macos-15"

--- a/features/fixtures/example_builder/Assets/Editor/ExampleAppBuilder.cs
+++ b/features/fixtures/example_builder/Assets/Editor/ExampleAppBuilder.cs
@@ -1,0 +1,96 @@
+using System.Linq;
+using UnityEngine;
+using UnityEditor;
+
+public class ExampleAppBuilder
+{
+    public static void AndroidRelease()
+    {
+        BuildAndroid(false);
+    }
+
+    public static void AndroidDev()
+    {
+        BuildAndroid(true);
+    }
+
+    static void BuildAndroid(bool dev)
+    {
+        Debug.Log("Building Example Android app...");
+
+        // Ensure an APK is produced (not an AAB) and avoid requiring a custom keystore on CI.
+        EditorUserBuildSettings.buildAppBundle = false;
+        PlayerSettings.Android.useCustomKeystore = false;
+        PlayerSettings.Android.keystoreName = string.Empty;
+        PlayerSettings.Android.keyaliasName = string.Empty;
+        
+        // Set scripting backend to IL2CPP (required for ARM64 and native libraries)
+        PlayerSettings.SetScriptingBackend(BuildTargetGroup.Android, ScriptingImplementation.IL2CPP);
+        PlayerSettings.Android.targetArchitectures = AndroidArchitecture.ARMv7 | AndroidArchitecture.ARM64;
+        PlayerSettings.SetApplicationIdentifier(BuildTargetGroup.Android, "com.bugsnag.unity.example.android");
+
+        // Set minSdkVersion to help avoid D8 issues
+        PlayerSettings.Android.minSdkVersion = AndroidSdkVersions.AndroidApiLevel26;
+        
+        var opts = CommonMobileBuildOptions(dev ? "example_dev.apk" : "example.apk", dev);
+        opts.target = BuildTarget.Android;
+
+#if UNITY_2022_1_OR_NEWER
+        PlayerSettings.insecureHttpOption = InsecureHttpOption.AlwaysAllowed;
+#endif
+
+        var result = BuildPipeline.BuildPlayer(opts);
+        Debug.Log("Build Result: " + result);
+    }
+
+    public static void IosRelease()
+    {
+        IosBuild(false);
+    }
+
+    public static void IosDev()
+    {
+        IosBuild(true);
+    }
+
+    static void IosBuild(bool dev)
+    {
+        Debug.Log("Building Example iOS app...");
+        PlayerSettings.SetApplicationIdentifier(BuildTargetGroup.iOS, "com.bugsnag.unity.example.ios");
+
+    #if UNITY_2022_1_OR_NEWER
+        PlayerSettings.insecureHttpOption = InsecureHttpOption.AlwaysAllowed;
+    #else
+        PlayerSettings.iOS.allowHTTPDownload = true;
+    #endif
+        
+        var opts = CommonMobileBuildOptions(dev ? "example_dev_xcode" : "example_xcode", dev);
+        opts.target = BuildTarget.iOS;
+        
+        var result = BuildPipeline.BuildPlayer(opts);
+        Debug.Log("Build Result: " + result);
+    }
+
+    private static BuildPlayerOptions CommonMobileBuildOptions(string outputFile, bool dev)
+    {
+        var scenes = EditorBuildSettings.scenes.Where(s => s.enabled).Select(s => s.path).ToArray();
+        if (scenes.Length == 0)
+        {
+            // Some CI-created projects won't have EditorBuildSettings populated yet.
+            // Default to the example main scene if present.
+            const string defaultScene = "Assets/Scenes/Main.unity";
+            if (System.IO.File.Exists(defaultScene))
+            {
+                scenes = new[] { defaultScene };
+            }
+        }
+        PlayerSettings.defaultInterfaceOrientation = UIOrientation.Portrait;
+
+        BuildPlayerOptions opts = new BuildPlayerOptions();
+        opts.scenes = scenes;
+        opts.locationPathName = Application.dataPath + "/../" + outputFile;
+        opts.options = dev ? BuildOptions.Development : BuildOptions.None;
+
+        return opts;
+    }
+}

--- a/features/fixtures/example_builder/Assets/Editor/ExampleAppBuilder.cs.meta
+++ b/features/fixtures/example_builder/Assets/Editor/ExampleAppBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a2f8b1c3d4e5f6a7b8c9d0e1f2a3b4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs
+++ b/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+using UnityEditor.Android;
+
+public class ExampleGradlePostProcessor : IPostGenerateGradleAndroidProject
+{
+    public int callbackOrder => 0;
+
+    public void OnPostGenerateGradleAndroidProject(string path)
+    {
+        // Unity passes the module path (often .../Gradle/unityLibrary).
+        // gradle.properties lives at the Gradle project root (the parent directory).
+        var gradleRoot = Directory.GetParent(path)?.FullName;
+        if (string.IsNullOrEmpty(gradleRoot))
+        {
+            return;
+        }
+
+        var gradlePropertiesPath = Path.Combine(gradleRoot, "gradle.properties");
+        if (!File.Exists(gradlePropertiesPath))
+        {
+            return;
+        }
+
+        var lines = File.ReadAllLines(gradlePropertiesPath).ToList();
+
+        // Ensure AndroidX is enabled, and disable Jetifier. Bugsnag is AndroidX-native and
+        // Jetifier can produce transformed jars that occasionally trigger D8 issues.
+        SetOrAdd(lines, "android.useAndroidX", "true");
+        SetOrAdd(lines, "android.enableJetifier", "false");
+        SetOrAdd(lines, "android.enableDexingArtifactTransform", "false");
+        
+        // Increase JVM heap to prevent StackOverflowError in D8 (especially Unity 2021)
+        SetOrAdd(lines, "org.gradle.jvmargs", "-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError");
+
+        File.WriteAllLines(gradlePropertiesPath, lines);
+    }
+
+    private static void SetOrAdd(System.Collections.Generic.List<string> lines, string key, string value)
+    {
+        var prefix = key + "=";
+        for (var index = 0; index < lines.Count; index++)
+        {
+            if (lines[index].StartsWith(prefix, StringComparison.Ordinal))
+            {
+                lines[index] = prefix + value;
+                return;
+            }
+        }
+
+        lines.Add(prefix + value);
+    }
+}

--- a/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs
+++ b/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs
@@ -45,16 +45,23 @@ public class ExampleGradlePostProcessor : IPostGenerateGradleAndroidProject
             // Unity 6000+ to avoid changing older CI behavior.
             try
             {
-                var embeddedJars = Directory.GetFiles(gradleRoot, "kotlin-stdlib*.jar", SearchOption.AllDirectories);
-                foreach (var jar in embeddedJars)
+                // Remove commonly embedded Kotlin/JetBrains jars that can conflict
+                // with Gradle-resolved dependencies (e.g. kotlin-annotations.jar,
+                // kotlin-stdlib*.jar). Match several patterns to be resilient.
+                var patterns = new[] { "kotlin-stdlib*.jar", "kotlin-annotations*.jar", "kotlin-*.jar" };
+                foreach (var pattern in patterns)
                 {
-                    try { File.Delete(jar); }
-                    catch (Exception ex) { Debug.LogWarning($"Failed to delete embedded jar '{jar}': {ex.Message}"); }
+                    var embeddedJars = Directory.GetFiles(gradleRoot, pattern, SearchOption.AllDirectories);
+                    foreach (var jar in embeddedJars)
+                    {
+                        try { File.Delete(jar); }
+                        catch (Exception ex) { Debug.LogWarning($"Failed to delete embedded jar '{jar}': {ex.Message}"); }
+                    }
                 }
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"Error while scanning for embedded kotlin stdlib jars: {ex.Message}");
+                Debug.LogWarning($"Error while scanning for embedded kotlin jars: {ex.Message}");
             }
         }
         

--- a/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs
+++ b/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs
@@ -37,6 +37,25 @@ public class ExampleGradlePostProcessor : IPostGenerateGradleAndroidProject
         if (int.TryParse(majorVersionString, out var majorVersion) && majorVersion >= 6000)
         {
             SetOrAdd(lines, "android.useFullClasspathForDexingTransform", "true");
+
+            // Remove embedded kotlin stdlib jars from the generated Gradle
+            // project to avoid duplicate-class errors when AGP pulls a
+            // kotlin stdlib dependency (seen as KotlinNullPointerException
+            // duplicate-class errors during assemble). This only runs for
+            // Unity 6000+ to avoid changing older CI behavior.
+            try
+            {
+                var embeddedJars = Directory.GetFiles(gradleRoot, "kotlin-stdlib*.jar", SearchOption.AllDirectories);
+                foreach (var jar in embeddedJars)
+                {
+                    try { File.Delete(jar); }
+                    catch (Exception ex) { Debug.LogWarning($"Failed to delete embedded jar '{jar}': {ex.Message}"); }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"Error while scanning for embedded kotlin stdlib jars: {ex.Message}");
+            }
         }
         
         // Increase JVM heap to prevent StackOverflowError in D8 (especially Unity 2021)

--- a/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs
+++ b/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using UnityEditor.Android;
+using UnityEngine;
 
 public class ExampleGradlePostProcessor : IPostGenerateGradleAndroidProject
 {
@@ -29,7 +30,14 @@ public class ExampleGradlePostProcessor : IPostGenerateGradleAndroidProject
         // Jetifier can produce transformed jars that occasionally trigger D8 issues.
         SetOrAdd(lines, "android.useAndroidX", "true");
         SetOrAdd(lines, "android.enableJetifier", "false");
-        SetOrAdd(lines, "android.enableDexingArtifactTransform", "false");
+        // Only enable the alternative transform option for Unity 6000+ (AGP
+        // versions used by Unity 6000). Leave 2021/2022 behavior unchanged so
+        // CI builds for those editors are not affected.
+        var majorVersionString = Application.unityVersion.Split('.')[0];
+        if (int.TryParse(majorVersionString, out var majorVersion) && majorVersion >= 6000)
+        {
+            SetOrAdd(lines, "android.useFullClasspathForDexingTransform", "true");
+        }
         
         // Increase JVM heap to prevent StackOverflowError in D8 (especially Unity 2021)
         SetOrAdd(lines, "org.gradle.jvmargs", "-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError");

--- a/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs.meta
+++ b/features/fixtures/example_builder/Assets/Editor/ExampleGradlePostProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b3c9d2e4f5a6b7c8d9e0f1a2b3c4d5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/features/scripts/build_example_android.sh
+++ b/features/scripts/build_example_android.sh
@@ -44,6 +44,12 @@ cp "$example_source/ProjectSettings/EditorBuildSettings.asset" "$builder_path/Pr
 cp "$example_source/ProjectSettings/InputManager.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
 cp "$example_source/ProjectSettings/GraphicsSettings.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
 
+# Ensure the builder project directory exists and print contents for CI debugging
+mkdir -p "$builder_path"
+echo "Builder project path: $builder_path"
+echo "Contents of builder project (top-level):"
+ls -la "$builder_path" || true
+
 # Import Bugsnag package (example scripts depend on it)
 echo "Importing Bugsnag.unitypackage into builder project"
 set +e

--- a/features/scripts/build_example_android.sh
+++ b/features/scripts/build_example_android.sh
@@ -57,7 +57,8 @@ if [[ "$UNITY_VERSION" == 2021.* ]]; then
 else
   if [ -d "$example_source/Packages" ] || [ -f "$example_source/Packages/manifest.json" ]; then
     mkdir -p "$builder_path/Packages"
-    cp -R "$example_source/Packages/" "$builder_path/Packages/" 2>/dev/null || true
+    # Copy the contents of Packages/ into the builder project's Packages/
+    cp -R "$example_source/Packages/." "$builder_path/Packages/" 2>/dev/null || true
     echo "Packages copied:" && ls -la "$builder_path/Packages" || true
   else
     echo "No Packages/ found in example source"

--- a/features/scripts/build_example_android.sh
+++ b/features/scripts/build_example_android.sh
@@ -50,6 +50,20 @@ echo "Builder project path: $builder_path"
 echo "Contents of builder project (top-level):"
 ls -la "$builder_path" || true
 
+# Copy Packages/ to ensure Unity Package Manager manifest is present (eg. com.unity.ugui)
+echo "Copying Packages/manifest.json if present (skipping for Unity 2021 to preserve behavior)..."
+if [[ "$UNITY_VERSION" == 2021.* ]]; then
+  echo "Unity 2021 detected; skipping Packages copy to preserve 2021 behavior"
+else
+  if [ -d "$example_source/Packages" ] || [ -f "$example_source/Packages/manifest.json" ]; then
+    mkdir -p "$builder_path/Packages"
+    cp -R "$example_source/Packages/" "$builder_path/Packages/" 2>/dev/null || true
+    echo "Packages copied:" && ls -la "$builder_path/Packages" || true
+  else
+    echo "No Packages/ found in example source"
+  fi
+fi
+
 # Import Bugsnag package (example scripts depend on it)
 echo "Importing Bugsnag.unitypackage into builder project"
 set +e

--- a/features/scripts/build_example_android.sh
+++ b/features/scripts/build_example_android.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+if [ -z "$UNITY_VERSION" ]; then
+  echo "UNITY_VERSION must be set"
+  exit 1
+fi
+
+UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION"
+if [ ! -d "$UNITY_PATH" ]; then
+  echo "Unity $UNITY_VERSION not found at $UNITY_PATH"
+  exit 1
+fi
+
+# CI-specific builder project
+REPO_ROOT="$(pwd)"
+builder_path="$REPO_ROOT/features/fixtures/example_builder"
+example_source="$REPO_ROOT/example"
+
+# Write the Unity log into the example folder so Buildkite artifact upload can always find it
+log_file="$example_source/build_android_example.log"
+OUTPUT_APK="example.apk"
+RENAMED_APK="example_${UNITY_VERSION:0:4}.apk"
+
+echo "Building Android example app with Unity $UNITY_VERSION"
+
+# Always try to preserve the Unity log for CI debugging
+mkdir -p "$example_source"
+rm -f "$log_file" 2>/dev/null || true
+touch "$log_file"
+trap 'cp -f "$log_file" "$example_source/build_android_example.log" 2>/dev/null || true' EXIT
+
+# Ensure clean Android build environment
+mkdir -p "$HOME/.android"
+rm -rf "$builder_path/.gradle-user-home" 2>/dev/null || true
+mkdir -p "$builder_path/.gradle-user-home"
+export GRADLE_USER_HOME="$builder_path/.gradle-user-home"
+
+# Unity needs ProjectSettings to know about scenes and build settings
+# Copy minimal required ProjectSettings files only
+echo "Copying required ProjectSettings (EditorBuildSettings, InputManager, GraphicsSettings)..."
+mkdir -p "$builder_path/ProjectSettings"
+cp "$example_source/ProjectSettings/EditorBuildSettings.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
+cp "$example_source/ProjectSettings/InputManager.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
+cp "$example_source/ProjectSettings/GraphicsSettings.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
+
+# Import Bugsnag package (example scripts depend on it)
+echo "Importing Bugsnag.unitypackage into builder project"
+set +e
+$UNITY_PATH/Unity.app/Contents/MacOS/Unity \
+  -nographics \
+  -quit \
+  -batchmode \
+  -silent-crashes \
+  -logFile "$log_file" \
+  -projectPath "$builder_path" \
+  -importPackage "$REPO_ROOT/Bugsnag.unitypackage"
+IMPORT_RESULT=$?
+set -e
+
+if [ $IMPORT_RESULT -ne 0 ]; then
+  echo "Unity import failed with exit code $IMPORT_RESULT"
+  echo "=== Unity log tail (import) ==="
+  tail -n 200 "$log_file" || true
+  echo "=== Compiler errors (import) ==="
+  grep -E "error CS[0-9]+|Scripts have compiler errors" -n "$log_file" || true
+  exit $IMPORT_RESULT
+fi
+
+# Then copy example app assets (which reference Bugsnag types)
+echo "Copying example assets to builder project..."
+rm -rf "$builder_path/Assets/Scenes" "$builder_path/Assets/Scripts" "$builder_path/Assets/Resources" "$builder_path/Assets/Plugins" 2>/dev/null || true
+mkdir -p "$builder_path/Assets"
+cp -R "$example_source/Assets/Scenes" "$builder_path/Assets/" 2>/dev/null || true
+cp -R "$example_source/Assets/Scripts" "$builder_path/Assets/" 2>/dev/null || true
+cp -R "$example_source/Assets/Resources" "$builder_path/Assets/" 2>/dev/null || true
+
+# Build Android
+echo "Building Android APK..."
+set +e
+$UNITY_PATH/Unity.app/Contents/MacOS/Unity \
+  -nographics \
+  -quit \
+  -batchmode \
+  -silent-crashes \
+  -logFile "$log_file" \
+  -projectPath "$builder_path" \
+  -executeMethod ExampleAppBuilder.AndroidRelease
+RESULT=$?
+set -e
+
+if [ $RESULT -ne 0 ]; then 
+  echo "Android example build failed with exit code $RESULT"
+  echo "=== Build log tail ==="
+  tail -n 200 "$log_file" || true
+  echo "=== Compiler errors ==="
+  grep -E "error CS[0-9]+|Scripts have compiler errors|CommandInvokationFailure|Gradle build failed" -n "$log_file" || true
+  exit $RESULT
+fi
+
+# Unity 2021+ with IL2CPP/Gradle leaves the APK in the Gradle build directory
+if [ ! -f "$builder_path/$OUTPUT_APK" ]; then
+  # Unity places APKs in different locations depending on version and build pipeline.
+  CANDIDATES=(
+    "$builder_path/Library/Bee/Android/Prj/IL2CPP/Gradle/launcher/build/outputs/apk/release/launcher-release.apk"
+    "$builder_path/Temp/gradleOut/launcher/build/outputs/apk/release/launcher-release.apk"
+  )
+
+  FOUND_APK=""
+  for candidate in "${CANDIDATES[@]}"; do
+    if [ -f "$candidate" ]; then
+      FOUND_APK="$candidate"
+      break
+    fi
+  done
+
+  if [ -n "$FOUND_APK" ]; then
+    echo "APK found at $FOUND_APK, copying to project root..."
+    cp "$FOUND_APK" "$builder_path/$OUTPUT_APK"
+  else
+    echo "ERROR: APK not found at $builder_path/$OUTPUT_APK and no Gradle output APK was located"
+    echo "Searched locations:"
+    for candidate in "${CANDIDATES[@]}"; do
+      echo "  - $candidate"
+    done
+    echo "=== Unity log tail ==="
+    tail -n 200 "$log_file" || true
+    exit 1
+  fi
+fi
+
+# Move to example directory for artifact upload
+mv "$builder_path/$OUTPUT_APK" "$example_source/$RENAMED_APK"
+
+echo "Android example app built successfully: $example_source/$RENAMED_APK"

--- a/features/scripts/build_example_ios.sh
+++ b/features/scripts/build_example_ios.sh
@@ -38,6 +38,26 @@ cp "$example_source/ProjectSettings/EditorBuildSettings.asset" "$builder_path/Pr
 cp "$example_source/ProjectSettings/InputManager.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
 cp "$example_source/ProjectSettings/GraphicsSettings.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
 
+# Ensure the builder project directory exists and print contents for CI debugging
+mkdir -p "$builder_path"
+echo "Builder project path: $builder_path"
+echo "Contents of builder project (top-level):"
+ls -la "$builder_path" || true
+
+# Copy Packages/ to ensure Unity Package Manager manifest is present (eg. com.unity.ugui)
+echo "Copying Packages/manifest.json if present (skipping for Unity 2021 to preserve behavior)..."
+if [[ "$UNITY_VERSION" == 2021.* ]]; then
+  echo "Unity 2021 detected; skipping Packages copy to preserve 2021 behavior"
+else
+  if [ -d "$example_source/Packages" ] || [ -f "$example_source/Packages/manifest.json" ]; then
+    mkdir -p "$builder_path/Packages"
+    cp -R "$example_source/Packages/" "$builder_path/Packages/" 2>/dev/null || true
+    echo "Packages copied:" && ls -la "$builder_path/Packages" || true
+  else
+    echo "No Packages/ found in example source"
+  fi
+fi
+
 # Import Bugsnag package (example scripts depend on it)
 echo "Importing Bugsnag.unitypackage into builder project"
 set +e

--- a/features/scripts/build_example_ios.sh
+++ b/features/scripts/build_example_ios.sh
@@ -51,7 +51,8 @@ if [[ "$UNITY_VERSION" == 2021.* ]]; then
 else
   if [ -d "$example_source/Packages" ] || [ -f "$example_source/Packages/manifest.json" ]; then
     mkdir -p "$builder_path/Packages"
-    cp -R "$example_source/Packages/" "$builder_path/Packages/" 2>/dev/null || true
+    # Copy the contents of Packages/ into the builder project's Packages/
+    cp -R "$example_source/Packages/." "$builder_path/Packages/" 2>/dev/null || true
     echo "Packages copied:" && ls -la "$builder_path/Packages" || true
   else
     echo "No Packages/ found in example source"

--- a/features/scripts/build_example_ios.sh
+++ b/features/scripts/build_example_ios.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+if [ -z "$UNITY_VERSION" ]; then
+  echo "UNITY_VERSION must be set"
+  exit 1
+fi
+
+UNITY_PATH="/Applications/Unity/Hub/Editor/$UNITY_VERSION"
+if [ ! -d "$UNITY_PATH" ]; then
+  echo "Unity $UNITY_VERSION not found at $UNITY_PATH"
+  exit 1
+fi
+
+# CI-specific builder project
+REPO_ROOT="$(pwd)"
+builder_path="$REPO_ROOT/features/fixtures/example_builder"
+example_source="$REPO_ROOT/example"
+
+# Write the Unity log into the example folder so Buildkite artifact upload can always find it
+log_file="$example_source/build_ios_example.log"
+XCODE_PROJECT="example_xcode"
+IPA_OUTPUT="example_${UNITY_VERSION:0:4}.ipa"
+
+echo "Building iOS example app with Unity $UNITY_VERSION"
+
+# Always try to preserve the Unity log for CI debugging
+mkdir -p "$example_source"
+rm -f "$log_file" 2>/dev/null || true
+touch "$log_file"
+trap 'cp -f "$log_file" "$example_source/build_ios_example.log" 2>/dev/null || true' EXIT
+
+# Unity needs ProjectSettings to know about scenes and build settings
+# Copy minimal required ProjectSettings files only
+echo "Copying required ProjectSettings (EditorBuildSettings, InputManager, GraphicsSettings)..."
+mkdir -p "$builder_path/ProjectSettings"
+cp "$example_source/ProjectSettings/EditorBuildSettings.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
+cp "$example_source/ProjectSettings/InputManager.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
+cp "$example_source/ProjectSettings/GraphicsSettings.asset" "$builder_path/ProjectSettings/" 2>/dev/null || true
+
+# Import Bugsnag package (example scripts depend on it)
+echo "Importing Bugsnag.unitypackage into builder project"
+set +e
+$UNITY_PATH/Unity.app/Contents/MacOS/Unity \
+  -nographics \
+  -quit \
+  -batchmode \
+  -silent-crashes \
+  -logFile "$log_file" \
+  -projectPath "$builder_path" \
+  -importPackage "$REPO_ROOT/Bugsnag.unitypackage"
+IMPORT_RESULT=$?
+set -e
+
+if [ $IMPORT_RESULT -ne 0 ]; then
+  echo "Unity import failed with exit code $IMPORT_RESULT"
+  echo "=== Unity log tail (import) ==="
+  tail -n 200 "$log_file" || true
+  echo "=== Compiler errors (import) ==="
+  grep -E "error CS[0-9]+|Scripts have compiler errors" -n "$log_file" || true
+  exit $IMPORT_RESULT
+fi
+
+# Then copy example app assets (which reference Bugsnag types)
+echo "Copying example assets to builder project..."
+rm -rf "$builder_path/Assets/Scenes" "$builder_path/Assets/Scripts" "$builder_path/Assets/Resources" "$builder_path/Assets/Plugins" 2>/dev/null || true
+mkdir -p "$builder_path/Assets"
+cp -R "$example_source/Assets/Scenes" "$builder_path/Assets/" 2>/dev/null || true
+cp -R "$example_source/Assets/Scripts" "$builder_path/Assets/" 2>/dev/null || true
+cp -R "$example_source/Assets/Resources" "$builder_path/Assets/" 2>/dev/null || true
+cp -R "$example_source/Assets/Plugins" "$builder_path/Assets/" 2>/dev/null || true
+
+# Build iOS Xcode project
+echo "Building iOS Xcode project..."
+set +e
+$UNITY_PATH/Unity.app/Contents/MacOS/Unity \
+  -nographics \
+  -quit \
+  -batchmode \
+  -silent-crashes \
+  -logFile "$log_file" \
+  -projectPath "$builder_path" \
+  -executeMethod ExampleAppBuilder.IosRelease
+BUILD_RESULT=$?
+set -e
+
+if [ $BUILD_RESULT -ne 0 ]; then
+  echo "iOS example build failed with exit code $BUILD_RESULT"
+  echo "=== Unity log tail (build) ==="
+  tail -n 200 "$log_file" || true
+  echo "=== Compiler errors (build) ==="
+  grep -E "error CS[0-9]+|Scripts have compiler errors" -n "$log_file" || true
+  exit $BUILD_RESULT
+fi
+
+XCODE_PATH="$builder_path/$XCODE_PROJECT"
+
+if [ ! -d "$XCODE_PATH" ]; then
+  echo "ERROR: Xcode project not found at $XCODE_PATH"
+  tail -n 100 "$log_file" || true
+  exit 1
+fi
+
+# Build and archive the Xcode project
+echo "Building Xcode project with xcodebuild..."
+pushd "$XCODE_PATH"
+
+ARCHIVE_PATH="$PWD/example.xcarchive"
+
+xcodebuild \
+  -project Unity-iPhone.xcodeproj \
+  -scheme Unity-iPhone \
+  -configuration Release \
+  -archivePath "$ARCHIVE_PATH" \
+  archive \
+  CODE_SIGN_IDENTITY="" \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO
+
+if [ $? -ne 0 ]; then
+  echo "Xcode archive build failed"
+  exit 1
+fi
+
+# Package as unsigned IPA (CI doesn't have signing certificates)
+echo "Creating unsigned IPA from archive..."
+mkdir -p "$ARCHIVE_PATH/Products/Applications"
+cp -R "$ARCHIVE_PATH/Products/Applications/Unity-iPhone.app" "$PWD/" 2>/dev/null || true
+cp -R "$ARCHIVE_PATH/Products/Applications/"*.app "$PWD/" 2>/dev/null || true
+
+# Find the .app bundle
+APP_BUNDLE=$(find "$PWD" -maxdepth 1 -name "*.app" | head -n 1)
+if [ -z "$APP_BUNDLE" ]; then
+  echo "ERROR: Could not find .app bundle"
+  exit 1
+fi
+
+# Create Payload directory and IPA
+rm -rf Payload 2>/dev/null || true
+mkdir -p Payload
+cp -R "$APP_BUNDLE" Payload/
+zip -qr "$example_source/$IPA_OUTPUT" Payload
+
+popd
+
+if [ -f "$example_source/$IPA_OUTPUT" ]; then
+  echo "iOS example app built successfully: $example_source/$IPA_OUTPUT"
+else
+  echo "ERROR: IPA not created"
+  exit 1
+fi


### PR DESCRIPTION
##Goal

Ensure example app CI builds import [Bugsnag.unitypackage] and produce Android/iOS artifacts for Unity 2021, 2022 and 6000 without breaking existing editors.

##Design

Approach: Make Gradle/workarounds conditional on editor major version (inspect [Application.unityVersion] so Unity 6000+ gets AGP-safe changes while Unity 2021/2022 behavior remains unchanged.
6000-specific: Set android.useFullClasspathForDexingTransform=true and remove embedded Kotlin/annotation jars from the generated Gradle project to avoid duplicate-class checks with AGP 8.x.
2021/2022-specific: Preserve prior behavior (no new dexing property); only copy Packages/ where required to restore UPM resolution for newer editors.

##Changeset

Postprocessor: Update [ExampleGradlePostProcessor.cs]
Conditionally set android.useFullClasspathForDexingTransform=true for Unity >= 6000.
Remove embedded [kotlin-*.jar] / [kotlin-annotations*.jar] files from the generated Gradle project for Unity >= 6000.
Remove any writes of the deprecated android.enableDexingArtifactTransform.
CI scripts: Update package handling in [build_example_android.sh] and [build_example_ios.sh]
Copy Packages/ only when needed (skip for Unity 2021) to restore UPM deps for newer editors.
Behavioral: Removed previous unconditional AAR-replacement workaround so 2021 behavior is preserved.

##Testing

Tested on CI: Android and iOS builds succeed for 2021, 2022, 6000 and produced APK/IPA artifacts and logs.