### PR TITLE
PLAT-7972 scripting metadata improvement

### DIFF
--- a/Bugsnag/Assets/Bugsnag/Runtime/BugsnagAutoInit.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/BugsnagAutoInit.cs
@@ -16,41 +16,10 @@ namespace BugsnagUnity
                     return;
                 }
                 var config = settings.GetConfig();
-                config.ScriptingBackend = FindScriptingBackend();
-                config.DotnetScriptingRuntime = FindDotnetScriptingRuntime();
-                config.DotnetApiCompatibility = FindDotnetApiCompatibility();
                 Bugsnag.Start(config);
             }
         }
 
-        private static string FindScriptingBackend()
-        {
-#if ENABLE_MONO
-            return "Mono";
-#elif ENABLE_IL2CPP
-            return "IL2CPP";
-#else
-            return "Unknown";
-#endif
-        }
-
-        private static string FindDotnetScriptingRuntime()
-        {
-#if NET_4_6
-            return ".NET 4.6 equivalent";
-#else
-            return ".NET 3.5 equivalent";
-#endif
-        }
-
-        private static string FindDotnetApiCompatibility()
-        {
-#if NET_2_0_SUBSET
-            return ".NET 2.0 Subset";
-#else
-            return ".NET 2.0";
-#endif
-        }
     }
 
 }

--- a/Bugsnag/Assets/Bugsnag/Runtime/Configuration.cs
+++ b/Bugsnag/Assets/Bugsnag/Runtime/Configuration.cs
@@ -181,11 +181,40 @@ namespace BugsnagUnity
 
         public LogTypeSeverityMapping LogTypeSeverityMapping { get; } = new LogTypeSeverityMapping();
 
-        public string ScriptingBackend;
+        public string ScriptingBackend = DetectScriptingBackend();
 
-        public string DotnetScriptingRuntime;
+        public string DotnetScriptingRuntime = DetectDotnetScriptingRuntime();
 
-        public string DotnetApiCompatibility;
+        public string DotnetApiCompatibility = DetectDotnetApiCompatibility();
+
+        private static string DetectScriptingBackend()
+        {
+#if ENABLE_MONO
+            return "Mono";
+#elif ENABLE_IL2CPP
+            return "IL2CPP";
+#else
+            return "Unknown";
+#endif
+        }
+
+        private static string DetectDotnetScriptingRuntime()
+        {
+#if NET_4_6
+            return ".NET 4.6 equivalent";
+#else
+            return ".NET 3.5 equivalent";
+#endif
+        }
+
+        private static string DetectDotnetApiCompatibility()
+        {
+#if NET_2_0_SUBSET
+            return ".NET 2.0 Subset";
+#else
+            return ".NET 2.0";
+#endif
+        }
 
         public EnabledErrorTypes EnabledErrorTypes = new EnabledErrorTypes();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 ## TBD
 
 ### Enhancements
