### PR TITLE
Upgrade Node.js dependency from 20 to 24

### DIFF
--- a/.github/workflows/update-cli.yml
+++ b/.github/workflows/update-cli.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
      
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: next
 

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -23,7 +23,7 @@ jobs:
       BUNDLE_GITHUB__COM: ${{ secrets.BUNDLE_ACCESS_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: next
 


### PR DESCRIPTION
## Goal

Upgrade Node.js dependency from 20 to 24

## Changeset

Changed actions/checkout@v4 to actions/checkout@v6 in update-cli.yml and update-dependencies.yml
