### PR TITLE
PLAT-16268 security issue fixes

### DIFF
--- a/Bugsnag/ProjectSettings/ProjectSettings.asset
+++ b/Bugsnag/ProjectSettings/ProjectSettings.asset
@@ -709,7 +709,7 @@ PlayerSettings:
   ps4GarlicHeapSize: 2048
   ps4ProGarlicHeapSize: 2560
   playerPrefsMaxSize: 32768
-  ps4Passcode: bi9UOuSpM2Tlh01vOzwvSikHFswuzleh
+  ps4Passcode: 
   ps4pnSessions: 1
   ps4pnPresence: 1
   ps4pnFriends: 1

--- a/example/ProjectSettings/ProjectSettings.asset
+++ b/example/ProjectSettings/ProjectSettings.asset
@@ -462,7 +462,7 @@ PlayerSettings:
   ps4DownloadDataSize: 0
   ps4GarlicHeapSize: 2048
   ps4ProGarlicHeapSize: 2560
-  ps4Passcode: lQ9wQj99nsQzldVI5ZuGXbEWRK5RhRXd
+  ps4Passcode: 
   ps4pnSessions: 1
   ps4pnPresence: 1
   ps4pnFriends: 1

--- a/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
+++ b/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
@@ -562,7 +562,7 @@ PlayerSettings:
   ps4DownloadDataSize: 0
   ps4GarlicHeapSize: 2048
   ps4ProGarlicHeapSize: 2560
-  ps4Passcode: 5PN2qmWqBlQ9wQj99nsQzldVI5ZuGXbE
+  ps4Passcode: 
   ps4pnSessions: 1
   ps4pnPresence: 1
   ps4pnFriends: 1

--- a/features/fixtures/minimalapp/ProjectSettings/ProjectSettings.asset
+++ b/features/fixtures/minimalapp/ProjectSettings/ProjectSettings.asset
@@ -601,7 +601,7 @@ PlayerSettings:
   ps4GarlicHeapSize: 2048
   ps4ProGarlicHeapSize: 2560
   playerPrefsMaxSize: 32768
-  ps4Passcode: bi9UOuSpM2Tlh01vOzwvSikHFswuzleh
+  ps4Passcode: 
   ps4pnSessions: 1
   ps4pnPresence: 1
   ps4pnFriends: 1

--- a/upm/UPMImportProject/ProjectSettings/ProjectSettings.asset
+++ b/upm/UPMImportProject/ProjectSettings/ProjectSettings.asset
@@ -462,7 +462,7 @@ PlayerSettings:
   ps4DownloadDataSize: 0
   ps4GarlicHeapSize: 2048
   ps4ProGarlicHeapSize: 2560
-  ps4Passcode: frAQBc8Wsa1xVPfvJcrgRYwTiizs2trQ
+  ps4Passcode: 
   ps4pnSessions: 1
   ps4pnPresence: 1
   ps4pnFriends: 1


### PR DESCRIPTION
## Goal

Remove PS4 passcode keys from project settings file

## Changeset

Removed PS4 passcode from below mention files:-

/example/ProjectSettings/ProjectSettings.asset
/features/fixtures/maze_runner/ProjectSettings/ProjectSettings.asset
/Bugsnag/ProjectSettings/ProjectSettings.asset
/features/fixtures/EDM_Fixture/ProjectSettings/ProjectSettings.asset
/features/fixtures/minimalapp/ProjectSettings/ProjectSettings.asset