-Added `State` property to `IThread` interface to expose thread state information from native error reports
+- Added `State` property to `IThread` interface to expose thread state information from native error reports
 [#981](https://github.com/bugsnag/bugsnag-unity/pull/981)
+
+- Auto-detect `ScriptingBackend`, `DotnetScriptingRuntime`, and `DotnetApiCompatibility` on `Configuration` initialisation
+[#992](https://github.com/bugsnag/bugsnag-unity/pull/992)
+
 
 ### Bug Fixes
 

--- a/features/csharp/csharp_config.feature
+++ b/features/csharp/csharp_config.feature
@@ -128,6 +128,15 @@ Feature: csharp events
     And the event "breadcrumbs.1.metaData.dictionary.stringArray.0" equals "12345678901234567890***80 CHARS TRUNCATED***"
     And the event "breadcrumbs.1.metaData.stringDictionary.testKey" equals "12345678901234567890***80 CHARS TRUNCATED***"
 
+  Scenario: Scripting backend fields are auto-populated for manual start
+    When I run the game in the "ScriptingBackendPopulated" state
+    And I wait to receive an error
+    Then the error is valid for the error reporting API sent by the Unity notifier
+    And the exception "message" equals "ScriptingBackendPopulated"
+    And the event "device.runtimeVersions.unityScriptingBackend" is not null
+    And the event "device.runtimeVersions.dotnetScriptingRuntime" is not null
+    And the event "device.runtimeVersions.dotnetApiCompatibility" is not null
+
   @skip_cocoa #not supported on these platforms
   Scenario: GenerateAnonymousId
     When I run the game in the "GenerateAnonymousId" state

--- a/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
+++ b/features/fixtures/maze_runner/Assets/Scenes/MainScene.unity
@@ -148,6 +148,7 @@ GameObject:
   - component: {fileID: 355371107}
   - component: {fileID: 355371108}
   - component: {fileID: 355371109}
+  - component: {fileID: 355371110}
   m_Layer: 0
   m_Name: Config
   m_TagString: Untagged
@@ -470,6 +471,18 @@ MonoBehaviour:
 
     Main.CUSTOM2
     () (at Assets/Scripts/Main.cs:123)'
+--- !u!114 &355371110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 355371092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7362c3e39d438464492bbb99c0ff80cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &372057234
 GameObject:
   m_ObjectHideFlags: 0

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/ScriptingBackendPopulated.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/ScriptingBackendPopulated.cs
@@ -1,10 +1,17 @@
+using BugsnagUnity;
+using UnityEngine;
+
 public class ScriptingBackendPopulated : Scenario
 {
     public override void PrepareConfig(string apiKey, string host)
     {
-        // Deliberately do NOT set ScriptingBackend, DotnetScriptingRuntime, or
-        // DotnetApiCompatibility — they should be auto-detected by Configuration.
-        base.PrepareConfig(apiKey, host);
+        Configuration = new Configuration(apiKey);
+        Configuration.Endpoints = new EndpointConfiguration(host + "/notify", host + "/sessions");
+        Configuration.AutoTrackSessions = false;
+        if (Application.platform == RuntimePlatform.IPhonePlayer)
+        {
+            Configuration.EnabledErrorTypes.OOMs = false;
+        }
     }
 
     public override void Run()

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/ScriptingBackendPopulated.cs
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/ScriptingBackendPopulated.cs
@@ -1,0 +1,14 @@
+public class ScriptingBackendPopulated : Scenario
+{
+    public override void PrepareConfig(string apiKey, string host)
+    {
+        // Deliberately do NOT set ScriptingBackend, DotnetScriptingRuntime, or
+        // DotnetApiCompatibility — they should be auto-detected by Configuration.
+        base.PrepareConfig(apiKey, host);
+    }
+
+    public override void Run()
+    {
+        DoSimpleNotify("ScriptingBackendPopulated");
+    }
+}

--- a/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/ScriptingBackendPopulated.cs.meta
+++ b/features/fixtures/maze_runner/Assets/Scripts/Scenarios/Csharp/Config/ScriptingBackendPopulated.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7362c3e39d438464492bbb99c0ff80cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Goal

Improve reporting of scripting metadata when bugsnag start manually.

## Design

The detection logic has been moved into Configuration.cs as field initialisers, using the same #if preprocessor directives that were previously private to BugsnagAutoInit:
Configuration.cs is a source file compiled as part of the developer's Unity project (not a precompiled DLL), the #if directives resolve against the developer's own scripting backend and API compatibility settings at their compile time. This means any new Configuration(apiKey) call automatically carries the correct values, regardless of whether auto-init or manual start is used.
BugsnagAutoInit no longer needs to set these fields explicitly and the methods have been removed from it.

## Changeset

Configuration.cs — ScriptingBackend, DotnetScriptingRuntime, and DotnetApiCompatibility fields now default to auto-detected values via new private Detect* static methods. Fields remain public so developers can still override them if needed.
BugsnagAutoInit.cs — Removed the now-redundant explicit assignments and private FindScriptingBackend(), FindDotnetScriptingRuntime(), FindDotnetApiCompatibility() methods.
ScriptingBackendPopulated.cs — New maze runner scenario that constructs Configuration manually without setting the scripting backend fields, exercising the auto-detection path.
MainScene.unity — Registered ScriptingBackendPopulated as a component on the Config GameObject so the scenario runner can discover it.
csharp_config.feature — New scenario Scripting backend fields are auto-populated for manual start that asserts device.runtimeVersions.unityScriptingBackend, device.runtimeVersions.dotnetScriptingRuntime, and device.runtimeVersions.dotnetApiCompatibility are all non-null in the reported payload.

## Testing

New maze runner scenario ScriptingBackendPopulated verified end-to-end: the scenario deliberately omits manual assignment of the scripting backend fields and confirms all three values are present and non-null in the error payload sent to the notifier API.
Existing csharp_config suite continues to pass unmodified — the Configuration field initialiser change is backward-compatible; any code that was already setting these fields explicitly will simply overwrite the defaults.